### PR TITLE
Add PyPSA-Earth offshore field example

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ NeqSim Python/Colab is part of the [NeqSim project](https://equinor.github.io/ne
 
 ## Getting Started
 See the [NeqSim Colab page](https://colab.research.google.com/github/EvenSol/NeqSim-Colab/blob/master/notebooks/examples_of_NeqSim_in_Colab.ipynb) for how to start using NeqSim in Colab/Python.
+For a demonstration of energy system analysis, see the [PyPSA-Earth offshore field example](https://colab.research.google.com/github/EvenSol/NeqSim-Colab/blob/master/notebooks/energyopt/PyPSAEarthOffshoreField.ipynb).
 
 ## Contributing
 See the [NeqSim Colab page](https://colab.research.google.com/github/EvenSol/NeqSim-Colab/blob/master/notebooks/examples_of_NeqSim_in_Colab.ipynb). Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details on our code of conduct, and the process for submitting pull requests.

--- a/notebooks/energyopt/PyPSAEarthOffshoreField.ipynb
+++ b/notebooks/energyopt/PyPSAEarthOffshoreField.ipynb
@@ -1,0 +1,82 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "view-in-github",
+    "colab_type": "text"
+   },
+   "source": "<a href=\"https://colab.research.google.com/github/EvenSol/NeqSim-Colab/blob/master/notebooks/energyopt/PyPSAEarthOffshoreField.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# PyPSA-Earth Example: Powering an Offshore Field\nThis notebook demonstrates how to use PyPSA-Earth to supply a new 100 MW offshore field from the Norwegian electricity grid."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Background\nNorway has announced a strategy to electrify offshore oil and gas installations using power delivered from the mainland grid.\nSupplying an offshore field from land can significantly reduce emissions because gas turbines or diesel generators are replaced by electricity generated onshore, typically from low-carbon sources.\nThis example illustrates how a new 100 MW field could be connected to the existing grid."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Modeling approach\nPyPSA-Earth builds detailed electricity networks from open data. Here we restrict the network to Norway and then add an additional bus representing the offshore facility.\nThe connection to land is modeled as a `Link` with a nominal capacity of 100 MW. A constant 100 MW `Load` is attached to the offshore bus to represent the field's power requirement.\nRunning `lopf` performs a linear optimal power flow to verify that the network can supply the new demand."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Theory\nElectrifying offshore fields allows operators to replace onboard generation from gas turbines with mainland electricity, reducing greenhouse gas emissions and improving efficiency.\nIn network studies PyPSA-Earth represents onshore and offshore locations as buses connected via high-voltage links. The optimal power flow determines whether the grid can supply the new demand without violating transmission constraints."
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "!pip install pypsa pypsa-earth"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "import pypsa\nimport pypsa_earth as earth\n\n# Build a PyPSA-Earth network for Norway\nn = earth.get_electricity_network(continent='Europe', country_codes=['NO'])\n\n# Add bus representing the offshore field (example coordinates)\nn.add('Bus', 'offshore_field', x=2.5, y=62.0, country='NO', carrier='AC')\n\n# Connect the field to an onshore bus\nonshore_bus = n.buses.index[0]\nn.add('Link', 'grid_to_field', bus0=onshore_bus, bus1='offshore_field', p_nom=100, efficiency=0.95)\n\n# Add constant demand of 100 MW at the offshore field\nn.add('Load', 'field_load', bus='offshore_field', p_set=100)\n\n# Run the linear optimal power flow\nn.lopf(n.snapshots)"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "n.links_t.p0.head()"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "n.loads"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Interpreting the results\nIn this simple demonstration the load is always 100 MW and is served via the onshore grid with an assumed efficiency of 95%.\nReal projects would model variable demand, cable losses, and potential constraints in the mainland grid.\nNevertheless, this approach shows how PyPSA-Earth can be extended to include offshore consumers in a standard transmission network."
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "name": "PyPSAEarthOffshoreField.ipynb",
+   "provenance": [],
+   "include_colab_link": true
+  },
+  "kernelspec": {
+   "name": "python3",
+   "display_name": "Python 3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## Summary
- create new PyPSA-Earth example notebook showing how to supply a 100 MW offshore field from Norway's grid
- reference the new example in the README with a direct Colab link
- expand notebook with theory section and add Colab metadata

## Testing
- `python -m json.tool notebooks/energyopt/PyPSAEarthOffshoreField.ipynb`
- `python -m py_compile /tmp/script_clean.py`


------
https://chatgpt.com/codex/tasks/task_e_6874aaaf70fc832d82f5ebbfa9314cbe