### PR TITLE
Add blue ammonia production example

### DIFF
--- a/notebooks/reactions/blue_ammonia_production.ipynb
+++ b/notebooks/reactions/blue_ammonia_production.ipynb
@@ -1,0 +1,141 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "view-in-github",
+    "colab_type": "text"
+   },
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/EvenSol/NeqSim-Colab/blob/master/notebooks/reactions/blue_ammonia_production.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "intro"
+   },
+   "source": [
+    "# Blue Ammonia Production\n",
+    "\n",
+    "Blue ammonia is produced from natural gas with carbon dioxide capture, combining steam methane reforming (SMR) and the Haber\u2013Bosch process.\n",
+    "The main reactions are:\n",
+    "\n",
+    "$$\\mathrm{CH_4 + H_2O \\rightarrow CO + 3H_2}$$\n",
+    "$$\\mathrm{CO + H_2O \\rightarrow CO_2 + H_2}$$\n",
+    "Overall hydrogen production:\n",
+    "$$\\mathrm{CH_4 + 2H_2O \\rightarrow CO_2 + 4H_2}$$\n",
+    "Ammonia synthesis (Haber\u2013Bosch):\n",
+    "$$\\mathrm{N_2 + 3H_2 \\rightleftharpoons 2NH_3}$$\n",
+    "\n",
+    "The following example uses NeqSim's Gibbs reactor to simulate these steps."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "id": "install"
+   },
+   "source": [
+    "%%capture\n",
+    "!pip install neqsim\n",
+    "import neqsim\n",
+    "from neqsim import jneqsim\n"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "id": "reformer"
+   },
+   "source": [
+    "# Steam methane reforming to produce hydrogen\n",
+    "system_reformer = jneqsim.thermo.system.SystemSrkEos(1000.0, 30.0)  # 1000 K, 30 bar\n",
+    "system_reformer.addComponent('methane', 1.0)\n",
+    "system_reformer.addComponent('water', 2.0)\n",
+    "system_reformer.addComponent('hydrogen', 0.0)\n",
+    "system_reformer.addComponent('CO', 0.0)\n",
+    "system_reformer.addComponent('CO2', 0.0)\n",
+    "system_reformer.setMixingRule(2)\n",
+    "feed = jneqsim.process.equipment.stream.Stream('feed', system_reformer)\n",
+    "reformer = jneqsim.process.equipment.reactor.GibbsReactor('reformer', feed)\n",
+    "reformer.setUseAllDatabaseSpecies(False)\n",
+    "reformer.setDampingComposition(0.01)\n",
+    "reformer.setMaxIterations(2500)\n",
+    "reformer.setConvergenceTolerance(1e-3)\n",
+    "reformer.setEnergyMode('isothermal')\n",
+    "reformer.run()\n",
+    "out1 = reformer.getOutletStream().getThermoSystem()\n",
+    "for name in ['methane','hydrogen','CO','CO2','water']:\n",
+    "    print(name, round(out1.getComponent(name).getz(),4))"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "id": "capture"
+   },
+   "source": [
+    "# Cooling and separating to capture CO2 and water\n",
+    "cooler = jneqsim.process.equipment.heatexchanger.Cooler('cooler', reformer.getOutletStream())\n",
+    "cooler.setOutTemperature(220.0)\n",
+    "cooler.run()\n",
+    "separator = jneqsim.process.equipment.separator.Separator('separator', cooler.getOutStream())\n",
+    "separator.run()\n",
+    "hydrogen_stream = separator.getGasOutStream()\n",
+    "gas = hydrogen_stream.getThermoSystem()\n",
+    "for name in ['hydrogen','CO2','methane']:\n",
+    "    try:\n",
+    "        print(name, round(gas.getComponent(name).getz(),4))\n",
+    "    except:\n",
+    "        pass"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "id": "ammonia"
+   },
+   "source": [
+    "# Ammonia synthesis using Gibbs reactor\n",
+    "system_NH3 = jneqsim.thermo.system.SystemSrkEos(700.0, 150.0)  # 700 K, 150 bar\n",
+    "system_NH3.addComponent('hydrogen', 3.0)\n",
+    "system_NH3.addComponent('nitrogen', 1.0)\n",
+    "system_NH3.addComponent('ammonia', 0.0)\n",
+    "system_NH3.setMixingRule(2)\n",
+    "synthesis = jneqsim.process.equipment.stream.Stream('synthesis gas', system_NH3)\n",
+    "reactorNH3 = jneqsim.process.equipment.reactor.GibbsReactor('ammonia reactor', synthesis)\n",
+    "reactorNH3.setUseAllDatabaseSpecies(False)\n",
+    "reactorNH3.setDampingComposition(0.01)\n",
+    "reactorNH3.setMaxIterations(2500)\n",
+    "reactorNH3.setConvergenceTolerance(1e-3)\n",
+    "reactorNH3.setEnergyMode('isothermal')\n",
+    "reactorNH3.run()\n",
+    "outNH3 = reactorNH3.getOutletStream().getThermoSystem()\n",
+    "for name in ['hydrogen','nitrogen','ammonia']:\n",
+    "    print(name, round(outNH3.getComponent(name).getz(),4))"
+   ],
+   "execution_count": null,
+   "outputs": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add notebook demonstrating blue ammonia production with Gibbs reactor
- add "Open in Colab" badge to notebook header

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c52dfd75dc832dabfbe2b703f8b858