### PR TITLE
Add improved valve Cv/Cg notebook

### DIFF
--- a/notebooks/process/valvesCvCg.ipynb
+++ b/notebooks/process/valvesCvCg.ipynb
@@ -1,0 +1,140 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 0,
+ "metadata": {
+  "colab": {
+   "name": "valvesCvCg.ipynb",
+   "provenance": [],
+   "include_colab_link": true
+  },
+  "kernelspec": {
+   "name": "python3",
+   "display_name": "Python 3"
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "view-in-github",
+    "colab_type": "text"
+   },
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/EvenSol/NeqSim-Colab/blob/master/notebooks/process/valvesCvCg.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "id": "setup"
+   },
+   "source": [
+    "%%capture\n",
+    "!pip install neqsim\n",
+    "import neqsim\n",
+    "from neqsim.thermo.thermoTools import fluid\n",
+    "from neqsim.process import clearProcess, stream, valve, runProcess\n",
+    "import math"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Valve Cv and Cg simulation\nThis notebook shows how control valves are simulated using the [NeqSim](https://github.com/equinor/neqsim) process framework. The valve model is implemented in the [`neqsim.processSimulation.processEquipment.valve`](https://github.com/equinor/neqsim/tree/master/src/main/java/neqsim/processSimulation/processEquipment/valve) package as the `ThrottlingValve` class."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Basic valve simulation\nCreate a simple gas stream and let it flow through a valve. The downstream pressure is fixed using `setOutletPressure`. When a `Cv` value is specified the mass flow through the valve is calculated from the pressure drop."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "inletTemperature = 20.0  # C\ninletPressure = 100.0  # bara\noutletPressure = 50.0  # bara\n\nfluid1 = fluid('srk')\nfluid1.addComponent('methane', 1.0)\nfluid1.setTemperature(inletTemperature, 'C')\nfluid1.setPressure(inletPressure, 'bara')\nfluid1.setTotalFlowRate(1000.0, 'kg/hr')\n\nclearProcess()\nstream1 = stream(fluid1)\nvalve1 = valve(stream1)\nvalve1.setOutletPressure(outletPressure, 'bara')\nvalve1.setCv(80.0)\nrunProcess()\n\nprint('Valve outlet pressure', valve1.getOutStream().getPressure('bara'), 'bara')\nprint('Valve mass flow', valve1.getOutStream().getFlowRate('kg/hr'))"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Cv and Cg\nThe valve can also be specified using the gas sizing coefficient `Cg`. Setting one coefficient automatically updates the other according to the standard valve sizing correlation used in NeqSim."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "valve1.setCg(95.0)\nprint('Updated Cv from Cg:', valve1.getCv())\nprint('Cg now:', valve1.getCg())"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Valve sizing\nThe size of a valve is typically given by its flow coefficient. For gas service the coefficients `Cv` or `Cg` are used. For liquid service the metric coefficient `Kv` is often used which is related to `Cv` by `Kv = 0.865 * Cv`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "Kv = stream1.getFlowRate('m3/hr')/math.sqrt(inletPressure-outletPressure)\nCv_calc = Kv/0.865\nprint('Calculated Kv', Kv)\nprint('Corresponding Cv', Cv_calc)"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Typical range of Cv values for common valve types (approximate):\n\n| Valve type | Cv range |\n|------------|---------|\n| 1/2'' globe | 4 - 6 |\n| 2'' globe   | 45 - 60 |\n| 2'' ball    | 275 - 300 |\n| 4'' ball    | 950 - 1300 |"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Valve flow equations\n",
+    "For an incompressible liquid the valve flow coefficient relates flow rate to pressure drop as $$Q = C_v \\sqrt{\\frac{\\Delta P}{G}}$$ where $G$ is the specific gravity.\n",
+    "For compressible gas service NeqSim uses the ANSI/ISA S75.01 correlations. The mass flow is computed from the $C_g$ coefficient by $$W = C_g P_1 \\sqrt{\\frac{P_2}{P_1} \\frac{M}{Z T_1}}$$ where $M$ is molecular weight, $Z$ is compressibility factor and $T_1$ is the upstream temperature."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Controlling downstream pressure by valve opening\nInstead of fixing the outlet pressure it is possible to set a valve opening with `setPercentValveOpening` and let NeqSim calculate the resulting pressure or flow."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "valve1.setOutletPressure(None)\nvalve1.setPercentValveOpening(50.0)\nrunProcess()\nprint('Downstream pressure with 50% opening', valve1.getOutStream().getPressure('bara'))\nprint('Resulting flow', valve1.getOutStream().getFlowRate('kg/hr'))"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### References\n",
+    "- [ISA-75.01 Control Valve Sizing](https://www.isa.org/standards/0100006944)\n",
+    "- [Fisher Control Valve Handbook](https://www.emerson.com/documents/automation/control-valve-handbook-en-3658406.pdf)\n",
+    "- [Control Valve Basics on Wikipedia](https://en.wikipedia.org/wiki/Control_valve)"
+   ]
+  }
+ ]
+}


### PR DESCRIPTION
## Summary
- rewrite valve Cv/Cg simulation notebook in standard format
- explain valve model location in the NeqSim repository
- demonstrate basic valve, Cv/Cg use, sizing, and valve opening control
- add valve flow equation section with references

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687201ed37a0832db855dc1b4eacd7a7