### PR TITLE
Add step-response tuning and noise examples to process control notebook

### DIFF
--- a/notebooks/process/process_control_with_neqsim.ipynb
+++ b/notebooks/process/process_control_with_neqsim.ipynb
@@ -1,310 +1,746 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
-      },
-      "source": [
-        "<a href=\"https://colab.research.google.com/github/EvenSol/NeqSim-Colab/blob/master/notebooks/process/process_control_with_neqsim.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "setup"
-      },
-      "execution_count": 5,
-      "outputs": [],
-      "source": [
-        "#@title Process Control in NeqSim\n",
-        "#@markdown This notebook introduces basic process control concepts and shows how they can be implemented in the [NeqSim](https://neqsim.github.io/neqsimpython/) process simulator.\n",
-        "%%capture\n",
-        "!pip install neqsim matplotlib\n",
-        "from neqsim import jneqsim\n",
-        "import matplotlib.pyplot as plt\n",
-        "from IPython.display import YouTubeVideo\n"
-      ],
-      "id": "setup"
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "process_control_basics",
-        "outputId": "c4410583-4819-4aa7-91fa-4767953cbab2",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 421
-        }
-      },
-      "execution_count": 6,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "<IPython.lib.display.YouTubeVideo at 0x78be30759b20>"
-            ],
-            "text/html": [
-              "\n",
-              "        <iframe\n",
-              "            width=\"600\"\n",
-              "            height=\"400\"\n",
-              "            src=\"https://www.youtube.com/embed/FEnwYVPDRDE\"\n",
-              "            frameborder=\"0\"\n",
-              "            allowfullscreen\n",
-              "            \n",
-              "        ></iframe>\n",
-              "        "
-            ]
-          },
-          "metadata": {},
-          "execution_count": 6
-        }
-      ],
-      "source": [
-        "#@title Video: Process Control Basics\n",
-        "#@markdown A short introduction to process control concepts.\n",
-        "YouTubeVideo('FEnwYVPDRDE', width=600, height=400)"
-      ],
-      "id": "process_control_basics"
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "pid_explained",
-        "outputId": "a6ca73b0-f8ed-4a71-f26b-648ca0b5d615",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 421
-        }
-      },
-      "execution_count": 7,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "<IPython.lib.display.YouTubeVideo at 0x78be3079f4d0>"
-            ],
-            "text/html": [
-              "\n",
-              "        <iframe\n",
-              "            width=\"600\"\n",
-              "            height=\"400\"\n",
-              "            src=\"https://www.youtube.com/embed/UR0hOmjaHp0\"\n",
-              "            frameborder=\"0\"\n",
-              "            allowfullscreen\n",
-              "            \n",
-              "        ></iframe>\n",
-              "        "
-            ],
-            "image/jpeg": "/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAUDBAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIChANCAgOCggIDhUNDhERExMTCAsWGBYSGBASExIBBQUFCAcIDwkJDxIUEA8UFBUUFBQVFBQVEhQUFBQUFRIUFBUUFBQUFBQUFRQUFRQUFBQUFRQUFBQUFBQUFBQVFP/AABEIAWgB4AMBIgACEQEDEQH/xAAcAAEAAgMBAQEAAAAAAAAAAAAABQYBBAcCAwj/xABWEAACAgEDAgMEBgUGBw0GBwABAgMEAAUREgYhEzFBBxQiURUjMmFxgTNCUpGhFlNicoKxCCRjkrLB0RdDRVRVc4OTlKLS0/AlNESjw+FWZHSElbPC/8QAGgEBAAMBAQEAAAAAAAAAAAAAAAECAwQFBv/EADwRAAICAQIEBAMHAQYGAwAAAAABAhEDITEEEkFRYXGBkROhsQUUIjLB0fBSI0JictLhFTNTssLxgpKT/9oADAMBAAIRAxEAPwD8ZYxjAGMYwBjGMAYxjAGMYwBjGMAYxjAGMYwBjGMAYxjAGMYwBjGMAYxjAGMYwBjGMAYxjAGMYwBjGMAYxjAGMYwBjGMAYxjAGMYwBjGMAYxjAGMYwBjGMAYxjAGMYwBjGMAYxjAGMYwBjGMAYxjAGMYwBjGMAYxjAGMYwBjGMAYxjAGMYwBjGMAYxjAGMYwBjGMAYxjAGMYwBjGMAYxjAGMYwBjGMAYxjAGMYwBjGMAYxjAGMYwBjGMAYxjAGMYwBjGMAYxjAGMYwBjGMAYxjAGMYwBjGbenUpbDiOFC7kE7DYbKo3ZmYkBVA8ySBgGpjJsdNWB9uSpF/wA5dqr/AAEhz51NBneyap4IyqZHYyJ4YiCh/EWTlxZSpBB32O474tE0yIxlj1PpO1EzrHxscRyKxH64J5hmrt8e23fcBh9588rpG2QnYaoxjGMkgYxjAGMYwBjGMAYxjAGMYwBjGMAYxjAGMYwBjGMAYxjAPWNsyFyROh29uXgS7Ab/AGG8h5+mQ5Jbs1x4MmS+RN1vSuiLxnrgfkcyyEHYggjsQRsR+IOSU5WYxkidKl8BZwpZG5kkKxChCN2J22A75pRRM52RWY9zsoJOw8+wyqki+XDPHXOmrSa8U1afsfHGbXuM381L/wBW/wDsz3DpVhzskEzH5LFIx/cFxzx7mRpZnJ2v0fqsn6PTL8m/kEp2W3/DjHkpD7LupH246Dq538v/AGdbA/eY8q8+NbyS9SSnYy7N7Juph/wBq/5ULJ/uTNSf2cdQR/b0PVl2+enW/wDysiPEYntJe6FMqmMktX0S5TKi3Vs1i+/EWIJYS222/HxVHLbceWRwB+W+aqSa0ehCGYzIz7T1nTjyUjkoZd/VT5H8MWWUW02loj4ZnPSr6bZsalTMMnht58UbceWzorj+DDIvWiyxycXKtE0vV3+zNPGMZJmMYxgDGMYAxjGAMYxgDGMYAxjGAbel0pLMqQxAcnJ7k7Kqgbu7t+qiqCSfQA5LyTch9H6cjyLIQJZgp8a4V7+X+9VgRuE+4Fj8vn09uat9YyBK8cS77hWMCmSSdVPn38OMEfLJvSnWteg02IAKJFFqTYB7U4Xn4bMe/uwfioj8m23O+/arZZI0X0dKKeLNXluSgbkLHKtCE/5WdQPeCDtuEIXz+I5taxqS9mFf6+xpUauyABYlKncrDGAFBQA7nyXb8ctdHS7DXJWngsQwwhyLUllwlhCnFknjmYqyOWY/CFCg7bdshr+iyJd97VlMA5xeBIskEjwRVmR4o+SlH+oRyDvsdt+3lleYvy0R0160j0K0UIsp7lVkSuyFirFC7yRSKQ8L8uR5qw2/AZtW+n6tnaPdqVwguEtErI5cliJC/ayN99pYzy27MhI3yW0+xRmrwK1gAS1vdY/eVED+HXkjEkccqkqBKBxIZh5bjzOfXqNzBSlW68EkUquKqCvHHx+rcRJEEZuTB2jPIEBRGe532yLJo51rugW6TFZ4XVRttKAWiYHyKyAbEH9+ROWelqVg6VcjaaQxierHGrMSoDidpUXf0IjjJH9EZWM0RkxjGMkgYxjAGMYwBjGMAYxjAGMYwBjGMAYxjAGMYwBjGMA+iD7iR+eTtjVYmiWIVSOAbifFcgM5+1t6+Q7E+maFXVZolCI/FRvsOKnzO/ntn1+n7X87/wB1f9mYzjKT228Wj1+E4nFhi0pyXMkpL4cZeNJuXfyN2hrCclDwrGiENGyqd0ZYmGxIG7c34Ekntt2z5/TZLM7V0dyVaNiD8JRAg5b7lx8IOxPc9zvmt/KC3/PN+4f6hj+UFv8Anm/hlfh63S93+x0/8RhyqPxJaNv/AJceqr+rotux87d55IoYdm2iDAdzseTFvL089vyzofSdq/oegajbrPJTu3dU0/T4p49ksLBDXs3LKRSjuiO70typ+IAA9socfUVoEEyEj5bKO3y3AzoOrTmfTulfE4hrup6hYkCjYeGlqnTgUA9gi+DOB/WbffMOIjbhjaXLKWvXa5focnFZOHnilk55ymkkk4pKkq1ak+lH1u9U9TRm1GvVNuW1TSR56yWroZRCQJwkjoEdk37gHvxbbfbIDVvaH1Skdcza1qirZiE8XG/OpMfiSRBjwcFfiifsfTY+ubF7U4JNSuwU6Mg1C/PZpGWW00kKmzK0UrxwCIMHYMftuwXcnbsNtbq/TJH1CKWWGSDS4pq1CCeZGjiNeDjCJAWALBlR5CRv9s51fc8K1UY+y/Y+dx8RNOpdVetX5KvH6Erp+o6taEMNnqHWPe7NaWzFAbNmWFESKSaMWJHsgq0iRFgFU7B0PrsK/wBKwm4tqe/ftxwQmvG0iSM7+NakMcbuJG+KNAsjsB3IXYEZYYPaLKdZsSNPFDR53BG0VeAHw1gnjqDxUi8R/KEA7/L0ypQ34Ro1qIyL7zY1GrIyEnxDFDXtEv8A1ec2347ZqsONbJdeiKRnndqWl8u2tau+i2R5+irqS34nsNH9HBjYcyScdlsR1vg4/aLNICPmMskEcVeqtwdQakYTOa+1SGdWMqxiQ7GW0nw8WHfb18sieuerIbXjJSieGK1KLNp5injTyhQEiPh9lrx/FxXcklyx77ARVrUIvomtVV95het2JU4kBUeCpHEeRGxJKS9h5bffh4oK1SZoviySbbVvZVtWt6PqXTWNVntdK3GmtW7UQ6jpJSNyZ5ZURdO1Az7cnYISHr8gp234fIZT9F1OCGIKyOGDlmCrGRMO2yMzDdVG3l3HxE5YrVx6/SulFOB8XW9YkPJEcHhS0iMbq4I3G7d/vyo/T03qtcj760H+pM4cMbUkkq5n8nXY+g4HPDBU+ZqVV+VP1u/0MwzVOJd4n8X49kB+r3b7Db/aXjv5d99h9+SsWrwuVZkVfBrkIAgBabbj2IB+e438iN8ifp2T+ar/APZ4v/Dmfp6YeSVx+FaD/Wmayxt9PmdmH7Qhi2lppdQWrWzeqNq3q8UnJhVCyNsoffkAoYHkV4jeXtty7DYntnnqa7JMqP4YWF1Ti3gohLRoFfaQDcqG3G2/yzV+n7H+Q/7NX/8ABmxe19pKorlV3L83YIijcfZCKigL28z5n8MLG4tUvnZfJx2PNjyKeR21f5Erktk6fW3rRAYxjOk+cGMYwBjGMAYxjAGMYwBjGMAYxn3pVnmkSKMbvI6og8t2YgDv6DvgH10uyIZRIU5gB1ZORXksiNGwDDup4sdj89sndW1bTZZ2srWtSSPxYpLOkcXiBVDMfBXme437MPP08s86dpNB5fCFszS78Uj4e7wTyb9kSySxVSdwCUG528t980pNV8JiiU6kLKxUh4TNIrKdiCbDN8QI+Q8sruW2N6HUrmpzQ1CxSu0samKFWESKWALN3Jcgerk5YK8MslG5ZiidnvW544EACLDHxaF2ldyFT4GKAepO2QPTXVE6WomsS7wjkOBXaJGKnw5BBFxUlX4nbb0ObWp1dVNhZZfAreA6Mp8WCKsjo7Sh+DuQ55uzb7HcschosmeNX0NRHUryWoK9iOAj3efxFJkknmd95lUxp+qo3O3w9yMho7l6g7Qh5oGB2eJvsfiY23Vh8jt3z31bKrSQqsqTGKtEkkkZ5IZSXkk2bYb/ABOc8UtekVBDOkduBeyx2FLGNfURTKQ8Q+4Hb7slbFXufDU9Xs2gonlZ1Tcqvwqik+ZCIAoY/PbfI7J8aZXt96MnhzH/AOCsMObN8q8+wWbf0VuLfjkEwIOxGxHYg+hySGecYxkkDGMYAxjGAMYxgDGMYAxjGAMYxgDGMYAxjGAMYxgDGMYAxjOx+we/ounVmuarDptyS3rmj6fFDdWOZqdKORrOqai0DHfwxG8MQJHEs58+BGAcgCnbfY7AgE7dtzvsN/n2P7s6amq6Db07RYbdzV6M+l1poNqtCtZjeWS/YutPFM1uNgd50G2248Md86BpXsxr6jpzaRU1GHhTvvJqFqjGl+o2qT1p5o2sWRKog0ipThEIsdw89ufj2BbKd14On4umNErQWdQs2ydVvwOYaMCK1i1BTeO3Es8kkaf+zXZAG3IcEgb5lmwrJWrTi7TXk12fRsJkIIOl0k8ZdX1/xQ/iCRdJqLIH35c+Z1Lflv33zNpOmbLl59a6gZ/5yfS6s5/f9JE7Z79lHstfXa89gXFgWK1XqBEiSw6NOrObNzlYiFPT0Ve8xLbseIUntln0n2J1WrWvedWEVqrc1SrZmj9x9w01tMkkiH0j7xbjsoJzHzUxxP8AC6dmYkDP7u/65fL9hSu6RT06e6YY9uor0Y9BJoBJ/MxXzn2fpPpsBGPUtkK4JUnp+yAwBKkqTa2IBBHb1GXPUP8AB/ASCCvqXK/PPVigexFWi07UBNC9izJpksFqWxZgrxIzNKYVDcQqjkyqYP216B9H6L0tCJ47IWLWY/GSG3XDEaiJiphvwxTIVE6+abd+xOV+7ZP+pP2h/oLWuxCP010yBv8Aylstt6LoE3I/hzuAb/icwIOkI+zWOoLZH83V02kjfgz2JiPzXJT2K+zGlrlTU7lzUbFVdPauvu9DT5NUuSCdZT43u0LBxCGjVOQG3KQAle2+1Y9mWmQadLHNfl+nfoeTXUg+qir1a9eRVfTLsUn1o1N4/Gk2BHDwkHFue+SuHl1nJ/8A1X0iiL8Cqdb9S0rFOjpum1bNanSluWOVuzHZsTT3PAEjM0MMaRoqVo1CgfMknKbnfdV9iWmPVtJpmpe9anHBBJpsQ1DRZU11vqmuvSrQTePVijiaRlWY8m4/MFc1dO9j2jCjqLza/DPqOmU7Vq7VpS1W91kqU0lasqsWOocrU0cPjxMI1Mcm5JIGb4sccaqO2r1d6t237shuzjutaJZpCsbMRjFurFcr7sreJWnLiKUcSdgTG/Y7HtkZndPa9o2kXtKiuabfktXNC0rpqrcjTwjRSvPV8B44JB8clqO6SXbfj/jYUDdGOcLy4GMYwBjGMAYxjAGMYwBjGMAYxjAGMYwBkx0n8NgyfzMFmXf9kpXk4sPvDFdvv2yHyZ0DdIrsp8lqmIfe88kaKv8AmiQ/2TkPYlbm9rWoSw1qUEbAQyUg7IUjYc3nn5OOSkrJ2HxAg9hnhuGpgHkkeoABWDkJHe2GysHPwpa7AEHYP2O+++/lo1v14hEWFqnWKGAgETwpJJI0kLDv4ihyShHkpIPYjK7hIls+s8LxsUdWR1JVlYFWUjzBU9wckKWg3JhzWBxHtuZZdoYtvmZZSF/jk3R1meOCKWzdlAcMsSRQxSWCkZ4btYlX4FB7Dux7emat2m1/eStaltSDctWssfewB6xDcrOv9TZv6OLFGr9D10/T6hXU/s10ltMPu5IAm/8AazAi0tfOa9L/AFYIIh/3pWOQ7qVJVgQQdiCCCCPMEHyObej0Gsy+GpVFCtJJI+4SKJBu8jkfqgfmSQB3OAStDUaMEiNBVmeRXVo3s2Ayq4YcWMMMahtvPYt5/PNHq0bahdA7f41Y/wD7WyW0ulW5KYKd68ocBpj/AItF8JBPAIG2Pl9p/luM+HWOmSiee2oLwSzyOXCkGF3cloLCecMyk7bHsdtwSDkLcl7FbxjGWKDGMYAxjGAMYxgDGMYAxjGAMYxgDGMYAxjGAMYxgDGMYAyydLdbajpkbQ05YUR38RhJSo2SX4hdw9qB2UbAdgdvuyt4wDoEXtg15QQLFLZhxbfRtEPJf2W3pfEv3HtmP91nVG/SwaJM3lzl6d0Itt8t1pjfKBjAOzdG+3I1lcajo+mX2DxvX8DTtE09ECBuUMyrpchliZuDbqUYcOzd+0Lr3to1W7ZmtTVdCZ5ppJjz6e0WZlMjl9hNNVaR9t/tOzMdtySe+czxgHQ6vtd1SJ0kir6HHJGQySR9O6JG6MDuCjpUDIQe+4Izc1v25a9eZXunTLjovBHt6LpVpkXffijT12Krv6DOYYwDo9D2yaxXcS149HrygECSDQdHhkAPmBJFVDAH5b5839repMzO9XQnd2LO79O6KzszdyzMau7Mfmdyc55jAOhR+1e8P+D+nSd99z03ooO/9msNzk3R9u12CnNWi0bpmOWwvhS249DpxyvVLpI1V4UAgkiLxxn4kJ+EfIEcixgF/ve1O7NDNA1HQVSeNo3MWg6XE+zAjkrxwgq433DDuCARlAxjAGMYwBjGMAYxjAGMYwBjGMAYxjAGS+n6OSgsWCIa3chmYI8/EfYrqQS7E9uW3Eepze6Q00N/jDrG55mKukv6LxVQyzTzD1ghiBcj1JQfPPWp6rRlkPixWrR+z701kRSMo8vDgEZSKP5J6DIbLJH00qXTZfqkrCKwe0Ulud5oHb0jfw/D8Ik9g3cbnvsO+bhtJGXg8OvuGHiV10t2POPkAH5yBuQ5MN9/U98hLmi8zA9LxJ4rIfw1ZR4sbxbeLHLx+H4QVbl2BVge3fJycXXpbTGeOaqjFJFkJSxWQr4iEo3EzxBgwJ7lN/2QcqyyIjXqprPWtV1lrCZTIiEurwTRuUkRS3xcdwrAnvtIPPbNmisGp8vGK1rMUbSvOir4diOP4pOcK7cbAXc8l7NsdwPPMaYht1rVbk0jKvvkBduTiWNfr49/6cW/b1MK5o0fqaU8vk9phVi+fhrxlskfd+hX+2ckgm9LppZME9dYpa1JXEtay6Rsm7MyySuQyvzLctyOIKFSNgN99qel2ZvAlgtadcjQvvGsfGXwkMjMqJ8O5VWYFQoPoc1tNm+iq5lWRSxEqnjxZLVl4/DEC/zlaBWZnfyLtxG/nkVJ1bMaz11hiTkjRB4+YCRuQXCRkkRkjcfCQNmPbIpvYm0tz49a6lXszI0CsSsapJOxblPxVVQsH7lwq93OxYk9hsM2ekfdXrWoJ5FiMstfdvGSCQxL4jMA0iMrqHEZKdu+x37ZVc9ZatKKXrZ1Kzc2hhj0+OtJG87VFlaNZYYErr4kkjCTfseTPyYdxGzebDb5UxX98MgtTzXJk5NG3wrJGsPiAzQ1ouLRmJQeBbsCB55W+l9VsVKVuQNvATHGkToGhlmnO0nMEfGPBikBG/6wz66V7yYpba82uXneKJlDjw4YijTyjwx8G7eHGvlsA/yynKaWQHUE8MtmWSugjhZgUQLwA+EBuKcjxXlyIG/kcjsn+qo/EEN0Kq+8KUsBAAq3IiVmBUdlLLwk2/pnIDNFsZvcYxjBAxjGAMYxgDGMYAxjGAZxmdsnKnSuoSwieOrI0RRpFYAbtGp2Z0Tfk6Ag9wCO2RKSW7IlKMd3RB57jUsdgCT37AbnsO/b8Bltr+z+65ID1SYxvZVZhK9McXP+MJEGYN8DDigZtxttvm90z07a07VKbWI2EEsqwrY4sIT7zG8YVi4HhybP3jcBhsdwMzeaNOnr2MXxEEnTTdXRR6td5XWONGeR2CoigszMx2VVA8yScw8ZVyj7qVYq3bcqQdm7A9yO+WToMFJNQlA+ur6dbeIr9pJDwgaRdvVY5ZW39Nt/TN7Sp9Er14FsQvasWIpDPKkh2p83khCrD2EkqIiSA7+ch37bZMsjXS/ISzNbJvyK71DozU3T41mhmQS17Ee/hzxMSA6g91YEFWQ91ZSDkTlo1g/+x9OVj8ZtX5IwT3Fciqm+2/wqZY5dvvV8rGTCTa1L4pOS17tex5xjGXNDOM2KlSWZisUbyMqNIwRSxCIOTuQPJQBuT6ZIdPaI1tinNYt/gikkVhC9hv0UDSgbRM4DbFu24G+2+4hyS3KuSW5DYz7WoHid45FKPGzI6MNmVlJVlYehBBGfHJLHrMZs0qkk7rFEjSSNyIRRuSFUux2+5VJ/I5tQaJaf3XhAze+llqhdiZikhibiAdxs4I77eXyyyi3siJSit2iMzOWh+m5oUsRWaxilgarPLZMyvHFTmPhchHEW8dGeaBg8ZOwUj1y33emdNtSyiqzTvHo1eQSJGtejHYWonGSxKHLRs6xyNxcL9YVDHuc2hw8pefZ+v7HPPi4R8V3Wq6ddupQL3T9iGpFcfw/CkdU2WWNpUMkZli8WJTyjDxgsN/MDIfJu7fmOn1a/KuIBPYk8OMjxml2jUy2Rvv8AYYKh7DZX277kwmZTSvTsbY3JrWt+nY84xjKFxjGMAYxjAGMYwBjGMAYxjAGMYwBjGMAuvSkZlqcE2Lr9IwbbgESXKsQr7k/ZDtDIgJ/WIHrlUbT5w3Awyh99uBjcPv8ALjtvvm708biNLLUjlkEUTPZCRNNGK4+2bKBSBD27ltgOx3GTS35rqj3S5PXn22ai1qYRvt/xSR38j/NMdx6FvLK7Ftzd0ei5gGkLuL9pZWWMK7skkstUpXk8JWKO8ddiQR25KG277T2i9EahQW1HaiMfuZNzUeSyCGGokUlfwjIVCvPN7w/ELuPqxue+edD1XTqMUun0YNSGp2gguXbHGvNJWjhltWaVWGI+JU8aRIYi3NzIgb7PLjml/LDVtSrrS1Es2lVo33DiWOOuEjfwvDkZt2lVmCqDyJ7Dy8r8sUtXfXTY4nPiJyuCSjdfiu67pL6MjNJpSxSCOMVpbFSWQKjSND4RhlIMsu7BWLAeZHHiw3J8s++uaGk7QpGyJWqNI0zodwlKdmtxWQfJ91Z49x5tGg9RmvNqMslaCQNUVbKnxxaQESWavCFn5cTy3jMLbHsCW288XtQiNIGeGCURzGqzU3MJEciCxCIpQCCisJAY3Vl8ttiN8y1PQ0IvUdbpTlC9KTaFPBhjS0UiESsxTkvhluex+IhviO57b5qjWok/RafSQfORZp2/fNIR/DHvmnJ9ilNKf/zFo8R/ZgjQn/OzP8omX9DVpQH0ZKyyMPwawXIP35eiln3g1S3IPqaVYj/JadC/8fDOb1Z9ZbulYRAfrGhUrj8neJR/HPfRIt6xqENGTUZ4DYEqwkM/Bp1id4IQiMqqZHVUBA82GTvW3T71o49Y01Gs6bMqR24bO173CyducE8jr8VaQjnFY+EsGKkh0YZTJJQrm2k9H0vt5voXhFyTa/u1fhd6vwItLG8LRaxOjpz5wrHZE06S8DGPqq7FVhG+532PbtuTm8lmnGkUU0UDkRqteNHse7ywuzPG6oSzTkszEllGzbg/ZyvVNM024eaWvcZD51JF5rz/AMhYd1UofQOQR5bnzyTm0ZyYh4E6R14jDEsvuL8wzvI0jNNNw5FnOwCkAAdz54dBWfAmKaeaoFSNbqfVxxoqRw2YEJruo8RmBYhozuF7SnKTl5nnqVGinck2IJBJFWinrS8mX7PjNVhWOBN9iQGdj5dvPKQ7bkn5kn9+WiUkecYxlioxjGAMYxgDGMYAxjGAehnTOjdZtGlYmYVVhq0bFU2VWJbinwd6cbOTyCmRlClQNzGQd9s5ll/0f2dPNo7apJa8EyQahYqQeAzpPDpb1ktNLY5gVzzsqqDi3JlIPHcb4cTLHFLndW6Wl6/+kzPLi+IqK9qXVd6fYNN4YWQy7QRx1uUrDYyv7uq85SCfiO57n5nIaSRm33YnkSx3JO7HzY7+Z+/Lf7M+kGv6nRgtQWhUn8edmjikDWIKcEtmZK78dmd1hKAjfYuMwns91m1J4lbRrsUNhp5KytDMsXhxsOUcc9gL4pTmidzyYkDuTlfvGCEnFtKkndpLW/2ZaONR2XsVjS781aVJ4JGjlQ7q6nuNwQQfQqQSCD2IJBzXlYkknzJJ8gPP7h5ZcG9l2vL7z4um2IPdahuyiwogPgBGk+ASEeJLwR28Jd34xudtlOZ0r2YazZltxJVCtp9T3y6ZJoUSrFwLqth+W0U7BTtE2z/MDY4+94FcuePna/nVe5fl1utSlb5jMnMZ0kGcZ96VdppI4kG7yOsaDfbdnYKo3Pl3IzqPtF6Ii0uvbj+hNTHu0xqLqs96MVpJ0l8J5YqiVRziZ0kCgOdgV3OY5uJjjkoPeW2qX1a9lbJSsrHTMTyaVfSqC9kz1nnjT9K9GNJmfZftPEJfDLBfkpPYZsdSdam28tWJY6+nScIo4zFw8FFljkSYrCfjmjClQ3c8CR33zbp+yPWmUPxqw7ymAc79QMLCxGeeu4jkbwZYYFaSRX4lEG7beWetR9l8un11sazdraWLBl9wV0nue/xxRRS+PXkpI6e7sJ4gsjEBuR9Ac5fvPDuX5k3eiWr9Erb26LuY/dk5c0vNeBVet9Qit37U8O/hSSEoWHFnAAXxGX9VmILbf0sg8zjO+KpJI0jHlikuhZfZ74y2zJFUnuKsFiOZK4PiJFYry12kD8WCMBISCw23G3rknZ67RY446+n14DWhsVasrSTySxQ2RIJS/wAQR7BM0h8TiNi3YAADNXqOVq2m6XUjJRbMD6hZ4nbxpXsTwQ+J+0I4oNgD2Bkc/rHKmoJOw7n0AzqeSWNUn4vbrTOVYY5ZOcl4LV9LWuta69NiSsa7bkUo0zFDXjqFewBrwuskcR2HdVZVPz7ZF75t/Rtj+Ym/6qT/AMOY+jbH8xN/1Un/AIc5XlT3fzOpQS2Rp4z6NEynZgVPyb4T/HPPA/8Ao5NknnGeuB/9HC4AxnVOqOkRNvBFFWhmhcNC0eytJRFVZZpJoo+Uj+G/DZypd/HI77doX+R/usckkh8WxVnrtJCYz7v7tK0Jilcy8WkVzLxMa7Mu2zAdyMFxEGjlhxcJLx7FUh02Rq0tscfDimhhYb/FymSV1IH7O0TfvGaG2dKopp1avqFOw3KZdTrxS7yiCLaKxZi8auiAngkbMTuTtyX0A3R0unpNzZt7GSxKZZ1adrIc23VOMSxeC1UwAOX35budh245Hx6btP0RC4mm7i2r0peCOb/hkzqugvC1eJOc1iWtHPLEiFjD4/xQp8O5ZzE0THsNjIBn16jtUJo42qwCtKs06PGnimNoBwNeQmV2Il7uG28+IOwyf1vrGWvLam0+wijUlrSeJHyS1UEMZieqxP2O/bsSCEQgj0tKcnVLvuXlObrlXo/T/wBlc1PSkWlXtxF9meStaR9t4rMY5jj2H1bxsCAe4KSD0yCy2atqStppEkyTWr14XJFQD6pYkmi3l4gBZZHlY8R6LuftDKpl8bbWvc0xNtO+55xjGXNBjJDRNItXp46tOvNasSsEiggjaWV2PoqICT+Pll7/AJIaPo/xdQXjauIe+iaLLDLIjDv4eoat8VeodwQUhE7j14nAKZ0p01f1WytPTqk92y/2Ya8ZkbbsC7bdo4xuN3YhR6nLo+jdPaGdtSnbXtRTs2nabL4OlQSDzjt6sN3tkb7FKqhd1I8XNDW/ahqDxirpoj0PT0dXSlpPOtyeM7xy27fI2L84+E85XOxG4C5LR6np/VIEeovBpfUGwWLVm4w6dqzeSxauqjjTunsBcUcGJ+tA/SYBXuqfaNqV6E01eLT9O9NL0yIUqH/SRRHlaf8ApzNIx+eU3JTqTQ7em2Zad6vLVswnjJDKvFh8mHo8bDYh1JVgQQSDkXgE1R1+RVSOwi2ooyPDEpdZodu/1FhCHi77dtyvbyyXhu6ba3NufUUKlWRJ7JsRnffkA6wlk2/DuD55T8xkcpKZ0F7umOsam/HEkQYRwwaZzEYY7nhJYBZ2OwJZu5OQHUWoVTE1eq08wewLEk0yRxblY2jVUij8h8ZO529O2V3GFElyGMYySpt6dbkrzRTxOY5YZEljdezI8bBkZT6EMAfyy/6r7QpKmpzXNIkQV7iRT2acsReqJrMSPqNJ4ZPhkqtOZlK/ZKsNu4BHN98k59HsJSivFAa0081dZFZW2mgSKR43Ud0PCVCN/Mb7eRw480eVq090QpfDmpxbTacd6tPo++xIaJ0zc1M2GqxRhkgnuJWUlXnihbeeOkj7md4kLOYwS3CNz32yunJzpXqGalJGyO4VJUmQo5SSGVDuk0Eg7xTLt2YfgQRl41mDR9ck5tPW0nVpRzE5Hh6PqTHfd5kTc6NdZt+Q2MBbc/Vg5jOcsbtq4+G6fit68Vt10OyWGMsanB/5k90+/in/ADx5TjJLqLRrOn2ZaduIw2ISA6Eq32lDoyuhKujKysGUkEMCCQcjc2TTVrZ7M5DGMYwBjGMAYxjAGMYwBjGMAznS9D9rVqpp9DS1hD0a9fUq92s0n1WoLqMkz7ybJyjMfioV2J+KFWzmmZzLPw2PMksitJ2vOmr86brtuiU2jser+2zWLHuL1RarGrTanJAlydtPmVqQpeJFRjVBXcLu4+Ntn4kbBQMhNV696gs1Y6zg8UrVajSeDI0s0VKxFZq+I0hYeIjwp8ahSwHxFsoyavZACieUKAAFDsAAPIAb9hnk6pY/npP89v8AbnJD7OwwpKEdNuvVv6s7U+Gr8Tm36IunUHX/AFBasS2GkkrmWW1O8UEbJD496p7lcmCPy2klg3UnftyPHjn2g9p+pBbkdylQvLf93ewLNRovFsVfFEVqUUnh8ewfGfkZOQc7FgSN8oy6xZHlPKPwdv8Abn0XXbY/+Il/z2/25p9yx0lyR0qulU7XzJvhn1mvRP8AVHqnpM1gSPGqllO5iHZyG9UXbuo+Q7j5ZsnRoU3E9uOOUbAxqjyEE9tmZRxBHrsTnvTeqbUZ+J2k+JSSzMW4g7lAd/hB9SBv2yQsaBAqe+PJKYyviiAqBKULAAlwSAvJh8W3kQdu+WlOUXUnXatb8D2eF4Lhs2LnwR53FN5Od8sYxvfRpv39GQa1Z6tkFV5PBKrAhSylo2Dg9vNTsD+GX+713Laty2INA0mC9csPZmtzQ2rT+8zSmaSSIXJ2irgyEkBU+HfscodvqC07syyuik7hVZgqj0CjfyA2H5Ypa9OsimWWZ4wRzQSspZfMjfftvkZMLmk5JWl3fzWz9TzUuC+LVz5ebslpffXp1OudH2NXllssbdbT2SfUupLliVrEdesQiVpJoVpxySfGLjQiMKwYOAR2yd606Pe7Thuap1JpNipAsNqCaezrLqsetSStE4CaWXAkalMOH+9+7lSF2AyB6J6kFbTNTsmGlcu26VKpXq3YhYqyRvqbXLXNC6oBGtWr8LkdyvnscmLF/TNR0u3DqfUhhu6hJpEjKdJiFehDpcVwLRqwULXhiEPbPHiFGyHcbtnVDhlFxlyRTSWvKu2tOvF9Tt45Thla4aH9nS5XKMW2qWrbVPUqdDoyJ6wNWWimpPRs6nXoT1Lu92hVNhmnpW7G8U7tDWllVGRCQjD7Q45zvqsA2fhRVHg1z8CBAS8EbseKjbuWPlna9f1vQdPqUvo7VPpLVKuiT6HBZlqT0qtWK1YvvZuKjBnntmvdaBF+wnxuSx4gce13XplmKQWGMSJCi8GbhusSI22+3bdTmuTm5em68O5zPXDJcQ+XVUoqLez6WqRYOo9a0d9JpxwQTTX1qtUKTnmlFBaew0yyqq+NIxdlQeSI7b7nbPfsKpSx6rDcC7CKnrEsUoKkxWINIvSwOR3Mbq6KykjzUEeWU7+UFv8AnSfxCt/eM6R7L7ss1TWZ0ilmatpE0QZIy0j3tSZaFaOGOIb/AApLYb1J8Jj2A2zg+08854mmkrXLp46fqcvCcHwGOE/7TI3TauK1k3ovzPT0JLp/XddsR6aLHWOsVbOrbijAJLs8exsyU4zYnWwphDTxOOyPsNj38sxW1Hq1noK/Uuqp71HfsWCbttvcqun2JoLFh9pPrU+olK7bcioUdyM+curdQQxaVX07TNQihpUYITK+hrNPFZMkstmarNLAzxnnKSpVl7qD2PfJbqzU7laW2+i6b1AJJaFXTqtmXTp6hoVa80UjJCFDvI8ojJeQlSXlkIHfN1j4Kto+y/n0PmJZOM5qV63XgraV6KtGnu7pklpVjqB9UEEuv3X0oVaF1rN2vXnt+BqTRQ14hXtrIrWDYnWM/EVHFjv22yK0y/rcpQWNX0mm0+pz6bUFnQqLtakrskcjoa+nuQokmiX4gBux+L4TkRrnWutv4oj06+zSQaFGZ7kFmScTaP8AXMx7bFZLJdiCfIL675XOoerrz6tQ1C5QNaCjYhlhoxRS14VRbPvcqxmcE85ZWkdnbckv8gAKvhuBe0IN+S7/ALFsa41/mdaeF6LxW7bryRfKnWFqvrGnUotZrXJ21WtUtR1+nqFOJU96SKVRZaASNud12VBuCe+cd6+C/SupFFCp7/c4KAAFX3mTioA7AAbDYZJdD3DY6k06wRsZtaqTEeexkvxuRv6/az59Z6xMmpX12iZVu2wA0EJ7e8S7bnh3P55hHFDHmfwoxSrZadT2eFhHkrNKV96T19Kr0Ia/rVmawbTOUmYKOcX1RHGNYxtwI2+FR+PfPjZ1OxInhyTyvGGLhGkdkDk7lwpO3In1882m1eN/0lSu34B4z+XhsB/DMe90W86si/1Zx/8A6jOdC0/u/Q6FweF/lyQ02tST+jXzIpjv55kD12O2T9mvRRInKzgTKWUB42IAdk7/AAjvuub2iTUeMqsrGDYGUytECPPiY9hzL/IKfx7ZV5aVpM7MH2TzZFjlkgrV3e2lpvTRUU85jPrNtyPH7O54/Pbftv8AftnzObnkyVOjGMYwVGMYwCxaN1pqlKlNp9O5LVrWXL2FrcIJZ91VDHNZjUSyQbL+iL8O57dzkz0FoNDWKsumptW18SmbTZJJitbVVKgNpTiQ8K13deUL7hZGdo27mM5RMkundZs6dahu05TBarOJIZVCMUcAjfjIpVuxI2II74Bta70teo1qdq1CYYr/AL2K/IgSFqVg1bKSRfahdJQQVYA5B5+i9W6j1j2gtoNDU9LNSKBrlmfWqlOcCSBoWkt2jGVEPHaujEKSWddl7sBnBda0a3SZUt1bNVpF5xrZglgZ0325osqgsu48x2wC69JdXQXq0eidQSM9ALw07UyhmuaFL+o0bfbn0sntLV3IA+OPiy7NVes+mbekXJKdtFDqFeOSNhJXswSDlBaqzL8M9aRNmVx5g+hBAg86B0r1dTsU4tF19JpaETMaGoVwG1DRmlPKQQq5C29PZvieqxHcs0bIxPIDn+MtnXHRFrSxFPzhu6bZZhS1SmxlpWuI3KBtg0FkA/FBKFkXvuNu+VPAGMYwBjGMA9DLz0+TL03rUZ7itf0i0g7/AA+It6rIR8gecQP9Vco2bNaaYJLHG0oSRQZkRm4usbc1Mir2ZVbY9/I98tHf3M82PnS6U0/Zp/NaGpmd8xjKmhMVtNE8POJy86Al4T9pkHk0X7XEea+Y23G432s2kdNaXqkUUVC3JS1bgq+5ak8Xut6fbbjSvqFWvM5HwwzqASwAkPbKRXnZGDoxVlIIIJBBHkRt5HJHUNQisR83QpaBG7oBwmHqXXtwk+9ex9QD3NcsOaK5W016p+n88GjsXwpw7SS26PxT6Pw2Zp6nRmrTSV7EUkE8LtHLFKhSSN1OzI6MN1YH0OauXa71lHqNFq+rV2s3K8Kpp+qRMFuIE2CVbzN2u1Au4Vm+sj2ADFfhyk7ZXFKTX41TXs/FHI0ecYxmhB6xjJrQ4I0SSzMNxGNoVYbrJMduxH6yqO5Hl5b+exrJ8qOjhuHeafKnW7beyS1bPjFodllVlQHmN1XmgkYejCMnkQfQ7d8j5ImRirgqwOxBGxB+Wx7jJigjSs1uySYlO5LEgzOB8MSbd/lvt5D8sjdRtvPI0rndmPf0AAGygD0AAAA+7Kxk26f88Dp4rDhhiUoqSbeibTtd6pVfTV9TTxjGaHnDGMYAxjGAMYxgHsHJzXbMhr1A7MWeN3bdjuQzlQD920a9sg4/Mb/MZK9Vn65V9I4YFH3bRISP3k5nJXJe56PDTlDh8rT0fLGvN3/4kPjGM0POPoGPzOb2jeAZR7wxWJQWbbcs3EbhF+TMe257DffI7PQxdOzXFNxknV09nsXfUtRjngheSHeqymM+ENjVlRmA8P8ArR8CVbs3c+Y3FLkADMFO4BOx223G/Y7enb0zc0rUZa5PHZkbs8bDeORfky+v4+Y9CM2dY09Ci2a4PgudnjPdoJCN+BP6ynYlW9QCD3BzWcudX1W/8/lHpcVllxkfibyitVWtUlafVeHTyIXJnp7qfUdPWZKN63TWxw8cVZ5YPF8IsY+ZiYE7cm2/rHIcqfkcZi4qSp014nkUTzdaaue51PUCfmb1r/zcJ1rq6ncanqAI8iL1oEfmJcgMZX4UOy9ibLR/uia//wAt6t//ACVz/wA3Nun7VOo4fsa3qnnvs92eQfukZspmDlXw2J6OK9kLL/8A7svU/wDyzd39D4i7g/MHjuD9+USWRnYsxLMxLMzEksSdyST5kk7588ZOLh8WK+SMVe9JK/YNt7mMyMxmVzQhExrnaCl/zBP755jkOTkz1B+hpf8A6f8A+tLkMczxfl9/qdv2h/zvSP8A2oxjGM0OIYxjAGMYwBjGMA6N7OvaXe0ypqtY6lqkaz6S9TTo4bdgQ17LXaUviKglCwfUxWBzUbjnt6nKTrWs27riS3as2nUEK9meWdwCeRAaViQCe+R+MAYxjALT0N1rZ0ozRBIren2wEv6ZbUyU7iKd1LqpDRWEJ3SeMrIh8jtuDNdSdFV7daXV+nmks0IlEl7T5SH1PRt/te8KoHven7/ZuRjbbYSCNvPnmSfTmuW9OsxXKNiStZgblHNE3FlPkQfR0YbhkYFWBIIIO2ARmM6frWiVeoq82qaNAlbUoI2n1fQoRshVdzLqejRju1P9aSqN2g3JXlH9jmJwDGMYwDOXj2HtvrlKEjlHa8enMh+y8FuvLBKpHqOL7/iBlHOXP2L2IodcozTOkccLTTF3ZUUGGtNIu7MQN+SqAPUkD1y8PzLzRz8YrwT/AMr+hTpfM/cdv3ds8Z6k8z+JzzlDoQxmcyFPyP7sEpNm5puoSV35xkdxsysAyOp81dT2ZT8su/SPU8UCS11jrT07DeJZ0jUF3ryOF4mSrcUiSpY4dldSp7AEsOxo9bTp5e8cUjj+irH+4Zt/yft794iv9Yqn7+RG2UySxyjyTprz28U+h6XDY+IceX4blHtTdX1T/iJ7qfQtLkrtqOkXQIlK+Npd50j1KqXbiPCYAJqMG5/SR7OBtyRfPKZk9p2lzwuHZazjyKSTQMrKexB+PcH7wQR6ZcOka1GAzi3DFPplqLjehRoZb9MxnlFa06ddyJUc77HZWUssg2IYZRl8ODpuVa11rsu9e/fuXh9k55xvlprdPTTuUXSaCspnnJWvGQCf1pG8xHHv6n1PkB3PoD9wr23LNtDViHc/73CnmFQfrOdjsPNjuT6nJj2iaJLTngDOk2lTLz063V3atYq8tmePlsVsA9pI32dX3DehOjevUnUIoseEm/CNfDQDsAWY/Fzc7dz/AHDtlFk50pLr8v8AfudOGOHlcU1Uau9Hkl49ortv+kTq9/xnAUFYYxxiTf7KDy/tHzJ9STmht92S3vVMfZqO33vMT+8Iq/356+l+PaKrAg/5vxD++Utmyk0qS+hx5cUZyc8mVNv+lSforSVLwZEcT8jnkjJ2hq1h5EQ+GFLKO1eAdtwP2M0uoSDan2AA8VwAoAA2byAHYZaMndNGWbhsaxfEhJvWqar21ZG4xjLnCMYxgDGMYB7U+R+WTdrVq0rmSSoS7faPjMATt32AXsPzyEzG+VlBPc6sHF5MMXGNU6bTSequt0+5Me/0v+J//Of/AGYN+n6Ul/OWU/3EZDYyvwl4+7Nv+JZf6cf/AOcP9JMDVKw8qMP5vOf/AKmZOsx+lOsP+tP98mQ2+N8fCj/Gyr+0Mv8AhXlGK+iJk68w+xDWX/oI2/iwOSXTesySTiBxDwmBjIEEIAY/YJAXvs/E/llWyV6RX/HID6I/iE/JY/jYn7gFOXx448y0Ong+P4j48PxPVpVsmno16nt9ckBIaKu2x2714h5feqjMfS0J+1SgPzIMy/6Mm38MiZjuzfif788ZX4cehzS4/Mpb35pP6omBcot9qrIv3xz7D9zo39+ZZNPbyksJ9xjjf+Idf7shsZHw+zfuPvzf5owf/wAUv+2iX9ypnytsP68BH8Vc5kadVPleiH9aOYf3RnIfGOR/1P5fsPveP/pQ95/6iY+h4f8Ajtf/AOb/AOXnoaGp+zarH+2y/wCmoyF3z1yP345Zdx94w9ca9GyWOgSfqy12/CxEP9JhmB0/Z37Kjf1ZYn/0WORO5+ZxzPzP7zip917ErLwvXHL0kv1iyc6nhZFqqw4ssHEruN1Ikk8x6b9j+eQZGGOYy0VyqjDisyy5HKKpaaXeyrel9DGMYyxzjGMYAxjGAMYxgDGMYAxjGAMYxgG9oup2KViG1Umkr2YJFlhmhcpJHIp3VkZe4P8A986Otej1ZuYEr6b1M3c1kKV9N15/U1lOyadqrHv4O4hmJPHw2PFuVZkHbANi/UlryvDPHJDNE7RyxSo0ckciHi6OjAMjgggg9xmtnUaOu1OpIEpa3YjqavCixafr0+4jsoi8Y6GuSAFmQABY7p3aPssnJNilF6q6eu6XaenfrvXsR7Eo+xDIw3SWKRSVmhYd1kQlWB3BOAROMzln9n2jwXHvrOrHwdK1C1CVJXjPVgM8bHb7S/AQQf2slKys5KKt7Iq2MycxkFiz6JQ2r+MldLEjyFfj+xEqAEk/EBuxPr6IfnmzytDylpV/uQ1tx/aTdgfzypKx8tzl8032aXfAjt6rNX0KjIvOObVHeKewm/2qenRq1q0CPJljCH9rMXibbbfyPZx/acMcYqEZJpJaSq31eiT18WyHtB3G02pIR8uUz/wVds0jSq+t3c+u0Uh/idsz1QmnpKI9Ne3NCi8XsW0ihaeTfYvHWiLeBF27Kzu3fuR5Z8NK08SBppW8OvH9t9tyx9I4x+s5+XoO57Y5OVb/AE/YiHFfHny/Di33cpuu7b5kqRIadpNaVtlsSyEAk8YQqgD7TM7yDio+ZGadyZILH+JSSbL2EhOzMe4JXbbZfTbPq9ySwRXqx+HESNokG7Pt5GV9t3Pr8h8hntpoqY2j4y2vWbs0cJ+UXo7j9vyHp88rHmjK7d9F+rOnI8UofgUYqLtzXNq+0E22/wCbErBrktHT5tOn/wAYitulh6kpBjrSoQY54u3KGyy7qxQqShAbfcbfHpyK1fkaDTtMSxKsZk8KKJppeC7AlVdyzncjsNyfllWldmJZiWJJJJ8yT6k5mKRkYMhKspBVlJDKQdwVI7ggjzGT8DRtVb18L8rR58uPknWNJRWi0Tfq6tt7ktY1ixGxQxQxOjFWRqsIZWB2KsHQkMCNtj3z4/T9oeTov9WKJf8ARXLlB1FS15Fr65IK2ogBK2vhC3i8RskOtRxjlYj22AtKDKnbkJB5VPq7pe7pUwhuRcPEXxIJkZZa1qE/Znq2IyUsQn9pSfkdjuMpjlFvkmkpe6fin1XzXVFPv/ErWM5V4OvofH+UVv8AnnH9U8f7sjXck7ncknck9ySfM588znSoxWyMM3E5ctfEk3W1tujzjGMkwGMYwBjGMAYxjAGMYwBjGMA+1eJpGCIpZmOyqASSfkAPM5MzyLUjaJSrWZFKyspBWFD5xqw7NI3kxHYDsPM5CxuVO6kg9+47HuNj3/A55OWTrbc6MWZY4tpfifXsvDx8TycxjGVOcYxjAGMYwBjGMAYxjAGMYwBjGMAYxjAGMYwBjGMAYxjAGMYwBjGMAYxjAGdB6U61glrRaRr8Ul3S4+QqWIiPpLRmf7UmnyOdpaxPxNTk+rbbdTG3xZz7GAWjr3pGXSZ41MkdqnaiFnT9Qr8vdr1RiVWaLkOSOGBR4m2aN1ZWHbc7Hs/1CCpBrM0kiLK2lS1asZ35yS3J4K8vAbbHau1gn7s3fZ/1VW93fRNa5vo1mQyRzoviWNGusoVdRpr5sh2UTQDtKg/bVCNjXfZRqNOvNOwNhTaowadJSRrVbV4rotlJ6E8f6YD3ZR4YHMGXZgpG2Wjd6GWeuWpOk2l81p67HO2yzdEdFXNWMrQiOCpWUPd1G2/gUKUZOwaxYIIDE9ljUNI57KpyzJ0Xp2iAS9TTO9wfFH07p8sfvu/mv0rcHJNLQ9vqgHnIP2Y/PK/1x11c1RYq/GKlptZiaelUlMNGruNi4j3LT2SPtTylpG3O7emVNSwp1No2g9tChOp6mvYa7qUCiCu/85pOkyAhHHbjPa5OPMRoc5/rGq2bs8lm3PNZsTMWlnnkeWWRj6vI5JbNHGAS+l0kKmeclYU7bL9qV/RE+R9S3kB+QP1Z5brCONRHDGDxQfDHCg+07MfP03Y9ydvuGfCjqnCPwZI0mh5FgjcgVY7AsjKQV32G48jsO2ZvaoGj8GGMQRbgsqksXI8i7nudtzsOwHy375g4yvbyfRf7nsQyYI4UlKlX4opPmk+11Sj6+ln1u3UhUwVT2I2lm8mm+4DzSL+j5nzPyEM2MDNYxo8/iOIlldvRLRJbJdkecYxljnGba3pNoVZjJHAxaOKQs8S8mDuBGTsqsR3A23zUxikwX/WqekanVlvUPC0q9Ahlt6VLKRUsr25y6RNMSwcE7mpISwBJRmA4jPSekV9P0+TWtRiimMyzVtGoy8WW1ZKmOW/NGftUq25237STcFG4V9rN7L+sNZMUty9q1uLQ9MWJZxvFI9mTiRV0ykJ42HvEnA9/KONHc/ZAMPr/ALbtetTvKJqsURZhBWGnadLFVh5EpXh8esxWJd/n3JJ8yc8e+Jcnigo8qerc3df03yXe3fTrqjT8O7+nz3OaMM85O9WdV3dVaJ7skUjQqyx+FVqVQAxDNutWJA53Hm25yCz14OTS5kk+ydr3pfQzMYxjJAxjGAMYxgDGMYAxjGAMYxgDGMYAxjGAMYxgDGMYAxjGAMYxgDGMYAxjGAMYxgDGMYAxjGAMYxgDGMYAxjGAM+1eF5HWONWd3YIiIpZmZjsqqq92Yk7bDN7pnTEuW4K0lqvSjlbaS3aZlggRVLvJJwUs2wU7KoJYlQO5y8WuuaWjo9XpaOaKVlMc/UFtUXVZ1PZloRoSuj1m7/YLTMCOUg+zgHiP2cQ6eqS9S6gukFlEi6XDF77rkikchypKypQDDfY2pEPrxOW3W+vPovputB0+tvR4tRu2wJGuvYv2atWKKGSxNMAqVHlnkZdqqxjaFgS3cnmvTWj09QDtZ1datySbZY7FS5YE5bbZzYrLI3iM7EbFCfvO+df6s0GnWiSt73oT6hTpx6ZFBcuxmDTECGS3ZaKSPaxfmsT2HAK7QgjcM4+HbHBtNnm8XxUFOOOnvb0fTxqqTad+Hc/PLkkkkkknckncknzJPqc+eT3VWhwUjGkeo1L0jBzKKfjvFAQQEUzSxIsrMCT8G4G3c5BbZk9ND0YSUlaPOMYyCRjGMAYxjAGMYwBjGMAlLWt2palei8pNStJPNDAAqostjh40h4gF3YRoN2JICgDYdsjMzmMKKWiQMYxjAGMYwBjGMAYxjAGMYwBjGMAYxjAGMYwBjGMAYxjAGMYwBjGMAYxjAGMYwBjGMAYxjAGMYwBjGMAYxjAGMZkYBjGT3U/Tr0YtNmMqSpqWnpfjKKy+GDYs1Xifl5uslZ+47HcZA4AxjGAXDpPqWDS6k01aOT6ZkkMcNtghjoVDH8clXvuL7sSviEfVqCV+JtxVZZGYliSSSSSSSSSdyST5nfLV05oNefQtavyB/eKFnR44GDkJwuvdSdXTbZifBjIPpxPzyo5bmdUUjiipOS3e7/Ty8DBOYxjKlxjGMAYxjAGMYwBjJDQmqrYjN2KeasCfFjrTR15mHE7cJpIpFT4tj3Q9gfLzzqXUtTpPTq2kzNpGsTtqlA3yja5XjaFPfbVRFJTTtn5CsXB2H29tu2AcdzJGSEFGSzOEp17EnjTMleFFaxM3fksQ8JPrZQhG/Fe/nsM6Z7c+kNThHT7Ppl6IPoWjU92pzIHvCKbeqPg+K1sB9X9rt5YByLGWCXovWFstTOlaj72kYmet7lZM6wt9mUxBOQjP7W22bujez/UrKWZGjhpR1JVrzPqdqvpgFlo2lWsvvroXn8NS3ADcDYnbcbgVLPbIQASCAwJUkEAgEgkH17gj8snNe6P1SgniXaNmtGDArPLGVVHsxPPXjkPlHK8UbyBG2YqN9tiDll9pn1WjdJVjtz+iblxj2+xd1m+Yx/mwb/2sA53jGMAYxjAGMYwBjGMAYxmxSgaWRIl4hpHWNS7KihnIUcnYgIu5G5PYYBZde9nes0arXLNF0rp4PiusteVq4nAMPvUUMjPVD8l2MiruWA8ztlSz9TR9KWrnW3UleRGp0bGm3NLlu2IZI6jNYpVtP09w7ALY8S6teSNVJLlVZfLcV/W/ZloOlwXb0cOs6i+mVpppYNXo3NLoWJBNUqxcn8KGUOHsSSeBG77rEN5PPcD897Hbfbtvtv6b/L+Gec6e+j6TepU9TMR0iCz1FBpluGtPLPWrVBUglsWohbLyCQeLK2zMwA7ZbV9nvT1Kc6fcs021SrSSWSOfWUoUrM1y9ZMfPUVSSNfdtPWlIYo+LSNbbv8AVlSByf2YaelvW9HqyIHjs6pp8EisN1aOW3Cjqw9QVJH5566toSWL2s2a1farXuWJpPCRUirwzXWhhAUbBI+bxoAB6gZ1H2fx6ZpHVGixaW2la7V1HVNLWG5Zinku0HS3HDZRK/iRiB/G5PHK6MWQQsNjyGVLVLFbWJdentRUaEun6fJNTjoQQUIrFhNVqQlZYl/95cxTzHt8XwA/qnAOa5nbOzQaHo40GPWmWiwTp6xprQePF7y/UkupTQwyNU5+JzSjIJ/F24cYk779stU1OZ+mK2n9MaHBqMF/Tq/0nqsctS1PHefhPeWzVZBNRnikTwkd3EaxbsgJcsAPzdjPbggkHzBIP/oZ4wBjGMAYxjAGMYwBjGMAYxjAGMYwCz+zXQYtS1BKsq2H5Q2JUhqtXjmnaCF52jWa0fDh+rjkbkwb7GwBLDNrrXp6lHUqappcllqNqWepJDdEXvVS5WSGV4nkhASeJ4rEUiSKq+bqQCu5k/8ABynWPqfSi/Di800P1m3hlrFSzAquCRuhaQAjcdjk10Z180ovtJ7hpg03RtRn0iGnBDTjTVbElGu88Qbk0154A6hmLMFT4eO2AcjyQoaFdsQTWoKdqatW72LEVeWSCDty+ulRSsXbv8RGdq6OuaZLV0y9esaDNXKanP1MuoLWm1qzZksTeFBUidPeOb146gikrsFV3lZiuzb6XRVqnQ0HQdSn1K5pzQa7rk6R0YHnnuJFBoYaurGRYI9xuhMwKlZm7MAVIHHTptgVxbMEoqtL4C2DGwgaYLzMSy7cWkC9yoO4GWTROgLVmrDda3pNSGx4jQi9qtOpNIkMrQvIkEr+I0fiJIu4XuUbbfbL51b7XNMlq2U0+ldgNrTRpkelTNUOiaXE5Z556kSIZLNkyPJIrt4ZV5eR58VAoXtF6rh1JNFjghaBdL0Sppj8gg8WeGWxNPOvD9Vnn9e5274B0Pr/AKOg9y6X31fRLEsGkGOKkk2oSNqLHW9SdYq8kFUKEdnMPJnTZkk7gANlRr+yjVbMoURUqU9q5qFWpp9i6kM8k1CUx2IK6zMTIqS7xBmb4mjYbnYnK9e6tnl+iPgjU6NXSvB9s+KEv2L4aUE+fOwV2Gw2UZZbXtm1mRJwPcopZZdSkjtx0oPfacerWZrV6vStuC9eF5LE3keQEjAMN8A2qXszrHTN57U8WtTaLP1FVqCOI1Dplcs/hzShi4ty1op512HELGqt3f4Zen7BbD6fJO1x1vpp8d9KppOtWeSxW99raZWvyyr75qj1SZjHDG6oFILb9s5vf6w1CWWGbxzHJBpkekI0IER9wjqmn4DcftBoWZWJ7tyPzyNvaxbnSGKe1YmjrLwrRyzyyJXTt8MCOxES9h2XbywC6aACnR+tuD3l13QIW+9Fqa1MP+8qn8s53m4moTiu9USyCtJLHO8AY+E80SSRxysnkXVJZQD6CRvnmngDGMYAxjGAMYxgDGMYBYujdN02y0q6hqbaZwVGhf3Ga6kpLEOr+A4aIgcSDswPcds6J7RH6Uue4ka/elXT9HpabDHU0J/jkqwuZJGe5ciCI9mWVtgCQG9TnGcYB1vqf2qxSVLmm0Y7MFJYtF+hkDJAdOs0IuF+yBEdxNZaa3ydW5P4gLHsAM0PbCa+sUtSSCzNHU0OrpHF7Xg2lkj01ac16rYCSCvaEhkdH4sRy7+ZzkeMA7jQ6+1C5FrNurpkuq0BJps15NV1O9e1CJ4lsQ1p5LGnPVkm08M5UxMrRIzxbgFgc0P8I/q659O61p4ZPBi6in1NG4bzLbFeCsPrGP6NUhQBCOxBzmPTmvXdNsJaoWrFOwgIWatK8MgVvtLyQglT6g9jmndtSTySTTSPLLK7SSSyMXkkkclnd3Y7s5JJJPnvgHQdY9tXUNrxVltV/CsCQ2aw07TxVszTENLcsVjAUlvFgD7wR4g2HEgdspvUGv2Ly01n4bUKUdCDggTavFJNKgfb7b8p5Pi/D5ZEYwBjGMAYxjAGMYwBjGMAYyaXp6c6Y2q7xist6PTwCx8V53ryWSUXbYxqkY5HfsZU+eQuAS9vqLUJq0VOW9clqQEGGrJZmevEVBCmKBnKRkAnyHbc58dS1q5ZVEsWrM6xjaNZp5ZVQHbcIJGIUdh5fIZHYwD3yO225233237b+W+3zzzvmMYB9q8zoyujMjowZHVirKyncMrDupB77jPmTv8AnnnGAeswDmMYAxjGAMYxgDGMYAxjGAMYxgDGMYAxjGAZBzGbVSjNMJTFG8ghiaeUqN/DiVlVpG+SAug3/pDNbbAMZLXNesTUaunOU92pz3LMACAOJLq1ln5P5su1SHYemx+eROMAYxjAGMYwBjGMAYxjAGMYwBjGMAYxjAM5dvZjp0M8OvGWKKWSPRZDTWRVZhbkv0I1eHl5SLC1huXoqucpOdS9hmpinT6qnKlj/J6SFSBvwezqFGsj/kZclK9CHNQVtN+CdX6069ilN0ve8xWkYNuV4bOSAgkJAQkkcGVvwYHyORE8LISrqykeYYEbfjvn6OeBEtVYO3+LXdUpf9h6SpVpiPu5RnfKRrOgwe6wTyib3U6HQuyFlafhalstVcpMx5Rqyx8wndeTqvYEEXeHItqfy2J4Li+H4uSxpSg2k021Jat7uo1Vb6nKqdSSZgkSM7HyVQSf4ZJ/Q0aD/GLUUTeqJvM4+76v4QfxbJbrOrPQ2rxqIa7pE5KNu0niwxzqJ3HcScJVPDyG/YHzNQ3yLj0O/JHFgfK1zPvbUWu6qm0+9kyNMqN2S8vL5TQyRg/2l5gfntniTp20O6xiVR+tCySjb5nwydvzyJ3z3FMynkrMpHkQSCPzxae69v4ynxsEvzQr/K2vfm5vqhLEyEqylSPMEEbfjvnzyYj16QjhYVLSeQEwJZR/RlUh1H3b7fdnt4aEuzJM9YnzSRTKoP3SR99v7O+OVPZ++hP3eE9cUl5SqL926+foQmYGTT6A7DlXeOyANyIieY/GJwH2+8AjIhlIOxGxHbKuNGOXBPH+ZVez6Pyex88YxkGAxjGAMYzIwDsdDpN7fSOkxrc0yqZtZ1m6fftQr0y0awabSTgs36Qh4Jt9vIFf2sgV9kGpuvKvZ0ayP8hremN/pzrnn2kScNE6Sr7/APBeoWyP6VrWry7/AI8ayj+yMoUU7Kd1YqR5EEgj8xnLkx5nbhNLzjf6o2xPFf40/Rr9mXh/ZJrY8oaTbfsazoz/ALwtzcZT9X06WpPJWnCrNC5SRUkilUMPMCSFmRx96kjNuLW2ZeNmNbC/tNssq/hMBy3/AK3IfdizpiOrS1XMiqOTxsAJYh6kj9dR+0PzAxilli/7Vxfkmvm5P6I6ZcJGa5sErrVp6SXps/Rshsxkpr+j2KMqw2Y/Ddoa9hPiV1aG1CliCRXQlWVo5FPb57emRmdSaaTT0ZwGMYxgDGMYAxjGAMYxgDGMYAxjGAMYxgDGMzgDMjAOfarXeRgkalmPkFBJP4AYbLRi5NJK2y6+yVFKa8z7+HHoFoyEbbhXt0IQQD9pucidtxlg/wAH86FNrkVbUNKe9BNDZVBLY7JKkLziRo0VQ/wRSLtv2Lg+mRHs7rNBpPV1lx3TS6mnbbj9Ne1iiwHbsT4dOc/2c1/YE+3Uukj0kteCf6s8UkLfwkOcX2hDm4fI02vwuqbXRu7RvDK4Jw5Vq9W0m/Lw9CF1OlWtSzSaeGiVnkeOlIeUkcZYssccvlPxUgd9mO3kcr5BB2PbbPoHaN91JDI3YjsQQexBHr2yT1tBKiW0H6T4ZgB2SZR3P3Bxsw+8t8s6I/hpXaNpRhnxuUVUo6tLZrul4dUQmMYzU4BjGMAYxjAGMYwBjGMAzjLTB0hI+hTa4JV8OHU4dNMHBuZaarLZ8bxN+IUeGF4+Z5b9tu9W2ysckZXTunT8H2JaAxm/Jpc6x+MycU7bFiF3B8iqnuw/AZphDk8y6Gk8M4NKSatWrW67nnfOw/4PekrYraz4vaKxJoOmnfy3sa1XvSefnxraZZcj5Kc5XeoNCqF2TkwB8MHdwpHJS2w2G4I7b79/LO0+ytWr9ORuo+snudSXht3LHSenkqVB29RPrExy+KpSRz8bCeOEk1Uq28WfWXVozCl6dJUE1DqbVGZELGOXW7b6bDv6K3hQllJ+7NDqlFi0/Wa8ZcRwaL00gjeRpBG1qardkReXlsWVf7GY6ontJo12nMoVo36f0WJANt+EE2ozk+pbmK+/9Y/PMdfzLt1lt9mO7otBfu91aeID8hTP7s7sjpOPv7P9keZkrC/gw/qXM+/44NLyXM14tX2r7dQUYpRrIdVJaj0rHESAeEsunRhWX5MWRV3+RziMi7Ej787Z7Qy8FbXiPhZZukaqn1D19Lmdvz5Rr+7Od+1bSVpatchjAWMSngBvttsOXn/TDZxZY1K+/wBbZ2/Z2VT4ZR1bi1r/AIXCGno/qVPGMZQ6RjGMA+0crKQykgg7gg9wfmNsl/pwSDa1DHYP7bckl7fOSMgufvYHIPGSpNG+LiJ49E9Hunqn6PQm1sae3Zq88X3pMj/waMf35620wetlvyiX/Wcg8sPRfRmp6zJJFplOa5JCgklSEKWRC3AMQzDty7YyZowTnOkl1dJfsari5PeMW/JL5Kl8iDm48jx347/Dv57b9t/v2z5HOx+072HavQSpPV0q60A0ilZvuB4wgue7l9QV9jugR1YkDso9c5dPpEkcZkkKJ2BCM6+IQdiNkBJ8jv32zlwcZhzx5sck14NfoZx4fJO2oulvpoiNxm1U0+WXbghIO+zHZV+HYn4j27Aj19RkjqOmQ1l4TPIZygbgqJwUsvJd5OZ3GxHcDNnNJ11L4+Byyg8lVFdXoreyT6tlo9oG0nTvSkzAGVYdZpc/UwVtS8aFT/Va5MPwIznWdG9pw930bpWi36Uadc1OT5Kuq35Grp9x8CrE/wD0oznOXOQ9ZsUrTxOro3FlO4I+ea5xkNWXhNxaknTWzR0z2gEapoek6xGgWSjvoeoIo2CmINZ06YD9h4JJY/uNUD5ZzQn/AF50j2HTrae/oEpHha3WMdfl2EeqVQ8+nSA+hZ/Eh/8A3P3ZzqeMozIwIZSVYHzBB2IP4EZycN+CUsX9Oq8pX9Ha8kjbM+dLJ1bd+ff1PjjGM7DmGMYwBjGMAYxjAGMYwBjGMAYxjAPWTsOkx+GDvJNLJHzRIk2Vd9+7Od9wCCCAPQ98ghk5BqkXu8UUniEJ4m6IwUOCQyAsd9gGMh8j55nk5tKPR+z/AINy+LX5dLve0vpb2fke6GgboZJnCL4JmCrszlA/AbAkAbnv5+Wba3aFeMrFu7ywsjspcFSUB+LlsN/EHpuOI9d8r9220jeoVRxjTkzBE3JCqSfs9zmrlfhuX5n6HQvtHHw+mCEbquaWr8Wrqr8joi/UdGuR8L6p1GiH5tDpGnFyP6vi6op/FM+HsDITXILBA2p1tSvkn0NLTbdhD+Toh/LPv1qOPS/S6A/pJ+oLRUfJrdOsp+//AN2cflny9iQ2s6m2x3Xp3qEj8foqwv8ArynGK8Mo91XvoeQnqUFvPJTQJ15NBIdoZwFJPkjDvHJ+R8/uLZF8fuOZAPyP3ds3cbVGvD5nhmprWunddU/BrQ+lyBopHjcbMjFSPkR2OfLfyyyChNqUPiV4ZJ7FdALKwxvK/gjZY52VATxHZSf6nzzS0npfU7g5VNPvWh5b16dicb/LeKMjfIhNS06rdFuKxLHP8LuL1j5P9Vs/EhsZe63se6pkAYdP6uFP60lGaJfzaUAD8834PYf1I3MtTrwiNGklNjVNKh8KNNuTyq9rlGg3G5IAG4y8pKKtukcxzTGdEf2XBBvP1D0xXPqv0v72w+Y20+CXv92YHQujKdper9H3/wAhS12dfyb3Bd8A56cZ0pegtFaOSSLqmpKI1LEDStXQE/qrzmhVQx9ATkFBoWleG7yayiuAxWJaVtmfbfZQ3DiGO23cgd8rzq6OvHwWScVLRJ7W0r8rasqWSPT2oipagstWr2xDIshrW0aStNx/UmRWUvGfUbjNBvPt5em+eRlmk1T2Zy7H6ope07w+i7GqVtC6frFeoYqiVF0/xKe/uIl94aF5PitDfiH37KNts/NfUWrPfuT3JI4IXsSmV460SwQIzHuIol7Iu/fb7zmkJ34eFzbwy3Mx8jwLgbBuG+3Lbtv558d84OD+zsfDOco7ybd63Wmmr8C7m3Rbb2nxySBmaU8467u23wRKyJzd37kjz9Bt+WfIa1XrgLHD3HiAhZCAD4gdGV9iSNtgR6hfPvkHZ1KeRFjeRiiABU8gAPLsPMj5nNPOhYbVSPZyfa/JNy4eKTlu2k30bSu+pu6zeNmZ5iAvLb4V8hsAO3y8s65R1tKPSFCRGPvkljXqsCL3KxW20sTTH1HasVHbvu2cXGdh6z6x1XQK2haXpeoWqAh0SrbuCtK0LSW9WeXU2MpXuxWGesg38gn3nOnG+TbpseTLM55Hkyattu/HueqGvNqi6V7yYzat9Ve8WYY0ZOMfhabXjcp34Rn6wDv5hsieoNSgMWvwTTKk97qOvKyEPyEEDan4s7bD9GGsqPnvv2yOHtm6r/8AxDq//bZv9uel9s3VX/L2pt/Wss/+lvl3lbPMXBxvfTp4U7X6Ez1x1HUvrrMNeUO1zqGnJUUK4MlSCG7XSUbjsp5wdj3+Mds8+2HSfH+kdQVwxh6g1GmE+H9AOEgcHfchZJCPkPEGRg9tnVX/AC1cP4mE/wB8eJfbJ1BLwWzeNmNJY5jHNWpsGeJgykt4HLfsNzv322O47ZTJK1truvn+5vwXDrDkS5moNNPq60rp05UznwX/ANbjPO2dvve07UpKc1qvNUdUNLtLpOjPIjv4wtrIppdlZ/CII7beW3cZ8Nb6+tK2ptJR0GyKduKKJbHT2kP9XM04ILJArFhwTY/j88wWRfz0LZJ/DlyyTX0e1NednGAD8sxxPyP7s7RL1mTqctH6F6YCL43F/wCT9Ll9XA8y7gEA9wAcjl9oG9F7R0HpgstqOAL9CQKvF4pJCfgkB33QZbmX0KrPF1XWn77HKeP3H92CD8j+7OzWurlG/DQemSRp9a4F+hVYvJO0CGMbT77bykjbv2Gamt9fVIYgh0Ppz3h4QJI49KRfAlJYH60ysCwHH4QDsSdzkfEXQ6uHx/G12it29l4eL8jkfE/fm1p16au5eGWWFirIXikeNirDZlLIQeJ9RkhLr7FiVr1lU/qCvGVH4cgT/HIdm775P5lUkWzQxxrklffSjpftx63h1S3SNCxYatBo+nUpfEMsfOavEUm3Rm+Mbn7R8++Qmo1g6QuEh2lgiLzSScWBUcW2Bfud023AOU7PRcnzJ+77vuHy8858XCRxQjCG0dPF/Q6uE41YYyUlfNXVKmvNPy6eZY9R19I3K11RlWSQhyo4skoTdGjIH2Si7Ht5ZDW7MtqYFzzkfjGAAF+SIoAGwHkM0ss/sooi1r2i1iN1n1XT4nHnuj24Q/b1+Hlm8McY7FOK+0c/EWpP8Ld8q2VbaeC7k1/hBuo1+3UjO8Wlx09HjHyGlU4KTj/rYZT+ec/4n5H92dQ6q9pED6lqE30FocpmvW5mkmrTyvIZLErl3Mk5+I77nbYd/LN+p7VNIZAsvTOjV2A2MkOm1rIP3mKwyn9zjOpY4vaS+f7HlvLJf3X8v3OPkZjO1LrvT909tH6fkc7/AFcg1jQpW+XGWC/LVDfcQgyL1vUtBqMIrnR1iuzDdWj1+4A6ftxPJBIkqf0lJGRLE0r6d1qi0csZaLfs9H7HNtE1CSpZgtQtxlrTRTxN+zJE6yIf85Rl29u2kJDqst2su1PVEh1Ott5IuoQpaaL7irSuNj6Lgah0a53bSuoYt/SLW9PcD8PF0vc/mck9Y6o6bsVlhK9ROYai06qWp9KlihiikklhVmhrRu3Fppdm89n27gAZxZMcviLJHommu6dfNV82d3DOErhN0ns+z6N+HT5nKsZ1IVelY4lmj03Xr4AUyEavQgjDcfiVo49OaSMb79yfzzTj6o6YXfbpaw/y8XqG0f3iGqmaxmpbFM3DzxOpryfRrun1RznbPXH7jnQX670uLtU6S0VR+1csaxef97XkT/u5aourNPprE17prp97c0ayx0KtG2ZEjkHKJ7Us911iZl2YRqjNxKk8dxm0Y35Lq9jmlLlpU23sluziYGAv3Z1PVeqnZ+f0NoGlQ+YX6NikkI+SrJu7fuA+/NCT2imFCscFGViNg30Xp8Cr96hIyzfmRi8X9Tf+VWvdtHSuEz1c1GC/xOn7JN+tUc62xlvX2i6nufjrFT5p7hSCbfLiIR2yK6k1730qz1akMi78pa8RhaQbAASIHKdtvRQe+S1Ho/f+M59eu/ht76fQg8YxmZIxjGAMYxgDGMYAzIzGel88A7R1Jr2nUdE6Tis6JW1SU6PZnSS3d1CKKMS63qgZBXpSxBm3jBLFjvuBt2yE0n2rw1Gdq3TPT0RlgnqyEJqrl69mMxTRMZNQO4ZGKk+fc9xmp7WDtp3SK+o6dYkeoDa5rBU/mM55kOKkqewOh/7pNQeXSnTIP3wam38G1DbMr7T0XunTXSyH0P0XLLt/ZntMp/MZzrGSDr3Sf+EBrumTNJVTSoonXga8GkUKsW3IEHlUijkZhsduTsO57ZEdSdbdQXuVhda1WzC25aL36yPA37lWhjcKqjfswXiQB5eQ53n1r2HjbkjFWHkQSCP3ZguHgpvJBJSlVut67+R1Yc0FFwyK0+q0afh3XgfS1ZnkJ8SSVyT8XN3Yk+u/I9zl19i4LT6rDx5eN09ri9gNx4VCSyp8v2oBlVXqC1+s6v8A85HHIf3upOWn2f8AtX1PQ3syUVpBrUBrymWlC/wnfYqVAII3Pbup9QdhmfFLLLG1CKb6W6X0LSx8MlcZS8nFL58zKIFJ7Dfv6Df1yVr6OygSWm8CPzAbvK4/ycXmfxOy/fnk9QWR9lkj++KGKM/vjUH+ORs0zOSzMWJ7kk77n883/G/D5l1Lhseq5pPs1S9dW38je1TUfEAjjHh149/DjB9T+u5/WkPqfyGwyNwcb5dJJaHNmzSyycpP/bwS6JHnGMZJiMYxgDGMYB6X/Uf7jnQv8Int1FbXyEdfSolHlssWkUI1Xb02C5QacDyyJFGpZ5GWNFHmzuQqgfeSQPzy9/4RFhJOp9Z4EMsNv3UkdwWpwxVH2+7nA2Ac+xjGAMYxgG3RtyQuHjYofL7iD5qwPYqfke2TzdSxSx2UnrcmtNC8ssUxjJeEtxbiwZfJ28th5ZWMzvlHBN2bRzyUeXRq06aTpqtr22Lh9PU2tteKTxyuJQQGSRQZIGg7DZT2Db+fpmmtykKxreJYZDOtg/VRqxZImjC8uZAHxk77HK1vjK/CXdl1mhp/Zw0SW3bbYsWp9USOdq6CsPBhgLKxaVooEREVpD5D4AdlA75Xj37+eYwcuoqOxnPLKSSey2WyXoecYxljIYxjAGdE/wAHFAeqNHZvKK01g/d7tXnsb/l4e/5ZzvOh/wCDwduoax9RT1kj8RouoEHAOfyMSSSdye5J9Se5P8c8Z6b/AFD+4Z5wD0Dk/ofU09ZDXkCWqbHeSnY3aE/NoiDygl+TxkH8fLK+cZeM3F2mVlBSVNFm1rRYJK5v6czvWVlWzXkIaxRdzsniMoAmrseyzADv8LAHbetZK9Naw9KwJlVXUq0c0L7+HYgkHGWCQDzRl/cQCO4GSOu9Ogxm7p5azQPdu4aekTv9VcjXuhHkJduDjYgg7qNJRU1zR36r9UZxk4Pllt0b+jPv017R9c02Fa9PUrMNdAwWvyWSuAzF2HgSqyEFiT3HmclP92LXD9uTT5T+1LomjSMfxZqe5zn2fWrXeV1SNWeR2CoiAszMx2VVUdyxJ8s4JcFgnK5Y4tvrSt/I6lmnFaSdeZ13pL2j2rPvE16jostSpA8tiQ6NQikPL4IYIngjQLLJKVUHY7Dke/E5HSe2e2xJbStAZm+27aWpdz6ln8Tdifnla6vk90r19KjZSYd575jYMr3pNx4TOpIfwY+MfY7BjLt55U80y8Dw6SxqK038/wDYph4rM5PJzvsten++5ZesurDqQiBoaZS8IuSdPqCs0vPj+mIdjIBx7fLc/PKzjGWhBQVR2Dk27ZjGMZYgYxjAGMYwBjGMAYxjAGMYwDat3ZphEs00sogiEEAkkdxDCHeQQxBifDiDySNxGw3dj6nNXGMAYxjAGMYwBjGMAYxjAGMYwBjGMAYxjAGMYwD71Z3idJYneOSNleOSNijo6EMjo6ndWDAEEdwQMzbsSTSPLK7yyyO0kkkjM8kkjks7u7ElnLEkk9ySc18YAxjGAMYxgDGMYAxjGAMYxgDGMYAxjGAM2tOvTVpBNXmlglCuolhkeKQLKjRSKHQghWR3Uj1DEHsc1cYAxjGAMYxgGc29O1Ceu/OvNLA+xXnDI8TcW+0vJCDxPyzUxkptaoNJ7n0llZ2LOzMx7ksSxJ+ZJ88+2n3pq7+JBLLDJsV5xSNG+zDZhyQg7Edts1RmMJtOxSqjO+YxjIAxjGAMYxgDGMYAxjGAMYxgDGMYAxjGAMYxgDGMYAxjGAMYxgDGMYAxjGAMYxgDGMYAxjGAMYxgDGMYAxjGAMYxgDGMYAxjGAMYxgDGMYAxjGAMYxgDGMYAxjGAMYxgDGMYAxjGAMYxgDGMYAxjGAMYxgDGMYAxjGAMYxgDGMYAxjGAMYxgDGMYAxjGAMYxgDGMYAxjGAMYxgDGMYAxjGAMYxgDGMYAxjGAMYxgDGMYAxjGAMYxgDGMYAxjGAMYxgDGMYAxjGAMYxgDGMYAxjGAMYxgH//Z\n"
-          },
-          "metadata": {},
-          "execution_count": 7
-        }
-      ],
-      "source": [
-        "#@title Video: PID Controller Explained\n",
-        "#@markdown Understanding proportional-integral-derivative control.\n",
-        "YouTubeVideo('UR0hOmjaHp0', width=600, height=400)"
-      ],
-      "id": "pid_explained"
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "AC_mHX3FdkzX"
-      },
-      "source": [
-        "## Process control theory\n",
-        "Process control keeps process variables such as pressure, flow or level close to desired setpoints. Feedback controllers (P, PI and PID) compare a measured value with the setpoint and manipulate an actuator to reduce the error.\n"
-      ],
-      "id": "AC_mHX3FdkzX"
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "re3RX1JVdkzZ"
-      },
-      "source": [
-        "## Control options in NeqSim\n",
-        "NeqSim supports dynamic simulation with measurement devices (transmitters) and controller devices. Controllers can be attached to valves or other equipment and tuned by specifying proportional (K$_p$), integral (T$_i$) and derivative (T$_d$) parameters.\n"
-      ],
-      "id": "re3RX1JVdkzZ"
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "oPimuGy_dkza"
-      },
-      "source": [
-        "## Example: controlling separator level and pressure\n",
-        "The example below shows a simple separator with control of both liquid level and gas outlet pressure. A level transmitter and a pressure transmitter provide measurements which are used by PID controllers connected to outlet valves.\n"
-      ],
-      "id": "oPimuGy_dkza"
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "55jIS1xZdkzb",
-        "outputId": "6550ef3e-d15f-4a8d-e4d7-dfc69bcba317",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 449
-        }
-      },
-      "execution_count": 28,
-      "outputs": [
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "<Figure size 640x480 with 1 Axes>"
-            ],
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAhYAAAGwCAYAAAD16iy9AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAARVhJREFUeJzt3XlcVXX+x/H3BWSRVURBFFDLrVxyScNKzTTLMm1zMkaxRafS1GlqzMq0mWm0+jWNLZrVpE2jWc6Ureo4pqXmguaapmYkmiIusbkgcL+/P45cuSwKerhX8PV8PI6Xe9bP+QrcN+d8zzkOY4wRAACADXy8XQAAAKg5CBYAAMA2BAsAAGAbggUAALANwQIAANiGYAEAAGxDsAAAALbx8/QGnU6n9u3bp9DQUDkcDk9vHgAAnANjjHJychQbGysfn/KPS3g8WOzbt09xcXGe3iwAALDBnj171KhRo3KnezxYhIaGSrIKCwsL8/TmAQDAOcjOzlZcXJzrc7w8Hg8WRac/wsLCCBYAAFQzZ+vGQOdNAABgG4IFAACwDcECAADYxuN9LACgsgoLC5Wfn+/tMoAarVatWvL19T3v9RAsAFywjDFKT09XZmamt0sBLgoRERGKiYk5r/tMESwAXLCKQkX9+vVVu3ZtbqoHVBFjjI4dO6aMjAxJUoMGDc55XQQLABekwsJCV6ioW7eut8sBarygoCBJUkZGhurXr3/Op0XovAngglTUp6J27dpergS4eBT9vJ1PnyaCBYALGqc/AM+x4+eNYAEAAGxTqWAxceJEORwOt6Fly5ZVVRsAAKhmKn3E4vLLL9f+/ftdw/Lly6uiLgBADTVx4kRdccUVHt3mzJkzFRER4dFtXqwqHSz8/PwUExPjGqKioqqirnPndEp5OVL2filrr5RzQDp2xBqXf0IqLJCM8XaVAGqogwcP6qGHHlJ8fLwCAgIUExOjPn36aMWKFd4urcKGDh2qAQMGeLsMVFOVvtx0586dio2NVWBgoBITEzVp0iTFx8eXO39eXp7y8vJc77Ozs8+t0rN5vYuUvc8KEKpAcPCpJfnWknz8rMG3ljXOx7fY+FPvXdP9Tr93Db6Sw9f9vdu44u/LePXxlRw+xcb7WEPx8W7vyxscp1/lcB8nx5m/lsNaf/3LJD//qvn/AS4Sd9xxh06ePKl3331XTZs21YEDB7R48WIdPnzY26UpPz9ftWrV8tj2Tp48KX9/fqdcbCoVLLp06aKZM2eqRYsW2r9/v5599llde+212rJlS7nPZ580aZKeffZZW4o9o7xcKa9YaCn6UHaWc8mMM7/8aReryKZS/9elhK7ergQokzFGx/MLPb7doFq+Feotn5mZqWXLlmnp0qXq3r27JCkhIUGdO3cuNd9jjz2mTz75RHl5eerUqZNefvlltWvXTpJ1qmDevHl66KGH9Je//EWHDx/WLbfcorfeekvh4eGSpJSUFD355JNav3698vPzdcUVV+jll19Whw4dXNtxOByaOnWq5s+fr8WLF+vxxx/X+PHjNXz4cH311VdKT09XfHy8Hn74YY0ePdq17Xfffde1vCQtWbJEPXr00ObNmzV69GitXLlStWvX1h133KG//e1vCgkJkWQd6cjMzNSVV16p119/XQEBAUpNTa1QG7/99tt66aWXlJqaqsaNG2vUqFF6+OGHJUldu3bVtddeq+eff941/8GDBxUbG6vFixerW7duysvL01NPPaX3339fmZmZat26tZ5//nn16NGjQtuHfSoVLG666SbX123btlWXLl2UkJCgDz/8UPfff3+Zy4wbN06PPvqo6312drbi4uLOsdwz+O2/JV9/yT9ECgiVagVZf40bIzkLrRBRmC85C6yh8FSwcBYW+7rAOlXiLCjx/tR8zoLT63K9Lzg93hSfp8R04yw2T9Grs9j7kl87iy3jPD3dGPdpMu7zG3PqVI8p9t7p/r7U15JOZEpHfpJm9JW6/E66/hnJP9j+/yfgPBzPL9Rlzyz0+Ha3/qmPavuf/ddlSEiIQkJCNG/ePF111VUKCAgoc7677rpLQUFBmj9/vsLDwzV9+nRdf/312rFjhyIjIyVJP/74oz788EN99tlnys7O1v3336+HH35Ys2bNkiTl5OQoOTlZr776qowxeumll9S3b1/t3LnT7Q+9iRMnavLkyfr73/8uPz8/OZ1ONWrUSHPnzlXdunX17bffavjw4WrQoIEGDhyoxx57TNu2bVN2drZmzJghSYqMjNTRo0fVp08fJSYmKiUlRRkZGXrggQc0cuRIzZw507W9xYsXKywsTIsWLapw+86aNUvPPPOMXnvtNbVv317r16/XsGHDFBwcrOTkZCUlJemFF17Q5MmTXWHngw8+UGxsrK699lpJ0siRI7V161bNmTNHsbGx+vjjj3XjjTdq8+bNatasWYVrwfk7rztvRkREqHnz5vrxxx/LnScgIKDcHy5b1W9V9niHQ/L1s4ZaQVVfR3V1Ikta+JS0/j1p9RvSjgXSgDekhERvVwZUG35+fpo5c6aGDRumN954Qx06dFD37t119913q23btpKk5cuXa82aNcrIyHD9bvy///s/zZs3T//+9781fPhwSdKJEyf0z3/+Uw0bNpQkvfrqq7r55pv10ksvKSYmRj179nTb9ptvvqmIiAh9/fXXuuWWW1zj77nnHt17771u8xY/itykSROtXLlSH374oQYOHKiQkBAFBQUpLy9PMTExrvneffddV03BwdYfHa+99pr69eun559/XtHR0ZKk4OBgvf3225U6BTJhwgS99NJLuv322101bd26VdOnT1dycrIGDhyoMWPGaPny5a4gMXv2bA0aNEgOh0NpaWmaMWOG0tLSFBsbK0l67LHHtGDBAs2YMUN//etfK1wLzt95BYvc3Fzt2rVLgwcPtqseeEtguNT/NenyAdKno6Vff5Zm9pWufUzqPtYKZoCXBdXy1dY/9fHKdivqjjvu0M0336xly5Zp1apVmj9/vl544QW9/fbbGjp0qDZu3Kjc3NxStyk/fvy4du3a5XofHx/vChWSlJiYKKfTqe3btysmJkYHDhzQ008/raVLlyojI0OFhYU6duyY0tLS3NbbqVOnUjW+/vrreuedd5SWlqbjx4/r5MmTZ71KY9u2bWrXrp0rVEjS1Vdf7aqpKFi0adOmUqHi6NGj2rVrl+6//34NGzbMNb6goMB12qdevXq64YYbNGvWLF177bVKTU3VypUrNX36dEnS5s2bVVhYqObNm7utOy8vj9vBe0GlPi0ee+wx9evXTwkJCdq3b58mTJggX19fDRo0qKrqg6dd2kt6eKU0f6y0cbb0zQvST0uk29+0+mAAXuRwOCp0SsLbAgMD1bt3b/Xu3Vvjx4/XAw88oAkTJmjo0KHKzc1VgwYNtHTp0lLLVeZyyOTkZB0+fFhTpkxRQkKCAgIClJiYqJMnT7rNVzwISNKcOXP02GOP6aWXXlJiYqJCQ0P14osvavXq1eeyq6WU3N7Z5ObmSpLeeustdenSxW1a8WdVJCUladSoUXr11Vc1e/ZstWnTRm3atHGtw9fXV+vWrSv1fIui/h/wnEr9hO7du1eDBg3S4cOHVa9ePV1zzTVatWqV6tWrV1X1wRsCw6TbpknNekmf/V7amyK9ca3Ub4rU5k5vVwdUO5dddpnmzZsnSerQoYPS09Pl5+enxo0bl7tMWlqa9u3b5zq0v2rVKvn4+KhFixaSpBUrVmjq1Knq27evJGnPnj06dOjQWWtZsWKFunbt6uoYKcntSIkk+fv7q7DQvZNsq1atNHPmTB09etQVHlasWOFW07mIjo5WbGysfvrpJyUlJZU7X//+/TV8+HAtWLBAs2fP1pAhQ1zT2rdvr8LCQmVkZLhOlcB7KnUfizlz5mjfvn3Ky8vT3r17NWfOHF1yySVVVRu8rfUd0kMrpPiu0slc6T/3S5//3rofCIBSDh8+rJ49e+pf//qXNm3apNTUVM2dO1cvvPCC+vfvL0nq1auXEhMTNWDAAP33v//Vzz//rG+//VZPPfWU1q5d61pXYGCgkpOTtXHjRi1btkyjRo3SwIEDXf0emjVrpvfee0/btm3T6tWrlZSU5Ho65Zk0a9ZMa9eu1cKFC7Vjxw6NHz9eKSkpbvM0btxYmzZt0vbt23Xo0CHl5+crKSnJVdOWLVu0ZMkSPfLIIxo8eLDrNMi5evbZZzVp0iS98sor2rFjhzZv3qwZM2bob3/7m2ue4OBgDRgwQOPHj9e2bdvcjpQ3b95cSUlJGjJkiD766COlpqZqzZo1mjRpkr744ovzqg2Vx7NCcGYRcVLyZ1K3x633a9+R/tFbOrzrzMsBF6GQkBB16dJFL7/8srp166bWrVtr/PjxGjZsmF577TVJ1umcL7/8Ut26ddO9996r5s2b6+6779bu3bvdPqAvvfRS3X777erbt69uuOEGtW3bVlOnTnVN/8c//qFff/1VHTp00ODBgzVq1CjVr1//rDX+7ne/0+23367f/OY36tKliw4fPux29EKShg0bphYtWqhTp06qV6+eVqxYodq1a2vhwoU6cuSIrrzySt155526/vrrXft1Ph544AG9/fbbmjFjhtq0aaPu3btr5syZatKkidt8SUlJ2rhxo6699tpS90+aMWOGhgwZoj/84Q9q0aKFBgwYoJSUlDPeZwlVw2GMZ29DmZ2drfDwcGVlZSksLMyTm8b52vk/6aNh0vEjUkCYdNsbUsubvV0VaqgTJ04oNTVVTZo0UWBgoLfL8aii+1hs2LDB26XgInOmn7uKfn5zxAIV16yX9OByKe4q62Zkc+6RvvrLqftpAABAsEBlhTeUhn4udXnQev/Ni9Ksu6znsQAALnoEC1Seby3ppuel296U/IKkXYulN3tIB773dmVAjTBx4kROg6DaIljg3LX7jfTAIqlOYylzt/R2b2nrJ96uCgDgRQQLnJ+YNtKwJVLTHlL+UenDIdJXz1nPQQEAXHQIFjh/tSOlpP9IV42w3n/zgvTBb089wh4AcDEhWMAevn7SjX+1HlzmGyBt/0L6xw3WM0cAABcNggXsdcUg6d4vpZBoKWOr9OZ10s/LvV0VAMBDCBawX6NOVr+LBu2sm2n9s7+07l1vVwUAF5Tx48dr+PDhrvc9evTQmDFjqmRbb7zxhvr161cl6y6JYIGqEd5QuneBdPntkrNA+myUtOBJbqaFGu/gwYN66KGHFB8fr4CAAMXExKhPnz5asWKFt0ursKFDh2rAgAHeLqNGS09P15QpU/TUU095ZHv33XefvvvuOy1btqzKt0WwQNXxry3d+Y7U40nr/arXpffvlk5ke7cuoArdcccdWr9+vd59913t2LFDn376qXr06KHDhw97uzTl5+d7dHslH+F+oazLLudT09tvv62uXbsqISHBxopKM8aooKBA/v7+uueee/TKK69U6fYkggWqmsMh9Rgr3TXTupnWzv9aDzGjUydqoMzMTC1btkzPP/+8rrvuOiUkJKhz584aN26cbr31Vrf5HnjgAdWrV09hYWHq2bOnNm7c6Jo+ceJEXXHFFZo+fbri4uJUu3ZtDRw4UFlZWa55UlJS1Lt3b0VFRSk8PFzdu3fXd99951aPw+HQtGnTdOuttyo4OFjPPfecCgsLdf/996tJkyYKCgpSixYtNGXKFLdtv/vuu/rkk0/kcDjkcDi0dOlSSdLmzZvVs2dPBQUFqW7duho+fLhyc3NdyxYd6XjuuecUGxtb7uPUK7J/5a1rz549GjhwoCIiIhQZGan+/fvr559/di23dOlSde7cWcHBwYqIiNDVV1+t3bt3S5I2btyo6667TqGhoQoLC1PHjh1dT5Qtqqm4v//9726Ptj/XmsoyZ86cMk9NFBQUaOTIkQoPD1dUVJTGjx+v4o/0eu+999SpUyeFhoYqJiZG99xzjzIyMtz23+FwaP78+erYsaMCAgK0fLnVz61fv3769NNPdfz48TPWdr4IFvCMy2+zOnWGNpAO/iC91VPavdLbVaG6MUY6edTzQwWf1RgSEqKQkBDNmzdPeXl55c531113KSMjQ/Pnz9e6devUoUMHXX/99Tpy5PSt8X/88Ud9+OGH+uyzz7RgwQKtX7/e7SmkOTk5Sk5O1vLly7Vq1So1a9ZMffv2VU6O+2XeEydO1G233abNmzfrvvvuk9PpVKNGjTR37lxt3bpVzzzzjJ588kl9+OGHkqTHHntMAwcO1I033qj9+/dr//796tq1q44ePao+ffqoTp06SklJ0dy5c/W///1PI0eOdNve4sWLtX37di1atEiff/55uW1wtv0ra135+fnq06ePQkNDtWzZMq1YsUIhISG68cYbdfLkSRUUFGjAgAHq3r27Nm3apJUrV2r48OFyOBySrKejNmrUSCkpKVq3bp2eeOIJ1apV6yz/q+4qW1NZjhw5oq1bt6pTp06lpr377rvy8/PTmjVrNGXKFP3tb3/T22+/7Zqen5+vP//5z9q4caPmzZunn3/+WUOHDi21nieeeEKTJ0/Wtm3b1LZtW0lSp06dVFBQoNWrV1dqnyvNeFhWVpaRZLKysjy9aVwIsn4x5o1uxkwIM+bZusasn+XtinCBOn78uNm6das5fvz46ZF5udb3jqeHvNwK1/3vf//b1KlTxwQGBpquXbuacePGmY0bN7qmL1u2zISFhZkTJ064LXfJJZeY6dOnG2OMmTBhgvH19TV79+51TZ8/f77x8fEx+/fvL3O7hYWFJjQ01Hz22WeucZLMmDFjzlrziBEjzB133OF6n5ycbPr37+82z5tvvmnq1KljcnNPt8UXX3xhfHx8THp6umu56Ohok5eXd8btVWT/ylrXe++9Z1q0aGGcTqdrXF5engkKCjILFy40hw8fNpLM0qVLy9xuaGiomTlzZrk1tWvXzm3cyy+/bBISElzvz6Wmsqxfv95IMmlpaW7ju3fvblq1auW2rrFjx5pWrVqVuR5jjElJSTGSTE5OjjHGmCVLlhhJZt68eWXOX6dOnXLbwJhyfu5OqejnN0cs4FlhsdK986XL+kvOfGneQ9KiCdypEzXGHXfcoX379unTTz/VjTfeqKVLl6pDhw6aOXOmJOtwfG5ururWres6whESEqLU1FTt2rXLtZ74+Hg1bNjQ9T4xMVFOp1Pbt2+XJB04cEDDhg1Ts2bNFB4errCwMOXm5iotLc2tnrL+Kn799dfVsWNH1atXTyEhIXrzzTdLLVfStm3b1K5dOwUHB7vGXX311W41SVKbNm3k7+9/1nY62/6Vta6NGzfqxx9/VGhoqKvdIiMjdeLECe3atUuRkZEaOnSo+vTpo379+mnKlCnav3+/a/lHH31UDzzwgHr16qXJkye7tXdFVbamshSdiij5WHJJuuqqq1xHWIraZefOnSostDq+r1u3Tv369VN8fLxCQ0PVvXt3SarQ/7skBQUF6dixY5XY48rzq9K1A2Xxry3dOVNa+lfr6agr/i4d2ind/qYUEOLt6nAhq1VbenKfd7ZbCYGBgerdu7d69+6t8ePH64EHHtCECRM0dOhQ5ebmqkGDBq5+C8VFRERUeBvJyck6fPiwpkyZooSEBAUEBCgxMbHU4ffiQUCyzu0/9thjeumll5SYmKjQ0FC9+OKLth0eL7k9O9eVm5urjh07atasWaXmrVevniRpxowZGjVqlBYsWKAPPvhATz/9tBYtWqSrrrpKEydO1D333KMvvvhC8+fP14QJEzRnzhzddttt8vHxcevLIJXd2fVcaiopKipKkvTrr7+WO09Zik5H9enTR7NmzVK9evWUlpamPn36nPX/vciRI0cqtc1zQbCAd/j4SD2flqJaSJ+MsO7U+U4fadD7UkS8t6vDhcrhkPzt++DylMsuu0zz5s2TJHXo0EHp6eny8/Nz6xhYUlpamvbt26fY2FhJ0qpVq+Tj4+PqMLhixQpNnTpVffv2lWR1IDx06NBZa1mxYoW6du3q1p+h5F/W/v7+rr+Qi7Rq1UozZ87U0aNHXR9aK1ascKupMs62f2Xp0KGDPvjgA9WvX19hYWHlzte+fXu1b99e48aNU2JiombPnq2rrrpKktS8eXM1b95cv//97zVo0CDNmDFDt912m+rVq6f09HQZY1xHDCryhNmK1lTcJZdcorCwMG3dulXNmzd3m1Yy4BX1n/H19dUPP/ygw4cPa/LkyYqLi5MkV+fTiti1a5dOnDih9u3bV3iZc8GpEHhX27usTp3B9aUDW6xOnWlV3LEIqCKHDx9Wz5499a9//UubNm1Samqq5s6dqxdeeEH9+/eXJPXq1UuJiYkaMGCA/vvf/+rnn3/Wt99+q6eeesrtQyIwMFDJycnauHGjli1bplGjRmngwIGKiYmRJDVr1kzvvfeetm3bptWrVyspKUlBQUFnrbFZs2Zau3atFi5cqB07dmj8+PFKSUlxm6dx48batGmTtm/frkOHDik/P19JSUmumrZs2aIlS5bokUce0eDBgxUdHV3ptjrb/pUlKSlJUVFR6t+/v5YtW6bU1FQtXbpUo0aN0t69e5Wamqpx48Zp5cqV2r17t/773/9q586datWqlY4fP66RI0dq6dKl2r17t1asWKGUlBS1atVKknVzqoMHD+qFF17Qrl279Prrr2v+/Pln3Y+z1VQWHx8f9erVy3W1RnFpaWl69NFHtX37dr3//vt69dVXNXr0aEnW6SN/f3+9+uqr+umnn/Tpp5/qz3/+c0WaW5K0bNkyNW3aVJdcckmFlzknZ+yBUQXovIkyZe4xZurVVke5P0XRqRNn7ER2oTpx4oR54oknTIcOHUx4eLipXbu2adGihXn66afNsWPHXPNlZ2ebRx55xMTGxppatWqZuLg4k5SU5OrMV9SRcOrUqSY2NtYEBgaaO++80xw5csS1ju+++8506tTJBAYGmmbNmpm5c+eahIQE8/LLL7vmkWQ+/vjjUjUOHTrUhIeHm4iICPPQQw+ZJ554wq3jYkZGhundu7cJCQkxksySJUuMMcZs2rTJXHfddSYwMNBERkaaYcOGuToNGlN2p8+yVGT/ylvX/v37zZAhQ0xUVJQJCAgwTZs2NcOGDTNZWVkmPT3dDBgwwDRo0MD4+/ubhIQE88wzz5jCwkKTl5dn7r77bhMXF2f8/f1NbGysGTlypNv317Rp00xcXJwJDg42Q4YMMc8991ypzpuVrak8X375pWnYsKEpLCx0jevevbt5+OGHzYMPPmjCwsJMnTp1zJNPPunWmXP27NmmcePGJiAgwCQmJppPP/3USDLr1683xpzuvPnrr7+W2uYNN9xgJk2aVG5NxtjTedNhTAWvo7JJdna2wsPDlZWVVeHDRrhI5OVKH/9O+uHUJWpdR0m9Jko+vl4tC95x4sQJpaamqkmTJmV2cqvJJk6cqHnz5lXoUHx1VNP3ryKMMerSpYvrlExV+/7779WzZ0/t2LFD4eHh5c53pp+7in5+cyoEF46AEGnge1K3P1rvv31Fen8Qd+oEUOM4HA69+eabKigo8Mj29u/fr3/+859nDBV2ofMmLiw+PlLPp6R6pzp17lwovd3L6tRZt4rPCwKAB11xxRWl7vZZVXr16uWR7UgSp0Jw4frlO2lOkpSzTwoMt547cqnnfjjgXRfzqRDAWzgVgpqtYQdp+FKpUWfpRJY06y7p21crfHtlAIDnESxwYQuNloZ+LrX/rWSc0n+flj4aLp2s2jvH4cLh4YOqwEXNjp83ggUufH4B0q2vSTe9IDl8pc0fSu/cIP2629uVoQoVPRyqqm8/DOC0op+3yj6crTg6b6J6cDikLr+Toi+XPkyW0jdLb/aQ7pohNe3h7epQBXx9fRUREeF6JHTt2rXdnqEAwD7GGB07dkwZGRmKiIiQr++5X+ZP501UP1l7pQ9+K+1bLzl8pOsnSFePtsIHahRjjNLT05WZmentUoCLQkREhGJiYsoM8RX9/CZYoHrKPy598Qdpw6kH/7S8RRow1bp6BDVOYWFhmQ+EAmCfWrVqnfFIRUU/vzkVguqpVpDU/3WpUSdp/ljrbp1vbpN+8y8p+jJvVweb+fr6ntehWQCeQ+dNVF8Oh9TpPuneBVJYI+nILunt66UN73u7MgC4aBEsUP016ij97hup6XVS/jFp3oPSJyOt0yUAAI8iWKBmCK4r/fY/Uo8nJTmk9e9Jb10vHdrp7coA4KJCsEDN4eMr9RgrDZknBdeTMr6Xpnfn1AgAeBDBAjVP0x7Sg8ulxtdK+UetUyMfDZfycrxdGQDUeAQL1EyhMdKQT6TrnrbudbHpA2l6N+vBZgCAKkOwQM3l4yt1f1wa+uWpq0Z+kv7RW1r2kuQs9HZ1AFAjESxQ8yUkSg8uky4bIDkLpMV/kmbeImWmebsyAKhxCBa4ONSOlO6aKQ2YJvmHSGnfStOuljbM5jHsAGAjggUuHg6HdMU9VsfORp2lvGxp3kPS+4OknAPerg4AagSCBS4+kU2ke+dbDy/zqSXtmC9N7SJt+Q9HLwDgPBEscHHy9ZOufVQavlSKaSMd/1X6933WU1Nz0r1dHQBUWwQLXNxiWksPfCV1Hyv5+FkPM3u9s7T+Xxy9AIBzQLAA/Pyl656Uhn8tNbhCOpElfTJCem+AdHiXt6sDgGqFYAEUiWktPbBY6v0nyS9Q+mmpNDVR+voFqSDP29UBQLVAsACK8/WTrh4tPbxSuqSnVJgnLXnOujT1p6+9XR0AXPAIFkBZIptKv/1IuuMfUnB96fBO6Z+3Sh8OkTL3eLs6ALhgESyA8jgcUps7pZEpUufh1jNHtn4ivXaldXok/7i3KwSACw7BAjiboAip74vS776R4rtKBcet0yOvXSlt/jdXjwBAMQQLoKJi2kj3fmmdHglrKGXtkf5zv/T29VLaKm9XBwAXBIIFUBmu0yNrpZ5PS7WCpV/WSe/0sW4NfmCrtysEAK8iWADnwr+21O1xadR6qUOy1f9i+5fStK7SR7+Tfv3Z2xUCgFcQLIDzERot3fqK9PBq6bL+koy0aY70aifps9E8mh3ARYdgAdihXnNp4D+lYV9JTXtIznxp3UzplQ7SZ2MIGAAuGgQLwE4NO0pDPrGentqk+6mAMUOacoV1iiRjm7crBIAq5TDGs9fKZWdnKzw8XFlZWQoLC/PkpgHP2/2ttHSylFrsrp0t+kpdR0nxV1mdQQGgGqjo5zfBAvCEX9ZJy/8ubftM0qkfudj20lUjpMsHSL61vFgcAJwdwQK4EB3cIa18Vdr4gfUcEkkKjZU63Sd1GGJ1BgWACxDBAriQHT0krX1HWvOWdDTDGufjJ7XqJ3W6X2p8DadJAFxQCBZAdVCQJ30/T1r7D2nP6tPjI5tK7X8rtRskhcV6rTwAKEKwAKqb9M1Syj+kzXOlk7nWOIePdGkvqc1AqWVfyT/YuzUCuGgRLIDq6uRR6yjG+vektJWnx9cKllrdIrW+07pXhp+/tyoEcBGq6Of3ed3HYvLkyXI4HBozZsz5rAZAcf7BUvsk6b4F0sh1Urc/SnUaS/lHpU0fSLPvkv7vUunjh6QdC63TKQBwgfA71wVTUlI0ffp0tW3b1s56ABQXdanU8ynpuielvSnSpg+lbZ9KuQekjbOtwT9EuqSndX+MZjdIwXW9XTWAi9g5BYvc3FwlJSXprbfe0l/+8pczzpuXl6e8vNN/UWVnZ5/LJoGLm8MhxXW2hpuetx7TvvUTK2Tk7Ldet31q9clo2NHql3FpL+teGT6+3q4ewEXknPpYJCcnKzIyUi+//LJ69OihK664Qn//+9/LnHfixIl69tlnS42njwVgA6dT2r9B2j7fGg5sdp8eGCE1uda6vXiTblJUcy5jBXBOqqzz5pw5c/Tcc88pJSVFgYGBZw0WZR2xiIuLI1gAVSFrr/TjYunH/0k/fS3lZblPD65v3Uq8aIhpy10/AVRIRYNFpU6F7NmzR6NHj9aiRYsUGBhYoWUCAgIUEBBQmc0AOFfhjaSOydZQWCDtW289p+TnZdbpk6MZp0+bSJJfoNSgnXX6pGFHqcEV1j00fHg+IVAtnTwqHf7R+rn2kkodsZg3b55uu+02+fqePmdbWFgoh8MhHx8f5eXluU0rC5ebAl5SkCft2yClfWuFjLRV0onM0vP5h0gxbayh/mVS9OVSvZZSID+vwAUlJ13av0lK32TdB+fAFunwLmvak7/Yft+bKjlicf3112vzZvdzuPfee69atmypsWPHnjVUAPAivwApvos1SJIx1i+hX9ZJv6y1Xg98b92cK22l+z00JCmsoRTVTKrbzHqNvESKbCKFx3FPDaAqGSNl/2L9YbB/g/Wavsm6OqwsIdFS1i9SveYeLPK0SgWL0NBQtW7d2m1ccHCw6tatW2o8gAucw2Fdzhp1qdTuN9a4wgLp8M7TfwUd/EHK2Gb9UisaflpaYj0+UlgjqU6CdSomPM56DYuVQmOk0AZS7bp0GgUqKjdD+uU7ad931unMfeulowdLz+fwsYJ+g7bWEcbo1tZrSH3P11zMOd/HAkAN5Osn1W9lDUVhQ5KO/yod2ikd2nHqdaf0a6p0JFUqOC5lpVlDeXxqScFRUnA965de7SgpqI5UO9J6DaojBYRJgeHWKRf/ECkgxHqlcylqspPHpP0braOGe08dOczaU3o+Hz+pXisptp3VF6rBFdZpSv/anq74rLilN4BzZ4x1OPZIqnVFSlbaqde91v01ctLL/kurMnz9pVpBkl+QVCvQevWtZZ3a8fW3fuEWHxwO6y85h4/1tetXnLGCS9fR1lEawNOMkX79Wdqzxrrh3d4Uq1+Es6DEjA6pXgsptoN1L5qGHayjEbUqdtFEVamSPhYA4MbhOHW6I6b8eQpOWlej5GZYj4s/miEdOywdOyIdP2K9nsiS8rKt1xNZVs/2wpPW8oUnT32dVf42KmPLR1K/KVKbO+1ZH1Ce/BNWn4g9q60wsWd12UE7JFpqdKV1ZVajTtbRiGrcWZpgAaBq+fmf6nvRqHLLFZy0OpKePCoVnJDyj59+Lcw/FTjyrH4hptD6q68wXzJOScb669A4JZ3q2+FwSN9/LO1eIf3nfusS3BsnW0dDADscPWyFh7SV1uu+9acDchGfWtaloHGdrTDR6ErrZ6MG9UHiVAiAi0dhgfT1ZOmb/5NkpPqXS7e9YXV+AyrDGClzt7R75emrqA7tKD1fcD0prsvpoUE7r5/SOFc8Nh0AyrPrK+k/w6Rjh6x+Gd0el655lMtmUT6nUzq4Tdr9rRUidq+UcvaVni+qxek728Z1sW44V0OORhAsAOBMcjOkz38v/fC59T66jTTgda/esRAXkMICKX2jFSSKhpI3lPPxszpXxieeGq6yrnSqoQgWAHA2xkjffyR98ZjVkdThI105zHpMfVCEt6uDJxXkWZd67l5hhYg9a6w+PsXVqm31iUi4WkpIlBp2uiAv96wqBAsAqKjcDGn+H63OnZJ1Xrz3n6S2d/PclJrq5FErPBQdjdibYnUGLi4wXIrvKiV0tcJEg4v7oX0ECwCorF1LpC8ft+4+Kln3Eeg1UWra3atlwQbHf5XSVlvPyvl5hXUZaMn7RwTXt45EJFxjhYn6lxEsiyFYAMC5KDgprZ4mff3C6UPhl/S0Agb9L6qPnANWiNi90joicWCLpBIfd2GNrADR+GorTNS9pMZ0tKwKBAsAOB+5GdI3L0prZ0jOfGtcy1usq0cadfRubXBX9EC9tJWnntz7rXTkp9Lz1b3U6mTZ+NQRiYh4z9dajREsAMAOR1KlJX+VNs+V6y/eJt2ka34vNb2Ov3C9oeCk9XyNPausIFHmHS0d1m2wExKtEBHfVQqN9kq5NQXBAgDsdHC7tGKKtOmD0+fm67WUrnxAavuban0L5gte7kFp75pTt8VeYz31s+CE+zy+AdYtseO7WCEirjNX9tiMYAEAVSFzj/Ttq9L6f0n5R61x/iFS24FSu0HW5YgcxTh3BSelA5utJ33uXWtdrfFraun5giJP34Qq/irrfhJ+AZ6v9yJCsACAqnQiS9o4R0p52/1WzpFNrSMYre/kKapn4yy02m7fBusoxC/rpPTNpZ+vIVmPDI+70goSjTpLUc0IcB5GsAAATzBGSv1G2jBL2vaZlH/s9LSoFlLLm6VWt0gN2l/cly4W5EkHf7CCw/5N1uWe6Zvd26tIUKT1lM+GnU69duS0xgWAYAEAnpaXK/3whdUPI/Vr9/sk1I6yOn027WHdFyMioWb+xW2MlLXXChEHvreGjK1WH5Wiq2uKqxVs3XiqYUfrdEbDjlKdxjWzbao5ggUAeNPxTOnH/1nPItm5qPTtoUMbWH+NN7rS+ss8+vLq9Vf5yWPWJZ2Hfzw9HPxBOrSz9L4WCQyXYtpaQ4O2VpCoe6nk4+vZ2nFOCBYAcKEoOGn1H/hpqXUkY29K6bs+SlJ4nHW3x/otrb4akU2lOk2ksFjPfvgaY92pMnuflP2LdQQie5+UmSb9+rP1uPDcA+Uv71PLutlU/cuswBR9ufV1RDxHIqoxggUAXKhOHrP6GOxNOXX55AYpe2/58zt8pJBoKTTGOtJRO1IKjJCC6lhHAWrVlmoFSn5B1pURDoe1jMNHMk6pMN8anPnWtk/mWs/KOJlrHVk5/qs1HDts3Q8iN6Ps0xYlBUZYnSjrXipFXiLVa2FdghvZ5KJ+pkZNVdHPbz8P1gQAkKwnYiacerhVkeOZVl+EA99bpxOO/GRdZvnrbutDPme/NWi95+oMqmPd9jq8oRTWUIqIs/o/1Gls9RGpwY8Ix7kjWADAhSAoonTYkKxLMo8etEJF9qlwcfxX6UTmqdcsKf+ElH9cKjhuXX1hjCRjHa2Qwzp64OtvvdYKsu674R9iBZygOqeGSOs1pL41BNfjvhA4JwQLALiQ+fieOgUSY3V2BC5wF/FF1QAAwG4ECwAAYBuCBQAAsA3BAgAA2IZgAQAAbEOwAAAAtiFYAAAA2xAsAACAbQgWAADANgQLAABgG4IFAACwDcECAADYhmABAABsQ7AAAAC2IVgAAADbECwAAIBtCBYAAMA2BAsAAGAbggUAALANwQIAANiGYAEAAGxDsAAAALYhWAAAANsQLAAAgG0IFgAAwDYECwAAYBuCBQAAsA3BAgAA2IZgAQAAbEOwAAAAtiFYAAAA2xAsAACAbQgWAADANgQLAABgG4IFAACwDcECAADYhmABAABsQ7AAAAC2IVgAAADbECwAAIBtCBYAAMA2lQoW06ZNU9u2bRUWFqawsDAlJiZq/vz5VVUbAACoZioVLBo1aqTJkydr3bp1Wrt2rXr27Kn+/fvr+++/r6r6AABANeIwxpjzWUFkZKRefPFF3X///WVOz8vLU15enut9dna24uLilJWVpbCwsPPZNAAA8JDs7GyFh4ef9fP7nPtYFBYWas6cOTp69KgSExPLnW/SpEkKDw93DXFxcee6SQAAcIGr9BGLzZs3KzExUSdOnFBISIhmz56tvn37ljs/RywAAKj+KnrEwq+yK27RooU2bNigrKws/fvf/1ZycrK+/vprXXbZZWXOHxAQoICAgMpuBgAAVEPn3ceiV69euuSSSzR9+vQKzV/RxAMAAC4cVd7HoojT6XQ71QEAAC5elToVMm7cON10002Kj49XTk6OZs+eraVLl2rhwoVVVR8AAKhGKhUsMjIyNGTIEO3fv1/h4eFq27atFi5cqN69e1dVfQAAoBqpVLD4xz/+UVV1AACAGoBnhQAAANsQLAAAgG0IFgAAwDYECwAAYBuCBQAAsA3BAgAA2IZgAQAAbEOwAAAAtiFYAAAA2xAsAACAbQgWAADANgQLAABgG4IFAACwDcECAADYhmABAABsQ7AAAAC2IVgAAADbECwAAIBtCBYAAMA2BAsAAGAbggUAALANwQIAANiGYAEAAGxDsAAAALYhWAAAANsQLAAAgG0IFgAAwDYECwAAYBuCBQAAsA3BAgAA2IZgAQAAbEOwAAAAtiFYAAAA2xAsAACAbQgWAADANgQLAABgG4IFAACwDcECAADYhmABAABsQ7AAAAC2IVgAAADbECwAAIBtCBYAAMA2BAsAAGAbggUAALANwQIAANiGYAEAAGxDsAAAALYhWAAAANsQLAAAgG0IFgAAwDYECwAAYBuCBQAAsA3BAgAA2IZgAQAAbEOwAAAAtiFYAAAA2xAsAACAbQgWAADANgQLAABgG4IFAACwDcECAADYhmABAABsU6lgMWnSJF155ZUKDQ1V/fr1NWDAAG3fvr2qagMAANVMpYLF119/rREjRmjVqlVatGiR8vPzdcMNN+jo0aNVVR8AAKhGHMYYc64LHzx4UPXr19fXX3+tbt26VWiZ7OxshYeHKysrS2FhYee6aQAA4EEV/fz2O5+NZGVlSZIiIyPLnScvL095eXluhQEAgJrpnDtvOp1OjRkzRldffbVat25d7nyTJk1SeHi4a4iLizvXTQIAgAvcOZ8KeeihhzR//nwtX75cjRo1Kne+so5YxMXFcSoEAIBqpEpPhYwcOVKff/65vvnmmzOGCkkKCAhQQEDAuWwGAABUM5UKFsYYPfLII/r444+1dOlSNWnSpKrqAgAA1VClgsWIESM0e/ZsffLJJwoNDVV6erokKTw8XEFBQVVSIAAAqD4q1cfC4XCUOX7GjBkaOnRohdbB5aYAAFQ/VdLH4jxueQEAAC4CPCsEAADYhmABAABsQ7AAAAC2IVgAAADbECwAAIBtCBYAAMA2BAsAAGAbggUAALANwQIAANiGYAEAAGxDsAAAALYhWAAAANsQLAAAgG0IFgAAwDYECwAAYBuCBQAAsA3BAgAA2IZgAQAAbEOwAAAAtiFYAAAA2xAsAACAbQgWAADANgQLAABgG4IFAACwDcECAADYhmABAABsQ7AAAAC2IVgAAADbECwAAIBtCBYAAMA2BAsAAGAbggUAALANwQIAANiGYAEAAGxDsAAAALYhWAAAANsQLAAAgG0IFgAAwDYECwAAYBuCBQAAsA3BAgAA2IZgAQAAbEOwAAAAtiFYAAAA2xAsAACAbQgWAADANgQLAABgG4IFAACwDcECAADYhmABAABsQ7AAAAC2IVgAAADbECwAAIBtCBYAAMA2BAsAAGAbggUAALANwQIAANiGYAEAAGxDsAAAALYhWAAAANsQLAAAgG0IFgAAwDYECwAAYJtKB4tvvvlG/fr1U2xsrBwOh+bNm1cFZQEAgOqo0sHi6NGjateunV5//fWqqAcAAFRjfpVd4KabbtJNN91UFbUAAIBqrtLBorLy8vKUl5fnep+dnV3VmwQAAF5S5Z03J02apPDwcNcQFxdX1ZsEAABeUuXBYty4ccrKynINe/bsqepNAgAAL6nyUyEBAQEKCAio6s0AAIALAPexAAAAtqn0EYvc3Fz9+OOPrvepqanasGGDIiMjFR8fb2txAACgeql0sFi7dq2uu+461/tHH31UkpScnKyZM2faVhgAAKh+Kh0sevToIWNMVdQCAACqOfpYAAAA2xAsAACAbQgWAADANgQLAABgG4IFAACwDcECAADYhmABAABsQ7AAAAC2IVgAAADbECwAAIBtCBYAAMA2BAsAAGAbggUAALANwQIAANiGYAEAAGxDsAAAALYhWAAAANsQLAAAgG0IFgAAwDYECwAAYBuCBQAAsA3BAgAA2IZgAQAAbEOwAAAAtiFYAAAA2xAsAACAbQgWAADANgQLAABgGz9vF2CXHzNydLLAyMjIGMmY09McjtOvDjlOf13yvWtea5yPQ3I4HMXGW/O7ra/YdLdpp/5xyFFqPQ5rQrFtll6H29en5ilaDwAAF6oaEywGvbVaB3PyvF2Gx5QMJT6nRhR9XXK6HO7ji76WK/icGle0TLH5y1rOej21bZ/TAUqnApBPibp83NbjcAtlbtOKLVe0XrnVdvprldiOj481smStxffJUWx/i7eN2/hi+1J6PafDnaNEXe6h89T63LZ9ep2lg2OxwFns/614+6vE+JLLSyX211Vv6TYvubxKvi9Rd/H1l7/PZwrG7vVJpb8fXOs4S42lgnoZ3+/l1Vb0vebjU1QFALvVmGARFRIgSaV+qRgj11EMSSo6kGG9P3V0Q5Ix5tRr0XTrvcqYXmp9xcaVta6qULSt0xupwo0BNZCPQ/L1cbhCoI/D4RaciwJM8SDjNt6nRNApFmhLBWWf0sHdPbS6B7KidZcMWm6hrozweaZlSobH0zVaE8sL5DrDtkuu0317ZQfEolBXXrguO0SXDug+5SxfVjg/07qL75eKz1POOspcv4r+GClZUwXD/zkG9DOto0F4kHy9FKBrTLCYP/pab5dQLmPKDh3FT9uUG0yKTXNWdNkS408vd3o+ZxnzFZ/39HTrfaHTlF5nsdey1mFc81jTnafWV3zbJZd3uq3r9DJWTdbXOlWfs9jykuR0ureP89SbonFu7VesRmeJdpDKrkvF9rF4mztPfVH6/7f4tLLap9g6y1i2+L6Wtd0zBVpXzCy5/yXWXd733pkCdcnwXXodZ9ivEusv9f1zlv2yk9NIzsJTP2RADbPmqetVPzTQK9uuMcHiQlaUWk+982YpQLVXMqgXD6PW9HKCifN0qLOCslFhsYDsdLoH66KgWnyadDoMFS2rUyG2eLAtHpiKArBKBvJi+1J8H8oM28UCWfFg6nSNLz9AlhfcS7Zl8eWKr6/ksq5Q6Cw9j4q39xkCp3uN7ustK2CXCpzF2raiAb1kOC7z6zKWL6stqjKgO4tNq2hAL2v9Di9+1hAsAFQrBHXgwsblpgAAwDYECwAAYBuCBQAAsA3BAgAA2IZgAQAAbEOwAAAAtiFYAAAA2xAsAACAbQgWAADANgQLAABgG4IFAACwDcECAADYhmABAABsQ7AAAAC28fhj04ueX5+dne3pTQMAgHNU9Lld9DleHo8Hi5ycHElSXFycpzcNAADOU05OjsLDw8ud7jBnix42czqd2rdvn0JDQ+VwOGxbb3Z2tuLi4rRnzx6FhYXZtt6aivaqHNqr4miryqG9Kof2qhw728sYo5ycHMXGxsrHp/yeFB4/YuHj46NGjRpV2frDwsL4ZqsE2qtyaK+Ko60qh/aqHNqrcuxqrzMdqShC500AAGAbggUAALBNjQkWAQEBmjBhggICArxdSrVAe1UO7VVxtFXl0F6VQ3tVjjfay+OdNwEAQM1VY45YAAAA7yNYAAAA2xAsAACAbQgWAADANjUmWLz++utq3LixAgMD1aVLF61Zs8bbJXncpEmTdOWVVyo0NFT169fXgAEDtH37drd5Tpw4oREjRqhu3boKCQnRHXfcoQMHDrjNk5aWpptvvlm1a9dW/fr19fjjj6ugoMCTu+JxkydPlsPh0JgxY1zjaCt3v/zyi37729+qbt26CgoKUps2bbR27VrXdGOMnnnmGTVo0EBBQUHq1auXdu7c6baOI0eOKCkpSWFhYYqIiND999+v3NxcT+9KlSssLNT48ePVpEkTBQUF6ZJLLtGf//xnt2csXMzt9c0336hfv36KjY2Vw+HQvHnz3Kbb1TabNm3Stddeq8DAQMXFxemFF16o6l2rEmdqr/z8fI0dO1Zt2rRRcHCwYmNjNWTIEO3bt89tHR5tL1MDzJkzx/j7+5t33nnHfP/992bYsGEmIiLCHDhwwNuleVSfPn3MjBkzzJYtW8yGDRtM3759TXx8vMnNzXXN8+CDD5q4uDizePFis3btWnPVVVeZrl27uqYXFBSY1q1bm169epn169ebL7/80kRFRZlx48Z5Y5c8Ys2aNaZx48ambdu2ZvTo0a7xtNVpR44cMQkJCWbo0KFm9erV5qeffjILFy40P/74o2ueyZMnm/DwcDNv3jyzceNGc+utt5omTZqY48ePu+a58cYbTbt27cyqVavMsmXLzKWXXmoGDRrkjV2qUs8995ypW7eu+fzzz01qaqqZO3euCQkJMVOmTHHNczG315dffmmeeuop89FHHxlJ5uOPP3abbkfbZGVlmejoaJOUlGS2bNli3n//fRMUFGSmT5/uqd20zZnaKzMz0/Tq1ct88MEH5ocffjArV640nTt3Nh07dnRbhyfbq0YEi86dO5sRI0a43hcWFprY2FgzadIkL1blfRkZGUaS+frrr40x1jdgrVq1zNy5c13zbNu2zUgyK1euNMZY38A+Pj4mPT3dNc+0adNMWFiYycvL8+wOeEBOTo5p1qyZWbRokenevbsrWNBW7saOHWuuueaacqc7nU4TExNjXnzxRde4zMxMExAQYN5//31jjDFbt241kkxKSoprnvnz5xuHw2F++eWXqiveC26++WZz3333uY27/fbbTVJSkjGG9iqu5AelXW0zdepUU6dOHbefxbFjx5oWLVpU8R5VrbKCWElr1qwxkszu3buNMZ5vr2p/KuTkyZNat26devXq5Rrn4+OjXr16aeXKlV6szPuysrIkSZGRkZKkdevWKT8/362tWrZsqfj4eFdbrVy5Um3atFF0dLRrnj59+ig7O1vff/+9B6v3jBEjRujmm292axOJtirp008/VadOnXTXXXepfv36at++vd566y3X9NTUVKWnp7u1V3h4uLp06eLWXhEREerUqZNrnl69esnHx0erV6/23M54QNeuXbV48WLt2LFDkrRx40YtX75cN910kyTa60zsapuVK1eqW7du8vf3d83Tp08fbd++Xb/++quH9sY7srKy5HA4FBERIcnz7eXxh5DZ7dChQyosLHT75S5J0dHR+uGHH7xUlfc5nU6NGTNGV199tVq3bi1JSk9Pl7+/v+ubrUh0dLTS09Nd85TVlkXTapI5c+bou+++U0pKSqlptJW7n376SdOmTdOjjz6qJ598UikpKRo1apT8/f2VnJzs2t+y2qN4e9WvX99tup+fnyIjI2tcez3xxBPKzs5Wy5Yt5evrq8LCQj333HNKSkqSJNrrDOxqm/T0dDVp0qTUOoqm1alTp0rq97YTJ05o7NixGjRokOuhY55ur2ofLFC2ESNGaMuWLVq+fLm3S7kg7dmzR6NHj9aiRYsUGBjo7XIueE6nU506ddJf//pXSVL79u21ZcsWvfHGG0pOTvZydReeDz/8ULNmzdLs2bN1+eWXa8OGDRozZoxiY2NpL1SZ/Px8DRw4UMYYTZs2zWt1VPtTIVFRUfL19S3VW//AgQOKiYnxUlXeNXLkSH3++edasmSJ2yPqY2JidPLkSWVmZrrNX7ytYmJiymzLomk1xbp165SRkaEOHTrIz89Pfn5++vrrr/XKK6/Iz89P0dHRtFUxDRo00GWXXeY2rlWrVkpLS5N0en/P9HMYExOjjIwMt+kFBQU6cuRIjWuvxx9/XE888YTuvvtutWnTRoMHD9bvf/97TZo0SRLtdSZ2tc3F9PMpnQ4Vu3fv1qJFi9weke7p9qr2wcLf318dO3bU4sWLXeOcTqcWL16sxMREL1bmecYYjRw5Uh9//LG++uqrUoe1OnbsqFq1arm11fbt25WWluZqq8TERG3evNntm7Dom7TkB0t1dv3112vz5s3asGGDa+jUqZOSkpJcX9NWp1199dWlLl3esWOHEhISJElNmjRRTEyMW3tlZ2dr9erVbu2VmZmpdevWueb56quv5HQ61aVLFw/sheccO3ZMPj7uv159fX3ldDol0V5nYlfbJCYm6ptvvlF+fr5rnkWLFqlFixY17jRIUajYuXOn/ve//6lu3bpu0z3eXpXu7nkBmjNnjgkICDAzZ840W7duNcOHDzcRERFuvfUvBg899JAJDw83S5cuNfv373cNx44dc83z4IMPmvj4ePPVV1+ZtWvXmsTERJOYmOiaXnQJ5Q033GA2bNhgFixYYOrVq1cjL6EsqfhVIcbQVsWtWbPG+Pn5meeee87s3LnTzJo1y9SuXdv861//cs0zefJkExERYT755BOzadMm079//zIvEWzfvr1ZvXq1Wb58uWnWrFmNuHyypOTkZNOwYUPX5aYfffSRiYqKMn/84x9d81zM7ZWTk2PWr19v1q9fbySZv/3tb2b9+vWuqxjsaJvMzEwTHR1tBg8ebLZs2WLmzJljateuXS0vNz1Te508edLceuutplGjRmbDhg1uv/uLX+HhyfaqEcHCGGNeffVVEx8fb/z9/U3nzp3NqlWrvF2Sx0kqc5gxY4ZrnuPHj5uHH37Y1KlTx9SuXdvcdtttZv/+/W7r+fnnn81NN91kgoKCTFRUlPnDH/5g8vPzPbw3nlcyWNBW7j777DPTunVrExAQYFq2bGnefPNNt+lOp9OMHz/eREdHm4CAAHP99deb7du3u81z+PBhM2jQIBMSEmLCwsLMvffea3Jycjy5Gx6RnZ1tRo8ebeLj401gYKBp2rSpeeqpp9x+0V/M7bVkyZIyf1clJycbY+xrm40bN5prrrnGBAQEmIYNG5rJkyd7ahdtdab2Sk1NLfd3/5IlS1zr8GR78dh0AABgm2rfxwIAAFw4CBYAAMA2BAsAAGAbggUAALANwQIAANiGYAEAAGxDsAAAALYhWAAAANsQLICL3NChQzVgwACPb3fmzJlyOBxyOBwaM2ZMhZYZOnSoa5l58+ZVaX0Azg2PTQdqMIfDccbpEyZM0JQpU+StG/CGhYVp+/btCg4OrtD8U6ZM0eTJk9WgQYMqrgzAuSJYADXY/v37XV9/8MEHeuaZZ9yeUhoSEqKQkBBvlCbJCj6VeSRzeHi4wsPDq7AiAOeLUyFADRYTE+MawsPDXR/kRUNISEipUyE9evTQI488ojFjxqhOnTqKjo7WW2+9paNHj+ree+9VaGioLr30Us2fP99tW1u2bNFNN92kkJAQRUdHa/DgwTp06FCla546daqaNWumwMBARUdH68477zzfZgDgQQQLAKW8++67ioqK0po1a/TII4/ooYce0l133aWuXbvqu+++0w033KDBgwfr2LFjkqTMzEz17NlT7du319q1a7VgwQIdOHBAAwcOrNR2165dq1GjRulPf/qTtm/frgULFqhbt25VsYsAqginQgCU0q5dOz399NOSpHHjxmny5MmKiorSsGHDJEnPPPOMpk2bpk2bNumqq67Sa6+9pvbt2+uvf/2rax3vvPOO4uLitGPHDjVv3rxC201LS1NwcLBuueUWhYaGKiEhQe3bt7d/BwFUGY5YACilbdu2rq99fX1Vt25dtWnTxjUuOjpakpSRkSFJ2rhxo5YsWeLqsxESEqKWLVtKknbt2lXh7fbu3VsJCQlq2rSpBg8erFmzZrmOigCoHggWAEqpVauW23uHw+E2ruhqE6fTKUnKzc1Vv379tGHDBrdh586dlTqVERoaqu+++07vv/++GjRooGeeeUbt2rVTZmbm+e8UAI/gVAiA89ahQwf95z//UePGjeXnd36/Vvz8/NSrVy/16tVLEyZMUEREhL766ivdfvvtNlULoCpxxALAeRsxYoSOHDmiQYMGKSUlRbt27dLChQt17733qrCwsMLr+fzzz/XKK69ow4YN2r17t/75z3/K6XSqRYsWVVg9ADsRLACct9jYWK1YsUKFhYW64YYb1KZNG40ZM0YRERHy8an4r5mIiAh99NFH6tmzp1q1aqU33nhD77//vi6//PIqrB6AnRzGW7fcA3BRmzlzpsaMGXNO/SccDoc+/vhjr9yKHMCZccQCgNdkZWUpJCREY8eOrdD8Dz74oFfvFArg7DhiAcArcnJydODAAUnWKZCoqKizLpORkaHs7GxJUoMGDSr8jBEAnkOwAAAAtuFUCAAAsA3BAgAA2IZgAQAAbEOwAAAAtiFYAAAA2xAsAACAbQgWAADANgQLAABgm/8HaiFPJfUmuLcAAAAASUVORK5CYII=\n"
-          },
-          "metadata": {}
-        }
-      ],
-      "source": [
-        "# define the feed fluid\n",
-        "fluid1 = jneqsim.thermo.system.SystemSrkEos(298.15, 10.0)\n",
-        "fluid1.addComponent(\"methane\", 0.9)\n",
-        "fluid1.addComponent(\"ethane\", 0.1)\n",
-        "fluid1.addComponent(\"n-heptane\", 1.0)\n",
-        "fluid1.setMixingRule('classic')\n",
-        "\n",
-        "# build process equipment\n",
-        "feed = jneqsim.process.equipment.stream.Stream(\"Feed\", fluid1)\n",
-        "feed.setFlowRate(50.0, \"kg/hr\")\n",
-        "feed.setPressure(10.0, \"bara\")\n",
-        "\n",
-        "inlet_valve = jneqsim.process.equipment.valve.ThrottlingValve(\"inlet valve\", feed)\n",
-        "inlet_valve.setOutletPressure(5.0)\n",
-        "inlet_valve.setPercentValveOpening(30)\n",
-        "inlet_valve.setCalculateSteadyState(False)\n",
-        "\n",
-        "sep = jneqsim.process.equipment.separator.Separator(\"Separator\")\n",
-        "sep.addStream(inlet_valve.getOutletStream())\n",
-        "sep.setSeparatorLength(0.3)\n",
-        "sep.setInternalDiameter(1.0)\n",
-        "sep.setLiquidLevel(0.5)\n",
-        "sep.setCalculateSteadyState(False)\n",
-        "\n",
-        "\n",
-        "liq_valve = jneqsim.process.equipment.valve.ThrottlingValve(\"liquid valve\", sep.getLiquidOutStream())\n",
-        "liq_valve.setOutletPressure(1.0)\n",
-        "liq_valve.setPercentValveOpening(50)\n",
-        "liq_valve.setCalculateSteadyState(False)\n",
-        "\n",
-        "gas_valve = jneqsim.process.equipment.valve.ThrottlingValve(\"gas valve\", sep.getGasOutStream())\n",
-        "gas_valve.setOutletPressure(1.0)\n",
-        "gas_valve.setPercentValveOpening(50)\n",
-        "gas_valve.setCalculateSteadyState(False)\n",
-        "\n",
-        "# measurement devices\n",
-        "level_trans = jneqsim.process.measurementdevice.LevelTransmitter(sep)\n",
-        "level_trans.setMaximumValue(0.8)\n",
-        "level_trans.setMinimumValue(0.2)\n",
-        "\n",
-        "pressure_trans = jneqsim.process.measurementdevice.PressureTransmitter(sep.getGasOutStream())\n",
-        "pressure_trans.setUnit(\"bar\")\n",
-        "pressure_trans.setMaximumValue(10.0)\n",
-        "pressure_trans.setMinimumValue(1.0)\n",
-        "\n",
-        "# controllers\n",
-        "level_contr = jneqsim.process.controllerdevice.ControllerDeviceBaseClass()\n",
-        "level_contr.setReverseActing(False)\n",
-        "level_contr.setTransmitter(level_trans)\n",
-        "level_contr.setControllerSetPoint(0.45)\n",
-        "level_contr.setControllerParameters(1.0, 200.0, 0.0)\n",
-        "\n",
-        "pressure_contr = jneqsim.process.controllerdevice.ControllerDeviceBaseClass()\n",
-        "pressure_contr.setReverseActing(False)\n",
-        "pressure_contr.setTransmitter(pressure_trans)\n",
-        "pressure_contr.setControllerSetPoint(5.0)\n",
-        "pressure_contr.setControllerParameters(1.0, 50.0, 0.0)\n",
-        "\n",
-        "liq_valve.setController(level_contr)\n",
-        "gas_valve.setController(pressure_contr)\n",
-        "\n",
-        "# assemble and run process\n",
-        "p = jneqsim.process.processmodel.ProcessSystem()\n",
-        "p.add(feed)\n",
-        "p.add(inlet_valve)\n",
-        "p.add(sep)\n",
-        "p.add(liq_valve)\n",
-        "p.add(gas_valve)\n",
-        "p.add(level_trans)\n",
-        "p.add(pressure_trans)\n",
-        "p.run()\n",
-        "\n",
-        "# dynamic simulation\n",
-        "p.setTimeStep(10.0)\n",
-        "\n",
-        "time=[]; level=[]; pressure=[]\n",
-        "for i in range(20):\n",
-        "    time.append(p.getTime())\n",
-        "    level.append(level_trans.getMeasuredValue())\n",
-        "    pressure.append(pressure_trans.getMeasuredValue())\n",
-        "    p.runTransient()\n",
-        "\n",
-        "pressure_contr.setControllerSetPoint(4.0)\n",
-        "\n",
-        "for i in range(50):\n",
-        "    time.append(p.getTime())\n",
-        "    level.append(level_trans.getMeasuredValue())\n",
-        "    pressure.append(pressure_trans.getMeasuredValue())\n",
-        "    p.runTransient()\n",
-        "\n",
-        "feed.setPressure(8.0, \"bara\")\n",
-        "level_contr.setControllerSetPoint(0.5)\n",
-        "\n",
-        "for i in range(50):\n",
-        "    time.append(p.getTime())\n",
-        "    level.append(level_trans.getMeasuredValue())\n",
-        "    pressure.append(pressure_trans.getMeasuredValue())\n",
-        "    p.runTransient()\n",
-        "\n",
-        "\n",
-        "plt.plot(time, level, label='Separator level')\n",
-        "plt.plot(time, pressure, label='Separator pressure (bar)')\n",
-        "plt.xlabel('Time [s]')\n",
-        "plt.legend()\n",
-        "plt.show()\n"
-      ],
-      "id": "55jIS1xZdkzb"
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "-jlZNo-sdkzd"
-      },
-      "source": [
-        "The plot shows how the PID controllers keep level and pressure close to their setpoints and how the pressure responds when the setpoint is changed from 5 to 4 bar.\n"
-      ],
-      "id": "-jlZNo-sdkzd"
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "name": "python",
-      "version": "3.12"
-    },
-    "colab": {
-      "provenance": [],
-      "name": "process_control_with_neqsim.ipynb",
-      "include_colab_link": true
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "view-in-github",
+    "colab_type": "text"
+   },
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/EvenSol/NeqSim-Colab/blob/master/notebooks/process/process_control_with_neqsim.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 5
+  {
+   "cell_type": "code",
+   "metadata": {
+    "id": "setup"
+   },
+   "execution_count": 5,
+   "outputs": [],
+   "source": [
+    "#@title Process Control in NeqSim\n",
+    "#@markdown This notebook introduces basic process control concepts and shows how they can be implemented in the [NeqSim](https://neqsim.github.io/neqsimpython/) process simulator.\n",
+    "%%capture\n",
+    "!pip install neqsim matplotlib\n",
+    "from neqsim import jneqsim\n",
+    "import matplotlib.pyplot as plt\n",
+    "from IPython.display import YouTubeVideo\n"
+   ],
+   "id": "setup"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "id": "process_control_basics",
+    "outputId": "c4410583-4819-4aa7-91fa-4767953cbab2",
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 421
+    }
+   },
+   "execution_count": 6,
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": [
+       "<IPython.lib.display.YouTubeVideo at 0x78be30759b20>"
+      ],
+      "text/html": [
+       "\n",
+       "        <iframe\n",
+       "            width=\"600\"\n",
+       "            height=\"400\"\n",
+       "            src=\"https://www.youtube.com/embed/FEnwYVPDRDE\"\n",
+       "            frameborder=\"0\"\n",
+       "            allowfullscreen\n",
+       "            \n",
+       "        ></iframe>\n",
+       "        "
+      ]
+     },
+     "metadata": {},
+     "execution_count": 6
+    }
+   ],
+   "source": [
+    "#@title Video: Process Control Basics\n",
+    "#@markdown A short introduction to process control concepts.\n",
+    "YouTubeVideo('FEnwYVPDRDE', width=600, height=400)"
+   ],
+   "id": "process_control_basics"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "id": "pid_explained",
+    "outputId": "a6ca73b0-f8ed-4a71-f26b-648ca0b5d615",
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 421
+    }
+   },
+   "execution_count": 7,
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": [
+       "<IPython.lib.display.YouTubeVideo at 0x78be3079f4d0>"
+      ],
+      "text/html": [
+       "\n",
+       "        <iframe\n",
+       "            width=\"600\"\n",
+       "            height=\"400\"\n",
+       "            src=\"https://www.youtube.com/embed/UR0hOmjaHp0\"\n",
+       "            frameborder=\"0\"\n",
+       "            allowfullscreen\n",
+       "            \n",
+       "        ></iframe>\n",
+       "        "
+      ],
+      "image/jpeg": "/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAUDBAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIChANCAgOCggIDhUNDhERExMTCAsWGBYSGBASExIBBQUFCAcIDwkJDxIUEA8UFBUUFBQVFBQVEhQUFBQUFRIUFBUUFBQUFBQUFRQUFRQUFBQUFRQUFBQUFBQUFBQVFP/AABEIAWgB4AMBIgACEQEDEQH/xAAcAAEAAgMBAQEAAAAAAAAAAAAABQYBBAcCAwj/xABWEAACAgEDAgMEBgUGBw0GBwABAgMEAAUREgYhEzFBBxQiURUjMmFxgTNCUpGhFlNicoKxCCRjkrLB0RdDRVRVc4OTlKLS0/AlNESjw+FWZHSElbPC/8QAGgEBAAMBAQEAAAAAAAAAAAAAAAECAwQFBv/EADwRAAICAQIEBAMHAQYGAwAAAAABAhEDITEEEkFRYXGBkROhsQUUIjLB0fBSI0JictLhFTNTssLxgpKT/9oADAMBAAIRAxEAPwD8ZYxjAGMYwBjGMAYxjAGMYwBjGMAYxjAGMYwBjGMAYxjAGMYwBjGMAYxjAGMYwBjGMAYxjAGMYwBjGMAYxjAGMYwBjGMAYxjAGMYwBjGMAYxjAGMYwBjGMAYxjAGMYwBjGMAYxjAGMYwBjGMAYxjAGMYwBjGMAYxjAGMYwBjGMAYxjAGMYwBjGMAYxjAGMYwBjGMAYxjAGMYwBjGMAYxjAGMYwBjGMAYxjAGMYwBjGMAYxjAGMYwBjGMAYxjAGMYwBjGMAYxjAGMYwBjGMAYxjAGMYwBjGbenUpbDiOFC7kE7DYbKo3ZmYkBVA8ySBgGpjJsdNWB9uSpF/wA5dqr/AAEhz51NBneyap4IyqZHYyJ4YiCh/EWTlxZSpBB32O474tE0yIxlj1PpO1EzrHxscRyKxH64J5hmrt8e23fcBh9588rpG2QnYaoxjGMkgYxjAGMYwBjGMAYxjAGMYwBjGMAYxjAGMYwBjGMAYxjAPWNsyFyROh29uXgS7Ab/AGG8h5+mQ5Jbs1x4MmS+RN1vSuiLxnrgfkcyyEHYggjsQRsR+IOSU5WYxkidKl8BZwpZG5kkKxChCN2J22A75pRRM52RWY9zsoJOw8+wyqki+XDPHXOmrSa8U1afsfHGbXuM381L/wBW/wDsz3DpVhzskEzH5LFIx/cFxzx7mRpZnJ2v0fqsn6PTL8m/kEp2W3/DjHkpD7LupH246Dq538v/AGdbA/eY8q8+NbyS9SSnYy7N7Juph/wBq/5ULJ/uTNSf2cdQR/b0PVl2+enW/wDysiPEYntJe6FMqmMktX0S5TKi3Vs1i+/EWIJYS222/HxVHLbceWRwB+W+aqSa0ehCGYzIz7T1nTjyUjkoZd/VT5H8MWWUW02loj4ZnPSr6bZsalTMMnht58UbceWzorj+DDIvWiyxycXKtE0vV3+zNPGMZJmMYxgDGMYAxjGAMYxgDGMYAxjGAbel0pLMqQxAcnJ7k7Kqgbu7t+qiqCSfQA5LyTch9H6cjyLIQJZgp8a4V7+X+9VgRuE+4Fj8vn09uat9YyBK8cS77hWMCmSSdVPn38OMEfLJvSnWteg02IAKJFFqTYB7U4Xn4bMe/uwfioj8m23O+/arZZI0X0dKKeLNXluSgbkLHKtCE/5WdQPeCDtuEIXz+I5taxqS9mFf6+xpUauyABYlKncrDGAFBQA7nyXb8ctdHS7DXJWngsQwwhyLUllwlhCnFknjmYqyOWY/CFCg7bdshr+iyJd97VlMA5xeBIskEjwRVmR4o+SlH+oRyDvsdt+3lleYvy0R0160j0K0UIsp7lVkSuyFirFC7yRSKQ8L8uR5qw2/AZtW+n6tnaPdqVwguEtErI5cliJC/ayN99pYzy27MhI3yW0+xRmrwK1gAS1vdY/eVED+HXkjEkccqkqBKBxIZh5bjzOfXqNzBSlW68EkUquKqCvHHx+rcRJEEZuTB2jPIEBRGe532yLJo51rugW6TFZ4XVRttKAWiYHyKyAbEH9+ROWelqVg6VcjaaQxierHGrMSoDidpUXf0IjjJH9EZWM0RkxjGMkgYxjAGMYwBjGMAYxjAGMYwBjGMAYxjAGMYwBjGMA+iD7iR+eTtjVYmiWIVSOAbifFcgM5+1t6+Q7E+maFXVZolCI/FRvsOKnzO/ntn1+n7X87/wB1f9mYzjKT228Wj1+E4nFhi0pyXMkpL4cZeNJuXfyN2hrCclDwrGiENGyqd0ZYmGxIG7c34Ekntt2z5/TZLM7V0dyVaNiD8JRAg5b7lx8IOxPc9zvmt/KC3/PN+4f6hj+UFv8Anm/hlfh63S93+x0/8RhyqPxJaNv/AJceqr+rotux87d55IoYdm2iDAdzseTFvL089vyzofSdq/oegajbrPJTu3dU0/T4p49ksLBDXs3LKRSjuiO70typ+IAA9socfUVoEEyEj5bKO3y3AzoOrTmfTulfE4hrup6hYkCjYeGlqnTgUA9gi+DOB/WbffMOIjbhjaXLKWvXa5focnFZOHnilk55ymkkk4pKkq1ak+lH1u9U9TRm1GvVNuW1TSR56yWroZRCQJwkjoEdk37gHvxbbfbIDVvaH1Skdcza1qirZiE8XG/OpMfiSRBjwcFfiifsfTY+ubF7U4JNSuwU6Mg1C/PZpGWW00kKmzK0UrxwCIMHYMftuwXcnbsNtbq/TJH1CKWWGSDS4pq1CCeZGjiNeDjCJAWALBlR5CRv9s51fc8K1UY+y/Y+dx8RNOpdVetX5KvH6Erp+o6taEMNnqHWPe7NaWzFAbNmWFESKSaMWJHsgq0iRFgFU7B0PrsK/wBKwm4tqe/ftxwQmvG0iSM7+NakMcbuJG+KNAsjsB3IXYEZYYPaLKdZsSNPFDR53BG0VeAHw1gnjqDxUi8R/KEA7/L0ypQ34Ro1qIyL7zY1GrIyEnxDFDXtEv8A1ec2347ZqsONbJdeiKRnndqWl8u2tau+i2R5+irqS34nsNH9HBjYcyScdlsR1vg4/aLNICPmMskEcVeqtwdQakYTOa+1SGdWMqxiQ7GW0nw8WHfb18sieuerIbXjJSieGK1KLNp5injTyhQEiPh9lrx/FxXcklyx77ARVrUIvomtVV95het2JU4kBUeCpHEeRGxJKS9h5bffh4oK1SZoviySbbVvZVtWt6PqXTWNVntdK3GmtW7UQ6jpJSNyZ5ZURdO1Az7cnYISHr8gp234fIZT9F1OCGIKyOGDlmCrGRMO2yMzDdVG3l3HxE5YrVx6/SulFOB8XW9YkPJEcHhS0iMbq4I3G7d/vyo/T03qtcj760H+pM4cMbUkkq5n8nXY+g4HPDBU+ZqVV+VP1u/0MwzVOJd4n8X49kB+r3b7Db/aXjv5d99h9+SsWrwuVZkVfBrkIAgBabbj2IB+e438iN8ifp2T+ar/APZ4v/Dmfp6YeSVx+FaD/Wmayxt9PmdmH7Qhi2lppdQWrWzeqNq3q8UnJhVCyNsoffkAoYHkV4jeXtty7DYntnnqa7JMqP4YWF1Ti3gohLRoFfaQDcqG3G2/yzV+n7H+Q/7NX/8ABmxe19pKorlV3L83YIijcfZCKigL28z5n8MLG4tUvnZfJx2PNjyKeR21f5Erktk6fW3rRAYxjOk+cGMYwBjGMAYxjAGMYwBjGMAYxn3pVnmkSKMbvI6og8t2YgDv6DvgH10uyIZRIU5gB1ZORXksiNGwDDup4sdj89sndW1bTZZ2srWtSSPxYpLOkcXiBVDMfBXme437MPP08s86dpNB5fCFszS78Uj4e7wTyb9kSySxVSdwCUG528t980pNV8JiiU6kLKxUh4TNIrKdiCbDN8QI+Q8sruW2N6HUrmpzQ1CxSu0samKFWESKWALN3Jcgerk5YK8MslG5ZiidnvW544EACLDHxaF2ldyFT4GKAepO2QPTXVE6WomsS7wjkOBXaJGKnw5BBFxUlX4nbb0ObWp1dVNhZZfAreA6Mp8WCKsjo7Sh+DuQ55uzb7HcschosmeNX0NRHUryWoK9iOAj3efxFJkknmd95lUxp+qo3O3w9yMho7l6g7Qh5oGB2eJvsfiY23Vh8jt3z31bKrSQqsqTGKtEkkkZ5IZSXkk2bYb/ABOc8UtekVBDOkduBeyx2FLGNfURTKQ8Q+4Hb7slbFXufDU9Xs2gonlZ1Tcqvwqik+ZCIAoY/PbfI7J8aZXt96MnhzH/AOCsMObN8q8+wWbf0VuLfjkEwIOxGxHYg+hySGecYxkkDGMYAxjGAMYxgDGMYAxjGAMYxgDGMYAxjGAMYxgDGMYAxjOx+we/ounVmuarDptyS3rmj6fFDdWOZqdKORrOqai0DHfwxG8MQJHEs58+BGAcgCnbfY7AgE7dtzvsN/n2P7s6amq6Db07RYbdzV6M+l1poNqtCtZjeWS/YutPFM1uNgd50G2248Md86BpXsxr6jpzaRU1GHhTvvJqFqjGl+o2qT1p5o2sWRKog0ipThEIsdw89ufj2BbKd14On4umNErQWdQs2ydVvwOYaMCK1i1BTeO3Es8kkaf+zXZAG3IcEgb5lmwrJWrTi7TXk12fRsJkIIOl0k8ZdX1/xQ/iCRdJqLIH35c+Z1Lflv33zNpOmbLl59a6gZ/5yfS6s5/f9JE7Z79lHstfXa89gXFgWK1XqBEiSw6NOrObNzlYiFPT0Ve8xLbseIUntln0n2J1WrWvedWEVqrc1SrZmj9x9w01tMkkiH0j7xbjsoJzHzUxxP8AC6dmYkDP7u/65fL9hSu6RT06e6YY9uor0Y9BJoBJ/MxXzn2fpPpsBGPUtkK4JUnp+yAwBKkqTa2IBBHb1GXPUP8AB/ASCCvqXK/PPVigexFWi07UBNC9izJpksFqWxZgrxIzNKYVDcQqjkyqYP216B9H6L0tCJ47IWLWY/GSG3XDEaiJiphvwxTIVE6+abd+xOV+7ZP+pP2h/oLWuxCP010yBv8Aylstt6LoE3I/hzuAb/icwIOkI+zWOoLZH83V02kjfgz2JiPzXJT2K+zGlrlTU7lzUbFVdPauvu9DT5NUuSCdZT43u0LBxCGjVOQG3KQAle2+1Y9mWmQadLHNfl+nfoeTXUg+qir1a9eRVfTLsUn1o1N4/Gk2BHDwkHFue+SuHl1nJ/8A1X0iiL8Cqdb9S0rFOjpum1bNanSluWOVuzHZsTT3PAEjM0MMaRoqVo1CgfMknKbnfdV9iWmPVtJpmpe9anHBBJpsQ1DRZU11vqmuvSrQTePVijiaRlWY8m4/MFc1dO9j2jCjqLza/DPqOmU7Vq7VpS1W91kqU0lasqsWOocrU0cPjxMI1Mcm5JIGb4sccaqO2r1d6t237shuzjutaJZpCsbMRjFurFcr7sreJWnLiKUcSdgTG/Y7HtkZndPa9o2kXtKiuabfktXNC0rpqrcjTwjRSvPV8B44JB8clqO6SXbfj/jYUDdGOcLy4GMYwBjGMAYxjAGMYwBjGMAYxjAGMYwBkx0n8NgyfzMFmXf9kpXk4sPvDFdvv2yHyZ0DdIrsp8lqmIfe88kaKv8AmiQ/2TkPYlbm9rWoSw1qUEbAQyUg7IUjYc3nn5OOSkrJ2HxAg9hnhuGpgHkkeoABWDkJHe2GysHPwpa7AEHYP2O+++/lo1v14hEWFqnWKGAgETwpJJI0kLDv4ihyShHkpIPYjK7hIls+s8LxsUdWR1JVlYFWUjzBU9wckKWg3JhzWBxHtuZZdoYtvmZZSF/jk3R1meOCKWzdlAcMsSRQxSWCkZ4btYlX4FB7Dux7emat2m1/eStaltSDctWssfewB6xDcrOv9TZv6OLFGr9D10/T6hXU/s10ltMPu5IAm/8AazAi0tfOa9L/AFYIIh/3pWOQ7qVJVgQQdiCCCCPMEHyObej0Gsy+GpVFCtJJI+4SKJBu8jkfqgfmSQB3OAStDUaMEiNBVmeRXVo3s2Ayq4YcWMMMahtvPYt5/PNHq0bahdA7f41Y/wD7WyW0ulW5KYKd68ocBpj/AItF8JBPAIG2Pl9p/luM+HWOmSiee2oLwSzyOXCkGF3cloLCecMyk7bHsdtwSDkLcl7FbxjGWKDGMYAxjGAMYxgDGMYAxjGAMYxgDGMYAxjGAMYxgDGMYAyydLdbajpkbQ05YUR38RhJSo2SX4hdw9qB2UbAdgdvuyt4wDoEXtg15QQLFLZhxbfRtEPJf2W3pfEv3HtmP91nVG/SwaJM3lzl6d0Itt8t1pjfKBjAOzdG+3I1lcajo+mX2DxvX8DTtE09ECBuUMyrpchliZuDbqUYcOzd+0Lr3to1W7ZmtTVdCZ5ppJjz6e0WZlMjl9hNNVaR9t/tOzMdtySe+czxgHQ6vtd1SJ0kir6HHJGQySR9O6JG6MDuCjpUDIQe+4Izc1v25a9eZXunTLjovBHt6LpVpkXffijT12Krv6DOYYwDo9D2yaxXcS149HrygECSDQdHhkAPmBJFVDAH5b5839repMzO9XQnd2LO79O6KzszdyzMau7Mfmdyc55jAOhR+1e8P+D+nSd99z03ooO/9msNzk3R9u12CnNWi0bpmOWwvhS249DpxyvVLpI1V4UAgkiLxxn4kJ+EfIEcixgF/ve1O7NDNA1HQVSeNo3MWg6XE+zAjkrxwgq433DDuCARlAxjAGMYwBjGMAYxjAGMYwBjGMAYxjAGS+n6OSgsWCIa3chmYI8/EfYrqQS7E9uW3Eepze6Q00N/jDrG55mKukv6LxVQyzTzD1ghiBcj1JQfPPWp6rRlkPixWrR+z701kRSMo8vDgEZSKP5J6DIbLJH00qXTZfqkrCKwe0Ulud5oHb0jfw/D8Ik9g3cbnvsO+bhtJGXg8OvuGHiV10t2POPkAH5yBuQ5MN9/U98hLmi8zA9LxJ4rIfw1ZR4sbxbeLHLx+H4QVbl2BVge3fJycXXpbTGeOaqjFJFkJSxWQr4iEo3EzxBgwJ7lN/2QcqyyIjXqprPWtV1lrCZTIiEurwTRuUkRS3xcdwrAnvtIPPbNmisGp8vGK1rMUbSvOir4diOP4pOcK7cbAXc8l7NsdwPPMaYht1rVbk0jKvvkBduTiWNfr49/6cW/b1MK5o0fqaU8vk9phVi+fhrxlskfd+hX+2ckgm9LppZME9dYpa1JXEtay6Rsm7MyySuQyvzLctyOIKFSNgN99qel2ZvAlgtadcjQvvGsfGXwkMjMqJ8O5VWYFQoPoc1tNm+iq5lWRSxEqnjxZLVl4/DEC/zlaBWZnfyLtxG/nkVJ1bMaz11hiTkjRB4+YCRuQXCRkkRkjcfCQNmPbIpvYm0tz49a6lXszI0CsSsapJOxblPxVVQsH7lwq93OxYk9hsM2ekfdXrWoJ5FiMstfdvGSCQxL4jMA0iMrqHEZKdu+x37ZVc9ZatKKXrZ1Kzc2hhj0+OtJG87VFlaNZYYErr4kkjCTfseTPyYdxGzebDb5UxX98MgtTzXJk5NG3wrJGsPiAzQ1ouLRmJQeBbsCB55W+l9VsVKVuQNvATHGkToGhlmnO0nMEfGPBikBG/6wz66V7yYpba82uXneKJlDjw4YijTyjwx8G7eHGvlsA/yynKaWQHUE8MtmWSugjhZgUQLwA+EBuKcjxXlyIG/kcjsn+qo/EEN0Kq+8KUsBAAq3IiVmBUdlLLwk2/pnIDNFsZvcYxjBAxjGAMYxgDGMYAxjGAZxmdsnKnSuoSwieOrI0RRpFYAbtGp2Z0Tfk6Ag9wCO2RKSW7IlKMd3RB57jUsdgCT37AbnsO/b8Bltr+z+65ID1SYxvZVZhK9McXP+MJEGYN8DDigZtxttvm90z07a07VKbWI2EEsqwrY4sIT7zG8YVi4HhybP3jcBhsdwMzeaNOnr2MXxEEnTTdXRR6td5XWONGeR2CoigszMx2VVA8yScw8ZVyj7qVYq3bcqQdm7A9yO+WToMFJNQlA+ur6dbeIr9pJDwgaRdvVY5ZW39Nt/TN7Sp9Er14FsQvasWIpDPKkh2p83khCrD2EkqIiSA7+ch37bZMsjXS/ISzNbJvyK71DozU3T41mhmQS17Ee/hzxMSA6g91YEFWQ91ZSDkTlo1g/+x9OVj8ZtX5IwT3Fciqm+2/wqZY5dvvV8rGTCTa1L4pOS17tex5xjGXNDOM2KlSWZisUbyMqNIwRSxCIOTuQPJQBuT6ZIdPaI1tinNYt/gikkVhC9hv0UDSgbRM4DbFu24G+2+4hyS3KuSW5DYz7WoHid45FKPGzI6MNmVlJVlYehBBGfHJLHrMZs0qkk7rFEjSSNyIRRuSFUux2+5VJ/I5tQaJaf3XhAze+llqhdiZikhibiAdxs4I77eXyyyi3siJSit2iMzOWh+m5oUsRWaxilgarPLZMyvHFTmPhchHEW8dGeaBg8ZOwUj1y33emdNtSyiqzTvHo1eQSJGtejHYWonGSxKHLRs6xyNxcL9YVDHuc2hw8pefZ+v7HPPi4R8V3Wq6ddupQL3T9iGpFcfw/CkdU2WWNpUMkZli8WJTyjDxgsN/MDIfJu7fmOn1a/KuIBPYk8OMjxml2jUy2Rvv8AYYKh7DZX277kwmZTSvTsbY3JrWt+nY84xjKFxjGMAYxjAGMYwBjGMAYxjAGMYwBjGMAuvSkZlqcE2Lr9IwbbgESXKsQr7k/ZDtDIgJ/WIHrlUbT5w3Awyh99uBjcPv8ALjtvvm708biNLLUjlkEUTPZCRNNGK4+2bKBSBD27ltgOx3GTS35rqj3S5PXn22ai1qYRvt/xSR38j/NMdx6FvLK7Ftzd0ei5gGkLuL9pZWWMK7skkstUpXk8JWKO8ddiQR25KG277T2i9EahQW1HaiMfuZNzUeSyCGGokUlfwjIVCvPN7w/ELuPqxue+edD1XTqMUun0YNSGp2gguXbHGvNJWjhltWaVWGI+JU8aRIYi3NzIgb7PLjml/LDVtSrrS1Es2lVo33DiWOOuEjfwvDkZt2lVmCqDyJ7Dy8r8sUtXfXTY4nPiJyuCSjdfiu67pL6MjNJpSxSCOMVpbFSWQKjSND4RhlIMsu7BWLAeZHHiw3J8s++uaGk7QpGyJWqNI0zodwlKdmtxWQfJ91Z49x5tGg9RmvNqMslaCQNUVbKnxxaQESWavCFn5cTy3jMLbHsCW288XtQiNIGeGCURzGqzU3MJEciCxCIpQCCisJAY3Vl8ttiN8y1PQ0IvUdbpTlC9KTaFPBhjS0UiESsxTkvhluex+IhviO57b5qjWok/RafSQfORZp2/fNIR/DHvmnJ9ilNKf/zFo8R/ZgjQn/OzP8omX9DVpQH0ZKyyMPwawXIP35eiln3g1S3IPqaVYj/JadC/8fDOb1Z9ZbulYRAfrGhUrj8neJR/HPfRIt6xqENGTUZ4DYEqwkM/Bp1id4IQiMqqZHVUBA82GTvW3T71o49Y01Gs6bMqR24bO173CyducE8jr8VaQjnFY+EsGKkh0YZTJJQrm2k9H0vt5voXhFyTa/u1fhd6vwItLG8LRaxOjpz5wrHZE06S8DGPqq7FVhG+532PbtuTm8lmnGkUU0UDkRqteNHse7ywuzPG6oSzTkszEllGzbg/ZyvVNM024eaWvcZD51JF5rz/AMhYd1UofQOQR5bnzyTm0ZyYh4E6R14jDEsvuL8wzvI0jNNNw5FnOwCkAAdz54dBWfAmKaeaoFSNbqfVxxoqRw2YEJruo8RmBYhozuF7SnKTl5nnqVGinck2IJBJFWinrS8mX7PjNVhWOBN9iQGdj5dvPKQ7bkn5kn9+WiUkecYxlioxjGAMYxgDGMYAxjGAehnTOjdZtGlYmYVVhq0bFU2VWJbinwd6cbOTyCmRlClQNzGQd9s5ll/0f2dPNo7apJa8EyQahYqQeAzpPDpb1ktNLY5gVzzsqqDi3JlIPHcb4cTLHFLndW6Wl6/+kzPLi+IqK9qXVd6fYNN4YWQy7QRx1uUrDYyv7uq85SCfiO57n5nIaSRm33YnkSx3JO7HzY7+Z+/Lf7M+kGv6nRgtQWhUn8edmjikDWIKcEtmZK78dmd1hKAjfYuMwns91m1J4lbRrsUNhp5KytDMsXhxsOUcc9gL4pTmidzyYkDuTlfvGCEnFtKkndpLW/2ZaONR2XsVjS781aVJ4JGjlQ7q6nuNwQQfQqQSCD2IJBzXlYkknzJJ8gPP7h5ZcG9l2vL7z4um2IPdahuyiwogPgBGk+ASEeJLwR28Jd34xudtlOZ0r2YazZltxJVCtp9T3y6ZJoUSrFwLqth+W0U7BTtE2z/MDY4+94FcuePna/nVe5fl1utSlb5jMnMZ0kGcZ96VdppI4kG7yOsaDfbdnYKo3Pl3IzqPtF6Ii0uvbj+hNTHu0xqLqs96MVpJ0l8J5YqiVRziZ0kCgOdgV3OY5uJjjkoPeW2qX1a9lbJSsrHTMTyaVfSqC9kz1nnjT9K9GNJmfZftPEJfDLBfkpPYZsdSdam28tWJY6+nScIo4zFw8FFljkSYrCfjmjClQ3c8CR33zbp+yPWmUPxqw7ymAc79QMLCxGeeu4jkbwZYYFaSRX4lEG7beWetR9l8un11sazdraWLBl9wV0nue/xxRRS+PXkpI6e7sJ4gsjEBuR9Ac5fvPDuX5k3eiWr9Erb26LuY/dk5c0vNeBVet9Qit37U8O/hSSEoWHFnAAXxGX9VmILbf0sg8zjO+KpJI0jHlikuhZfZ74y2zJFUnuKsFiOZK4PiJFYry12kD8WCMBISCw23G3rknZ67RY446+n14DWhsVasrSTySxQ2RIJS/wAQR7BM0h8TiNi3YAADNXqOVq2m6XUjJRbMD6hZ4nbxpXsTwQ+J+0I4oNgD2Bkc/rHKmoJOw7n0AzqeSWNUn4vbrTOVYY5ZOcl4LV9LWuta69NiSsa7bkUo0zFDXjqFewBrwuskcR2HdVZVPz7ZF75t/Rtj+Ym/6qT/AMOY+jbH8xN/1Un/AIc5XlT3fzOpQS2Rp4z6NEynZgVPyb4T/HPPA/8Ao5NknnGeuB/9HC4AxnVOqOkRNvBFFWhmhcNC0eytJRFVZZpJoo+Uj+G/DZypd/HI77doX+R/usckkh8WxVnrtJCYz7v7tK0Jilcy8WkVzLxMa7Mu2zAdyMFxEGjlhxcJLx7FUh02Rq0tscfDimhhYb/FymSV1IH7O0TfvGaG2dKopp1avqFOw3KZdTrxS7yiCLaKxZi8auiAngkbMTuTtyX0A3R0unpNzZt7GSxKZZ1adrIc23VOMSxeC1UwAOX35budh245Hx6btP0RC4mm7i2r0peCOb/hkzqugvC1eJOc1iWtHPLEiFjD4/xQp8O5ZzE0THsNjIBn16jtUJo42qwCtKs06PGnimNoBwNeQmV2Il7uG28+IOwyf1vrGWvLam0+wijUlrSeJHyS1UEMZieqxP2O/bsSCEQgj0tKcnVLvuXlObrlXo/T/wBlc1PSkWlXtxF9meStaR9t4rMY5jj2H1bxsCAe4KSD0yCy2atqStppEkyTWr14XJFQD6pYkmi3l4gBZZHlY8R6LuftDKpl8bbWvc0xNtO+55xjGXNBjJDRNItXp46tOvNasSsEiggjaWV2PoqICT+Pll7/AJIaPo/xdQXjauIe+iaLLDLIjDv4eoat8VeodwQUhE7j14nAKZ0p01f1WytPTqk92y/2Ya8ZkbbsC7bdo4xuN3YhR6nLo+jdPaGdtSnbXtRTs2nabL4OlQSDzjt6sN3tkb7FKqhd1I8XNDW/ahqDxirpoj0PT0dXSlpPOtyeM7xy27fI2L84+E85XOxG4C5LR6np/VIEeovBpfUGwWLVm4w6dqzeSxauqjjTunsBcUcGJ+tA/SYBXuqfaNqV6E01eLT9O9NL0yIUqH/SRRHlaf8ApzNIx+eU3JTqTQ7em2Zad6vLVswnjJDKvFh8mHo8bDYh1JVgQQSDkXgE1R1+RVSOwi2ooyPDEpdZodu/1FhCHi77dtyvbyyXhu6ba3NufUUKlWRJ7JsRnffkA6wlk2/DuD55T8xkcpKZ0F7umOsam/HEkQYRwwaZzEYY7nhJYBZ2OwJZu5OQHUWoVTE1eq08wewLEk0yRxblY2jVUij8h8ZO529O2V3GFElyGMYySpt6dbkrzRTxOY5YZEljdezI8bBkZT6EMAfyy/6r7QpKmpzXNIkQV7iRT2acsReqJrMSPqNJ4ZPhkqtOZlK/ZKsNu4BHN98k59HsJSivFAa0081dZFZW2mgSKR43Ud0PCVCN/Mb7eRw480eVq090QpfDmpxbTacd6tPo++xIaJ0zc1M2GqxRhkgnuJWUlXnihbeeOkj7md4kLOYwS3CNz32yunJzpXqGalJGyO4VJUmQo5SSGVDuk0Eg7xTLt2YfgQRl41mDR9ck5tPW0nVpRzE5Hh6PqTHfd5kTc6NdZt+Q2MBbc/Vg5jOcsbtq4+G6fit68Vt10OyWGMsanB/5k90+/in/ADx5TjJLqLRrOn2ZaduIw2ISA6Eq32lDoyuhKujKysGUkEMCCQcjc2TTVrZ7M5DGMYwBjGMAYxjAGMYwBjGMAznS9D9rVqpp9DS1hD0a9fUq92s0n1WoLqMkz7ybJyjMfioV2J+KFWzmmZzLPw2PMksitJ2vOmr86brtuiU2jser+2zWLHuL1RarGrTanJAlydtPmVqQpeJFRjVBXcLu4+Ntn4kbBQMhNV696gs1Y6zg8UrVajSeDI0s0VKxFZq+I0hYeIjwp8ahSwHxFsoyavZACieUKAAFDsAAPIAb9hnk6pY/npP89v8AbnJD7OwwpKEdNuvVv6s7U+Gr8Tm36IunUHX/AFBasS2GkkrmWW1O8UEbJD496p7lcmCPy2klg3UnftyPHjn2g9p+pBbkdylQvLf93ewLNRovFsVfFEVqUUnh8ewfGfkZOQc7FgSN8oy6xZHlPKPwdv8Abn0XXbY/+Il/z2/25p9yx0lyR0qulU7XzJvhn1mvRP8AVHqnpM1gSPGqllO5iHZyG9UXbuo+Q7j5ZsnRoU3E9uOOUbAxqjyEE9tmZRxBHrsTnvTeqbUZ+J2k+JSSzMW4g7lAd/hB9SBv2yQsaBAqe+PJKYyviiAqBKULAAlwSAvJh8W3kQdu+WlOUXUnXatb8D2eF4Lhs2LnwR53FN5Od8sYxvfRpv39GQa1Z6tkFV5PBKrAhSylo2Dg9vNTsD+GX+713Laty2INA0mC9csPZmtzQ2rT+8zSmaSSIXJ2irgyEkBU+HfscodvqC07syyuik7hVZgqj0CjfyA2H5Ypa9OsimWWZ4wRzQSspZfMjfftvkZMLmk5JWl3fzWz9TzUuC+LVz5ebslpffXp1OudH2NXllssbdbT2SfUupLliVrEdesQiVpJoVpxySfGLjQiMKwYOAR2yd606Pe7Thuap1JpNipAsNqCaezrLqsetSStE4CaWXAkalMOH+9+7lSF2AyB6J6kFbTNTsmGlcu26VKpXq3YhYqyRvqbXLXNC6oBGtWr8LkdyvnscmLF/TNR0u3DqfUhhu6hJpEjKdJiFehDpcVwLRqwULXhiEPbPHiFGyHcbtnVDhlFxlyRTSWvKu2tOvF9Tt45Thla4aH9nS5XKMW2qWrbVPUqdDoyJ6wNWWimpPRs6nXoT1Lu92hVNhmnpW7G8U7tDWllVGRCQjD7Q45zvqsA2fhRVHg1z8CBAS8EbseKjbuWPlna9f1vQdPqUvo7VPpLVKuiT6HBZlqT0qtWK1YvvZuKjBnntmvdaBF+wnxuSx4gce13XplmKQWGMSJCi8GbhusSI22+3bdTmuTm5em68O5zPXDJcQ+XVUoqLez6WqRYOo9a0d9JpxwQTTX1qtUKTnmlFBaew0yyqq+NIxdlQeSI7b7nbPfsKpSx6rDcC7CKnrEsUoKkxWINIvSwOR3Mbq6KykjzUEeWU7+UFv8AnSfxCt/eM6R7L7ss1TWZ0ilmatpE0QZIy0j3tSZaFaOGOIb/AApLYb1J8Jj2A2zg+08854mmkrXLp46fqcvCcHwGOE/7TI3TauK1k3ovzPT0JLp/XddsR6aLHWOsVbOrbijAJLs8exsyU4zYnWwphDTxOOyPsNj38sxW1Hq1noK/Uuqp71HfsWCbttvcqun2JoLFh9pPrU+olK7bcioUdyM+curdQQxaVX07TNQihpUYITK+hrNPFZMkstmarNLAzxnnKSpVl7qD2PfJbqzU7laW2+i6b1AJJaFXTqtmXTp6hoVa80UjJCFDvI8ojJeQlSXlkIHfN1j4Kto+y/n0PmJZOM5qV63XgraV6KtGnu7pklpVjqB9UEEuv3X0oVaF1rN2vXnt+BqTRQ14hXtrIrWDYnWM/EVHFjv22yK0y/rcpQWNX0mm0+pz6bUFnQqLtakrskcjoa+nuQokmiX4gBux+L4TkRrnWutv4oj06+zSQaFGZ7kFmScTaP8AXMx7bFZLJdiCfIL675XOoerrz6tQ1C5QNaCjYhlhoxRS14VRbPvcqxmcE85ZWkdnbckv8gAKvhuBe0IN+S7/ALFsa41/mdaeF6LxW7bryRfKnWFqvrGnUotZrXJ21WtUtR1+nqFOJU96SKVRZaASNud12VBuCe+cd6+C/SupFFCp7/c4KAAFX3mTioA7AAbDYZJdD3DY6k06wRsZtaqTEeexkvxuRv6/az59Z6xMmpX12iZVu2wA0EJ7e8S7bnh3P55hHFDHmfwoxSrZadT2eFhHkrNKV96T19Kr0Ia/rVmawbTOUmYKOcX1RHGNYxtwI2+FR+PfPjZ1OxInhyTyvGGLhGkdkDk7lwpO3In1882m1eN/0lSu34B4z+XhsB/DMe90W86si/1Zx/8A6jOdC0/u/Q6FweF/lyQ02tST+jXzIpjv55kD12O2T9mvRRInKzgTKWUB42IAdk7/AAjvuub2iTUeMqsrGDYGUytECPPiY9hzL/IKfx7ZV5aVpM7MH2TzZFjlkgrV3e2lpvTRUU85jPrNtyPH7O54/Pbftv8AftnzObnkyVOjGMYwVGMYwCxaN1pqlKlNp9O5LVrWXL2FrcIJZ91VDHNZjUSyQbL+iL8O57dzkz0FoNDWKsumptW18SmbTZJJitbVVKgNpTiQ8K13deUL7hZGdo27mM5RMkundZs6dahu05TBarOJIZVCMUcAjfjIpVuxI2II74Bta70teo1qdq1CYYr/AL2K/IgSFqVg1bKSRfahdJQQVYA5B5+i9W6j1j2gtoNDU9LNSKBrlmfWqlOcCSBoWkt2jGVEPHaujEKSWddl7sBnBda0a3SZUt1bNVpF5xrZglgZ0325osqgsu48x2wC69JdXQXq0eidQSM9ALw07UyhmuaFL+o0bfbn0sntLV3IA+OPiy7NVes+mbekXJKdtFDqFeOSNhJXswSDlBaqzL8M9aRNmVx5g+hBAg86B0r1dTsU4tF19JpaETMaGoVwG1DRmlPKQQq5C29PZvieqxHcs0bIxPIDn+MtnXHRFrSxFPzhu6bZZhS1SmxlpWuI3KBtg0FkA/FBKFkXvuNu+VPAGMYwBjGMA9DLz0+TL03rUZ7itf0i0g7/AA+It6rIR8gecQP9Vco2bNaaYJLHG0oSRQZkRm4usbc1Mir2ZVbY9/I98tHf3M82PnS6U0/Zp/NaGpmd8xjKmhMVtNE8POJy86Al4T9pkHk0X7XEea+Y23G432s2kdNaXqkUUVC3JS1bgq+5ak8Xut6fbbjSvqFWvM5HwwzqASwAkPbKRXnZGDoxVlIIIJBBHkRt5HJHUNQisR83QpaBG7oBwmHqXXtwk+9ex9QD3NcsOaK5W016p+n88GjsXwpw7SS26PxT6Pw2Zp6nRmrTSV7EUkE8LtHLFKhSSN1OzI6MN1YH0OauXa71lHqNFq+rV2s3K8Kpp+qRMFuIE2CVbzN2u1Au4Vm+sj2ADFfhyk7ZXFKTX41TXs/FHI0ecYxmhB6xjJrQ4I0SSzMNxGNoVYbrJMduxH6yqO5Hl5b+exrJ8qOjhuHeafKnW7beyS1bPjFodllVlQHmN1XmgkYejCMnkQfQ7d8j5ImRirgqwOxBGxB+Wx7jJigjSs1uySYlO5LEgzOB8MSbd/lvt5D8sjdRtvPI0rndmPf0AAGygD0AAAA+7Kxk26f88Dp4rDhhiUoqSbeibTtd6pVfTV9TTxjGaHnDGMYAxjGAMYxgHsHJzXbMhr1A7MWeN3bdjuQzlQD920a9sg4/Mb/MZK9Vn65V9I4YFH3bRISP3k5nJXJe56PDTlDh8rT0fLGvN3/4kPjGM0POPoGPzOb2jeAZR7wxWJQWbbcs3EbhF+TMe257DffI7PQxdOzXFNxknV09nsXfUtRjngheSHeqymM+ENjVlRmA8P8ArR8CVbs3c+Y3FLkADMFO4BOx223G/Y7enb0zc0rUZa5PHZkbs8bDeORfky+v4+Y9CM2dY09Ci2a4PgudnjPdoJCN+BP6ynYlW9QCD3BzWcudX1W/8/lHpcVllxkfibyitVWtUlafVeHTyIXJnp7qfUdPWZKN63TWxw8cVZ5YPF8IsY+ZiYE7cm2/rHIcqfkcZi4qSp014nkUTzdaaue51PUCfmb1r/zcJ1rq6ncanqAI8iL1oEfmJcgMZX4UOy9ibLR/uia//wAt6t//ACVz/wA3Nun7VOo4fsa3qnnvs92eQfukZspmDlXw2J6OK9kLL/8A7svU/wDyzd39D4i7g/MHjuD9+USWRnYsxLMxLMzEksSdyST5kk7588ZOLh8WK+SMVe9JK/YNt7mMyMxmVzQhExrnaCl/zBP755jkOTkz1B+hpf8A6f8A+tLkMczxfl9/qdv2h/zvSP8A2oxjGM0OIYxjAGMYwBjGMA6N7OvaXe0ypqtY6lqkaz6S9TTo4bdgQ17LXaUviKglCwfUxWBzUbjnt6nKTrWs27riS3as2nUEK9meWdwCeRAaViQCe+R+MAYxjALT0N1rZ0ozRBIren2wEv6ZbUyU7iKd1LqpDRWEJ3SeMrIh8jtuDNdSdFV7daXV+nmks0IlEl7T5SH1PRt/te8KoHven7/ZuRjbbYSCNvPnmSfTmuW9OsxXKNiStZgblHNE3FlPkQfR0YbhkYFWBIIIO2ARmM6frWiVeoq82qaNAlbUoI2n1fQoRshVdzLqejRju1P9aSqN2g3JXlH9jmJwDGMYwDOXj2HtvrlKEjlHa8enMh+y8FuvLBKpHqOL7/iBlHOXP2L2IodcozTOkccLTTF3ZUUGGtNIu7MQN+SqAPUkD1y8PzLzRz8YrwT/AMr+hTpfM/cdv3ds8Z6k8z+JzzlDoQxmcyFPyP7sEpNm5puoSV35xkdxsysAyOp81dT2ZT8su/SPU8UCS11jrT07DeJZ0jUF3ryOF4mSrcUiSpY4dldSp7AEsOxo9bTp5e8cUjj+irH+4Zt/yft794iv9Yqn7+RG2UySxyjyTprz28U+h6XDY+IceX4blHtTdX1T/iJ7qfQtLkrtqOkXQIlK+Npd50j1KqXbiPCYAJqMG5/SR7OBtyRfPKZk9p2lzwuHZazjyKSTQMrKexB+PcH7wQR6ZcOka1GAzi3DFPplqLjehRoZb9MxnlFa06ddyJUc77HZWUssg2IYZRl8ODpuVa11rsu9e/fuXh9k55xvlprdPTTuUXSaCspnnJWvGQCf1pG8xHHv6n1PkB3PoD9wr23LNtDViHc/73CnmFQfrOdjsPNjuT6nJj2iaJLTngDOk2lTLz063V3atYq8tmePlsVsA9pI32dX3DehOjevUnUIoseEm/CNfDQDsAWY/Fzc7dz/AHDtlFk50pLr8v8AfudOGOHlcU1Uau9Hkl49ortv+kTq9/xnAUFYYxxiTf7KDy/tHzJ9STmht92S3vVMfZqO33vMT+8Iq/356+l+PaKrAg/5vxD++Utmyk0qS+hx5cUZyc8mVNv+lSforSVLwZEcT8jnkjJ2hq1h5EQ+GFLKO1eAdtwP2M0uoSDan2AA8VwAoAA2byAHYZaMndNGWbhsaxfEhJvWqar21ZG4xjLnCMYxgDGMYB7U+R+WTdrVq0rmSSoS7faPjMATt32AXsPzyEzG+VlBPc6sHF5MMXGNU6bTSequt0+5Me/0v+J//Of/AGYN+n6Ul/OWU/3EZDYyvwl4+7Nv+JZf6cf/AOcP9JMDVKw8qMP5vOf/AKmZOsx+lOsP+tP98mQ2+N8fCj/Gyr+0Mv8AhXlGK+iJk68w+xDWX/oI2/iwOSXTesySTiBxDwmBjIEEIAY/YJAXvs/E/llWyV6RX/HID6I/iE/JY/jYn7gFOXx448y0Ong+P4j48PxPVpVsmno16nt9ckBIaKu2x2714h5feqjMfS0J+1SgPzIMy/6Mm38MiZjuzfif788ZX4cehzS4/Mpb35pP6omBcot9qrIv3xz7D9zo39+ZZNPbyksJ9xjjf+Idf7shsZHw+zfuPvzf5owf/wAUv+2iX9ypnytsP68BH8Vc5kadVPleiH9aOYf3RnIfGOR/1P5fsPveP/pQ95/6iY+h4f8Ajtf/AOb/AOXnoaGp+zarH+2y/wCmoyF3z1yP345Zdx94w9ca9GyWOgSfqy12/CxEP9JhmB0/Z37Kjf1ZYn/0WORO5+ZxzPzP7zip917ErLwvXHL0kv1iyc6nhZFqqw4ssHEruN1Ikk8x6b9j+eQZGGOYy0VyqjDisyy5HKKpaaXeyrel9DGMYyxzjGMYAxjGAMYxgDGMYAxjGAMYxgG9oup2KViG1Umkr2YJFlhmhcpJHIp3VkZe4P8A986Otej1ZuYEr6b1M3c1kKV9N15/U1lOyadqrHv4O4hmJPHw2PFuVZkHbANi/UlryvDPHJDNE7RyxSo0ckciHi6OjAMjgggg9xmtnUaOu1OpIEpa3YjqavCixafr0+4jsoi8Y6GuSAFmQABY7p3aPssnJNilF6q6eu6XaenfrvXsR7Eo+xDIw3SWKRSVmhYd1kQlWB3BOAROMzln9n2jwXHvrOrHwdK1C1CVJXjPVgM8bHb7S/AQQf2slKys5KKt7Iq2MycxkFiz6JQ2r+MldLEjyFfj+xEqAEk/EBuxPr6IfnmzytDylpV/uQ1tx/aTdgfzypKx8tzl8032aXfAjt6rNX0KjIvOObVHeKewm/2qenRq1q0CPJljCH9rMXibbbfyPZx/acMcYqEZJpJaSq31eiT18WyHtB3G02pIR8uUz/wVds0jSq+t3c+u0Uh/idsz1QmnpKI9Ne3NCi8XsW0ihaeTfYvHWiLeBF27Kzu3fuR5Z8NK08SBppW8OvH9t9tyx9I4x+s5+XoO57Y5OVb/AE/YiHFfHny/Di33cpuu7b5kqRIadpNaVtlsSyEAk8YQqgD7TM7yDio+ZGadyZILH+JSSbL2EhOzMe4JXbbZfTbPq9ySwRXqx+HESNokG7Pt5GV9t3Pr8h8hntpoqY2j4y2vWbs0cJ+UXo7j9vyHp88rHmjK7d9F+rOnI8UofgUYqLtzXNq+0E22/wCbErBrktHT5tOn/wAYitulh6kpBjrSoQY54u3KGyy7qxQqShAbfcbfHpyK1fkaDTtMSxKsZk8KKJppeC7AlVdyzncjsNyfllWldmJZiWJJJJ8yT6k5mKRkYMhKspBVlJDKQdwVI7ggjzGT8DRtVb18L8rR58uPknWNJRWi0Tfq6tt7ktY1ixGxQxQxOjFWRqsIZWB2KsHQkMCNtj3z4/T9oeTov9WKJf8ARXLlB1FS15Fr65IK2ogBK2vhC3i8RskOtRxjlYj22AtKDKnbkJB5VPq7pe7pUwhuRcPEXxIJkZZa1qE/Znq2IyUsQn9pSfkdjuMpjlFvkmkpe6fin1XzXVFPv/ErWM5V4OvofH+UVv8AnnH9U8f7sjXck7ncknck9ySfM588znSoxWyMM3E5ctfEk3W1tujzjGMkwGMYwBjGMAYxjAGMYwBjGMA+1eJpGCIpZmOyqASSfkAPM5MzyLUjaJSrWZFKyspBWFD5xqw7NI3kxHYDsPM5CxuVO6kg9+47HuNj3/A55OWTrbc6MWZY4tpfifXsvDx8TycxjGVOcYxjAGMYwBjGMAYxjAGMYwBjGMAYxjAGMYwBjGMAYxjAGMYwBjGMAYxjAGdB6U61glrRaRr8Ul3S4+QqWIiPpLRmf7UmnyOdpaxPxNTk+rbbdTG3xZz7GAWjr3pGXSZ41MkdqnaiFnT9Qr8vdr1RiVWaLkOSOGBR4m2aN1ZWHbc7Hs/1CCpBrM0kiLK2lS1asZ35yS3J4K8vAbbHau1gn7s3fZ/1VW93fRNa5vo1mQyRzoviWNGusoVdRpr5sh2UTQDtKg/bVCNjXfZRqNOvNOwNhTaowadJSRrVbV4rotlJ6E8f6YD3ZR4YHMGXZgpG2Wjd6GWeuWpOk2l81p67HO2yzdEdFXNWMrQiOCpWUPd1G2/gUKUZOwaxYIIDE9ljUNI57KpyzJ0Xp2iAS9TTO9wfFH07p8sfvu/mv0rcHJNLQ9vqgHnIP2Y/PK/1x11c1RYq/GKlptZiaelUlMNGruNi4j3LT2SPtTylpG3O7emVNSwp1No2g9tChOp6mvYa7qUCiCu/85pOkyAhHHbjPa5OPMRoc5/rGq2bs8lm3PNZsTMWlnnkeWWRj6vI5JbNHGAS+l0kKmeclYU7bL9qV/RE+R9S3kB+QP1Z5brCONRHDGDxQfDHCg+07MfP03Y9ydvuGfCjqnCPwZI0mh5FgjcgVY7AsjKQV32G48jsO2ZvaoGj8GGMQRbgsqksXI8i7nudtzsOwHy375g4yvbyfRf7nsQyYI4UlKlX4opPmk+11Sj6+ln1u3UhUwVT2I2lm8mm+4DzSL+j5nzPyEM2MDNYxo8/iOIlldvRLRJbJdkecYxljnGba3pNoVZjJHAxaOKQs8S8mDuBGTsqsR3A23zUxikwX/WqekanVlvUPC0q9Ahlt6VLKRUsr25y6RNMSwcE7mpISwBJRmA4jPSekV9P0+TWtRiimMyzVtGoy8WW1ZKmOW/NGftUq25237STcFG4V9rN7L+sNZMUty9q1uLQ9MWJZxvFI9mTiRV0ykJ42HvEnA9/KONHc/ZAMPr/ALbtetTvKJqsURZhBWGnadLFVh5EpXh8esxWJd/n3JJ8yc8e+Jcnigo8qerc3df03yXe3fTrqjT8O7+nz3OaMM85O9WdV3dVaJ7skUjQqyx+FVqVQAxDNutWJA53Hm25yCz14OTS5kk+ydr3pfQzMYxjJAxjGAMYxgDGMYAxjGAMYxgDGMYAxjGAMYxgDGMYAxjGAMYxgDGMYAxjGAMYxgDGMYAxjGAMYxgDGMYAxjGAM+1eF5HWONWd3YIiIpZmZjsqqq92Yk7bDN7pnTEuW4K0lqvSjlbaS3aZlggRVLvJJwUs2wU7KoJYlQO5y8WuuaWjo9XpaOaKVlMc/UFtUXVZ1PZloRoSuj1m7/YLTMCOUg+zgHiP2cQ6eqS9S6gukFlEi6XDF77rkikchypKypQDDfY2pEPrxOW3W+vPovputB0+tvR4tRu2wJGuvYv2atWKKGSxNMAqVHlnkZdqqxjaFgS3cnmvTWj09QDtZ1datySbZY7FS5YE5bbZzYrLI3iM7EbFCfvO+df6s0GnWiSt73oT6hTpx6ZFBcuxmDTECGS3ZaKSPaxfmsT2HAK7QgjcM4+HbHBtNnm8XxUFOOOnvb0fTxqqTad+Hc/PLkkkkkknckncknzJPqc+eT3VWhwUjGkeo1L0jBzKKfjvFAQQEUzSxIsrMCT8G4G3c5BbZk9ND0YSUlaPOMYyCRjGMAYxjAGMYwBjGMAlLWt2palei8pNStJPNDAAqostjh40h4gF3YRoN2JICgDYdsjMzmMKKWiQMYxjAGMYwBjGMAYxjAGMYwBjGMAYxjAGMYwBjGMAYxjAGMYwBjGMAYxjAGMYwBjGMAYxjAGMYwBjGMAYxjAGMZkYBjGT3U/Tr0YtNmMqSpqWnpfjKKy+GDYs1Xifl5uslZ+47HcZA4AxjGAXDpPqWDS6k01aOT6ZkkMcNtghjoVDH8clXvuL7sSviEfVqCV+JtxVZZGYliSSSSSSSSSdyST5nfLV05oNefQtavyB/eKFnR44GDkJwuvdSdXTbZifBjIPpxPzyo5bmdUUjiipOS3e7/Ty8DBOYxjKlxjGMAYxjAGMYwBjJDQmqrYjN2KeasCfFjrTR15mHE7cJpIpFT4tj3Q9gfLzzqXUtTpPTq2kzNpGsTtqlA3yja5XjaFPfbVRFJTTtn5CsXB2H29tu2AcdzJGSEFGSzOEp17EnjTMleFFaxM3fksQ8JPrZQhG/Fe/nsM6Z7c+kNThHT7Ppl6IPoWjU92pzIHvCKbeqPg+K1sB9X9rt5YByLGWCXovWFstTOlaj72kYmet7lZM6wt9mUxBOQjP7W22bujez/UrKWZGjhpR1JVrzPqdqvpgFlo2lWsvvroXn8NS3ADcDYnbcbgVLPbIQASCAwJUkEAgEgkH17gj8snNe6P1SgniXaNmtGDArPLGVVHsxPPXjkPlHK8UbyBG2YqN9tiDll9pn1WjdJVjtz+iblxj2+xd1m+Yx/mwb/2sA53jGMAYxjAGMYwBjGMAYxmxSgaWRIl4hpHWNS7KihnIUcnYgIu5G5PYYBZde9nes0arXLNF0rp4PiusteVq4nAMPvUUMjPVD8l2MiruWA8ztlSz9TR9KWrnW3UleRGp0bGm3NLlu2IZI6jNYpVtP09w7ALY8S6teSNVJLlVZfLcV/W/ZloOlwXb0cOs6i+mVpppYNXo3NLoWJBNUqxcn8KGUOHsSSeBG77rEN5PPcD897Hbfbtvtv6b/L+Gec6e+j6TepU9TMR0iCz1FBpluGtPLPWrVBUglsWohbLyCQeLK2zMwA7ZbV9nvT1Kc6fcs021SrSSWSOfWUoUrM1y9ZMfPUVSSNfdtPWlIYo+LSNbbv8AVlSByf2YaelvW9HqyIHjs6pp8EisN1aOW3Cjqw9QVJH5566toSWL2s2a1farXuWJpPCRUirwzXWhhAUbBI+bxoAB6gZ1H2fx6ZpHVGixaW2la7V1HVNLWG5Zinku0HS3HDZRK/iRiB/G5PHK6MWQQsNjyGVLVLFbWJdentRUaEun6fJNTjoQQUIrFhNVqQlZYl/95cxTzHt8XwA/qnAOa5nbOzQaHo40GPWmWiwTp6xprQePF7y/UkupTQwyNU5+JzSjIJ/F24cYk779stU1OZ+mK2n9MaHBqMF/Tq/0nqsctS1PHefhPeWzVZBNRnikTwkd3EaxbsgJcsAPzdjPbggkHzBIP/oZ4wBjGMAYxjAGMYwBjGMAYxjAGMYwCz+zXQYtS1BKsq2H5Q2JUhqtXjmnaCF52jWa0fDh+rjkbkwb7GwBLDNrrXp6lHUqappcllqNqWepJDdEXvVS5WSGV4nkhASeJ4rEUiSKq+bqQCu5k/8ABynWPqfSi/Di800P1m3hlrFSzAquCRuhaQAjcdjk10Z180ovtJ7hpg03RtRn0iGnBDTjTVbElGu88Qbk0154A6hmLMFT4eO2AcjyQoaFdsQTWoKdqatW72LEVeWSCDty+ulRSsXbv8RGdq6OuaZLV0y9esaDNXKanP1MuoLWm1qzZksTeFBUidPeOb146gikrsFV3lZiuzb6XRVqnQ0HQdSn1K5pzQa7rk6R0YHnnuJFBoYaurGRYI9xuhMwKlZm7MAVIHHTptgVxbMEoqtL4C2DGwgaYLzMSy7cWkC9yoO4GWTROgLVmrDda3pNSGx4jQi9qtOpNIkMrQvIkEr+I0fiJIu4XuUbbfbL51b7XNMlq2U0+ldgNrTRpkelTNUOiaXE5Z556kSIZLNkyPJIrt4ZV5eR58VAoXtF6rh1JNFjghaBdL0Sppj8gg8WeGWxNPOvD9Vnn9e5274B0Pr/AKOg9y6X31fRLEsGkGOKkk2oSNqLHW9SdYq8kFUKEdnMPJnTZkk7gANlRr+yjVbMoURUqU9q5qFWpp9i6kM8k1CUx2IK6zMTIqS7xBmb4mjYbnYnK9e6tnl+iPgjU6NXSvB9s+KEv2L4aUE+fOwV2Gw2UZZbXtm1mRJwPcopZZdSkjtx0oPfacerWZrV6vStuC9eF5LE3keQEjAMN8A2qXszrHTN57U8WtTaLP1FVqCOI1Dplcs/hzShi4ty1op512HELGqt3f4Zen7BbD6fJO1x1vpp8d9KppOtWeSxW99raZWvyyr75qj1SZjHDG6oFILb9s5vf6w1CWWGbxzHJBpkekI0IER9wjqmn4DcftBoWZWJ7tyPzyNvaxbnSGKe1YmjrLwrRyzyyJXTt8MCOxES9h2XbywC6aACnR+tuD3l13QIW+9Fqa1MP+8qn8s53m4moTiu9USyCtJLHO8AY+E80SSRxysnkXVJZQD6CRvnmngDGMYAxjGAMYxgDGMYBYujdN02y0q6hqbaZwVGhf3Ga6kpLEOr+A4aIgcSDswPcds6J7RH6Uue4ka/elXT9HpabDHU0J/jkqwuZJGe5ciCI9mWVtgCQG9TnGcYB1vqf2qxSVLmm0Y7MFJYtF+hkDJAdOs0IuF+yBEdxNZaa3ydW5P4gLHsAM0PbCa+sUtSSCzNHU0OrpHF7Xg2lkj01ac16rYCSCvaEhkdH4sRy7+ZzkeMA7jQ6+1C5FrNurpkuq0BJps15NV1O9e1CJ4lsQ1p5LGnPVkm08M5UxMrRIzxbgFgc0P8I/q659O61p4ZPBi6in1NG4bzLbFeCsPrGP6NUhQBCOxBzmPTmvXdNsJaoWrFOwgIWatK8MgVvtLyQglT6g9jmndtSTySTTSPLLK7SSSyMXkkkclnd3Y7s5JJJPnvgHQdY9tXUNrxVltV/CsCQ2aw07TxVszTENLcsVjAUlvFgD7wR4g2HEgdspvUGv2Ly01n4bUKUdCDggTavFJNKgfb7b8p5Pi/D5ZEYwBjGMAYxjAGMYwBjGMAYyaXp6c6Y2q7xist6PTwCx8V53ryWSUXbYxqkY5HfsZU+eQuAS9vqLUJq0VOW9clqQEGGrJZmevEVBCmKBnKRkAnyHbc58dS1q5ZVEsWrM6xjaNZp5ZVQHbcIJGIUdh5fIZHYwD3yO225233237b+W+3zzzvmMYB9q8zoyujMjowZHVirKyncMrDupB77jPmTv8AnnnGAeswDmMYAxjGAMYxgDGMYAxjGAMYxgDGMYAxjGAZBzGbVSjNMJTFG8ghiaeUqN/DiVlVpG+SAug3/pDNbbAMZLXNesTUaunOU92pz3LMACAOJLq1ln5P5su1SHYemx+eROMAYxjAGMYwBjGMAYxjAGMYwBjGMAYxjAM5dvZjp0M8OvGWKKWSPRZDTWRVZhbkv0I1eHl5SLC1huXoqucpOdS9hmpinT6qnKlj/J6SFSBvwezqFGsj/kZclK9CHNQVtN+CdX6069ilN0ve8xWkYNuV4bOSAgkJAQkkcGVvwYHyORE8LISrqykeYYEbfjvn6OeBEtVYO3+LXdUpf9h6SpVpiPu5RnfKRrOgwe6wTyib3U6HQuyFlafhalstVcpMx5Rqyx8wndeTqvYEEXeHItqfy2J4Li+H4uSxpSg2k021Jat7uo1Vb6nKqdSSZgkSM7HyVQSf4ZJ/Q0aD/GLUUTeqJvM4+76v4QfxbJbrOrPQ2rxqIa7pE5KNu0niwxzqJ3HcScJVPDyG/YHzNQ3yLj0O/JHFgfK1zPvbUWu6qm0+9kyNMqN2S8vL5TQyRg/2l5gfntniTp20O6xiVR+tCySjb5nwydvzyJ3z3FMynkrMpHkQSCPzxae69v4ynxsEvzQr/K2vfm5vqhLEyEqylSPMEEbfjvnzyYj16QjhYVLSeQEwJZR/RlUh1H3b7fdnt4aEuzJM9YnzSRTKoP3SR99v7O+OVPZ++hP3eE9cUl5SqL926+foQmYGTT6A7DlXeOyANyIieY/GJwH2+8AjIhlIOxGxHbKuNGOXBPH+ZVez6Pyex88YxkGAxjGAMYzIwDsdDpN7fSOkxrc0yqZtZ1m6fftQr0y0awabSTgs36Qh4Jt9vIFf2sgV9kGpuvKvZ0ayP8hremN/pzrnn2kScNE6Sr7/APBeoWyP6VrWry7/AI8ayj+yMoUU7Kd1YqR5EEgj8xnLkx5nbhNLzjf6o2xPFf40/Rr9mXh/ZJrY8oaTbfsazoz/ALwtzcZT9X06WpPJWnCrNC5SRUkilUMPMCSFmRx96kjNuLW2ZeNmNbC/tNssq/hMBy3/AK3IfdizpiOrS1XMiqOTxsAJYh6kj9dR+0PzAxilli/7Vxfkmvm5P6I6ZcJGa5sErrVp6SXps/Rshsxkpr+j2KMqw2Y/Ddoa9hPiV1aG1CliCRXQlWVo5FPb57emRmdSaaTT0ZwGMYxgDGMYAxjGAMYxgDGMYAxjGAMYxgDGMzgDMjAOfarXeRgkalmPkFBJP4AYbLRi5NJK2y6+yVFKa8z7+HHoFoyEbbhXt0IQQD9pucidtxlg/wAH86FNrkVbUNKe9BNDZVBLY7JKkLziRo0VQ/wRSLtv2Lg+mRHs7rNBpPV1lx3TS6mnbbj9Ne1iiwHbsT4dOc/2c1/YE+3Uukj0kteCf6s8UkLfwkOcX2hDm4fI02vwuqbXRu7RvDK4Jw5Vq9W0m/Lw9CF1OlWtSzSaeGiVnkeOlIeUkcZYssccvlPxUgd9mO3kcr5BB2PbbPoHaN91JDI3YjsQQexBHr2yT1tBKiW0H6T4ZgB2SZR3P3Bxsw+8t8s6I/hpXaNpRhnxuUVUo6tLZrul4dUQmMYzU4BjGMAYxjAGMYwBjGMAzjLTB0hI+hTa4JV8OHU4dNMHBuZaarLZ8bxN+IUeGF4+Z5b9tu9W2ysckZXTunT8H2JaAxm/Jpc6x+MycU7bFiF3B8iqnuw/AZphDk8y6Gk8M4NKSatWrW67nnfOw/4PekrYraz4vaKxJoOmnfy3sa1XvSefnxraZZcj5Kc5XeoNCqF2TkwB8MHdwpHJS2w2G4I7b79/LO0+ytWr9ORuo+snudSXht3LHSenkqVB29RPrExy+KpSRz8bCeOEk1Uq28WfWXVozCl6dJUE1DqbVGZELGOXW7b6bDv6K3hQllJ+7NDqlFi0/Wa8ZcRwaL00gjeRpBG1qardkReXlsWVf7GY6ontJo12nMoVo36f0WJANt+EE2ozk+pbmK+/9Y/PMdfzLt1lt9mO7otBfu91aeID8hTP7s7sjpOPv7P9keZkrC/gw/qXM+/44NLyXM14tX2r7dQUYpRrIdVJaj0rHESAeEsunRhWX5MWRV3+RziMi7Ej787Z7Qy8FbXiPhZZukaqn1D19Lmdvz5Rr+7Od+1bSVpatchjAWMSngBvttsOXn/TDZxZY1K+/wBbZ2/Z2VT4ZR1bi1r/AIXCGno/qVPGMZQ6RjGMA+0crKQykgg7gg9wfmNsl/pwSDa1DHYP7bckl7fOSMgufvYHIPGSpNG+LiJ49E9Hunqn6PQm1sae3Zq88X3pMj/waMf35620wetlvyiX/Wcg8sPRfRmp6zJJFplOa5JCgklSEKWRC3AMQzDty7YyZowTnOkl1dJfsari5PeMW/JL5Kl8iDm48jx347/Dv57b9t/v2z5HOx+072HavQSpPV0q60A0ilZvuB4wgue7l9QV9jugR1YkDso9c5dPpEkcZkkKJ2BCM6+IQdiNkBJ8jv32zlwcZhzx5sck14NfoZx4fJO2oulvpoiNxm1U0+WXbghIO+zHZV+HYn4j27Aj19RkjqOmQ1l4TPIZygbgqJwUsvJd5OZ3GxHcDNnNJ11L4+Byyg8lVFdXoreyT6tlo9oG0nTvSkzAGVYdZpc/UwVtS8aFT/Va5MPwIznWdG9pw930bpWi36Uadc1OT5Kuq35Grp9x8CrE/wD0oznOXOQ9ZsUrTxOro3FlO4I+ea5xkNWXhNxaknTWzR0z2gEapoek6xGgWSjvoeoIo2CmINZ06YD9h4JJY/uNUD5ZzQn/AF50j2HTrae/oEpHha3WMdfl2EeqVQ8+nSA+hZ/Eh/8A3P3ZzqeMozIwIZSVYHzBB2IP4EZycN+CUsX9Oq8pX9Ha8kjbM+dLJ1bd+ff1PjjGM7DmGMYwBjGMAYxjAGMYwBjGMAYxjAPWTsOkx+GDvJNLJHzRIk2Vd9+7Od9wCCCAPQ98ghk5BqkXu8UUniEJ4m6IwUOCQyAsd9gGMh8j55nk5tKPR+z/AINy+LX5dLve0vpb2fke6GgboZJnCL4JmCrszlA/AbAkAbnv5+Wba3aFeMrFu7ywsjspcFSUB+LlsN/EHpuOI9d8r9220jeoVRxjTkzBE3JCqSfs9zmrlfhuX5n6HQvtHHw+mCEbquaWr8Wrqr8joi/UdGuR8L6p1GiH5tDpGnFyP6vi6op/FM+HsDITXILBA2p1tSvkn0NLTbdhD+Toh/LPv1qOPS/S6A/pJ+oLRUfJrdOsp+//AN2cflny9iQ2s6m2x3Xp3qEj8foqwv8ArynGK8Mo91XvoeQnqUFvPJTQJ15NBIdoZwFJPkjDvHJ+R8/uLZF8fuOZAPyP3ds3cbVGvD5nhmprWunddU/BrQ+lyBopHjcbMjFSPkR2OfLfyyyChNqUPiV4ZJ7FdALKwxvK/gjZY52VATxHZSf6nzzS0npfU7g5VNPvWh5b16dicb/LeKMjfIhNS06rdFuKxLHP8LuL1j5P9Vs/EhsZe63se6pkAYdP6uFP60lGaJfzaUAD8834PYf1I3MtTrwiNGklNjVNKh8KNNuTyq9rlGg3G5IAG4y8pKKtukcxzTGdEf2XBBvP1D0xXPqv0v72w+Y20+CXv92YHQujKdper9H3/wAhS12dfyb3Bd8A56cZ0pegtFaOSSLqmpKI1LEDStXQE/qrzmhVQx9ATkFBoWleG7yayiuAxWJaVtmfbfZQ3DiGO23cgd8rzq6OvHwWScVLRJ7W0r8rasqWSPT2oipagstWr2xDIshrW0aStNx/UmRWUvGfUbjNBvPt5em+eRlmk1T2Zy7H6ope07w+i7GqVtC6frFeoYqiVF0/xKe/uIl94aF5PitDfiH37KNts/NfUWrPfuT3JI4IXsSmV460SwQIzHuIol7Iu/fb7zmkJ34eFzbwy3Mx8jwLgbBuG+3Lbtv558d84OD+zsfDOco7ybd63Wmmr8C7m3Rbb2nxySBmaU8467u23wRKyJzd37kjz9Bt+WfIa1XrgLHD3HiAhZCAD4gdGV9iSNtgR6hfPvkHZ1KeRFjeRiiABU8gAPLsPMj5nNPOhYbVSPZyfa/JNy4eKTlu2k30bSu+pu6zeNmZ5iAvLb4V8hsAO3y8s65R1tKPSFCRGPvkljXqsCL3KxW20sTTH1HasVHbvu2cXGdh6z6x1XQK2haXpeoWqAh0SrbuCtK0LSW9WeXU2MpXuxWGesg38gn3nOnG+TbpseTLM55Hkyattu/HueqGvNqi6V7yYzat9Ve8WYY0ZOMfhabXjcp34Rn6wDv5hsieoNSgMWvwTTKk97qOvKyEPyEEDan4s7bD9GGsqPnvv2yOHtm6r/8AxDq//bZv9uel9s3VX/L2pt/Wss/+lvl3lbPMXBxvfTp4U7X6Ez1x1HUvrrMNeUO1zqGnJUUK4MlSCG7XSUbjsp5wdj3+Mds8+2HSfH+kdQVwxh6g1GmE+H9AOEgcHfchZJCPkPEGRg9tnVX/AC1cP4mE/wB8eJfbJ1BLwWzeNmNJY5jHNWpsGeJgykt4HLfsNzv322O47ZTJK1truvn+5vwXDrDkS5moNNPq60rp05UznwX/ANbjPO2dvve07UpKc1qvNUdUNLtLpOjPIjv4wtrIppdlZ/CII7beW3cZ8Nb6+tK2ptJR0GyKduKKJbHT2kP9XM04ILJArFhwTY/j88wWRfz0LZJ/DlyyTX0e1NednGAD8sxxPyP7s7RL1mTqctH6F6YCL43F/wCT9Ll9XA8y7gEA9wAcjl9oG9F7R0HpgstqOAL9CQKvF4pJCfgkB33QZbmX0KrPF1XWn77HKeP3H92CD8j+7OzWurlG/DQemSRp9a4F+hVYvJO0CGMbT77bykjbv2Gamt9fVIYgh0Ppz3h4QJI49KRfAlJYH60ysCwHH4QDsSdzkfEXQ6uHx/G12it29l4eL8jkfE/fm1p16au5eGWWFirIXikeNirDZlLIQeJ9RkhLr7FiVr1lU/qCvGVH4cgT/HIdm775P5lUkWzQxxrklffSjpftx63h1S3SNCxYatBo+nUpfEMsfOavEUm3Rm+Mbn7R8++Qmo1g6QuEh2lgiLzSScWBUcW2Bfud023AOU7PRcnzJ+77vuHy8858XCRxQjCG0dPF/Q6uE41YYyUlfNXVKmvNPy6eZY9R19I3K11RlWSQhyo4skoTdGjIH2Si7Ht5ZDW7MtqYFzzkfjGAAF+SIoAGwHkM0ss/sooi1r2i1iN1n1XT4nHnuj24Q/b1+Hlm8McY7FOK+0c/EWpP8Ld8q2VbaeC7k1/hBuo1+3UjO8Wlx09HjHyGlU4KTj/rYZT+ec/4n5H92dQ6q9pED6lqE30FocpmvW5mkmrTyvIZLErl3Mk5+I77nbYd/LN+p7VNIZAsvTOjV2A2MkOm1rIP3mKwyn9zjOpY4vaS+f7HlvLJf3X8v3OPkZjO1LrvT909tH6fkc7/AFcg1jQpW+XGWC/LVDfcQgyL1vUtBqMIrnR1iuzDdWj1+4A6ftxPJBIkqf0lJGRLE0r6d1qi0csZaLfs9H7HNtE1CSpZgtQtxlrTRTxN+zJE6yIf85Rl29u2kJDqst2su1PVEh1Ott5IuoQpaaL7irSuNj6Lgah0a53bSuoYt/SLW9PcD8PF0vc/mck9Y6o6bsVlhK9ROYai06qWp9KlihiikklhVmhrRu3Fppdm89n27gAZxZMcviLJHommu6dfNV82d3DOErhN0ns+z6N+HT5nKsZ1IVelY4lmj03Xr4AUyEavQgjDcfiVo49OaSMb79yfzzTj6o6YXfbpaw/y8XqG0f3iGqmaxmpbFM3DzxOpryfRrun1RznbPXH7jnQX670uLtU6S0VR+1csaxef97XkT/u5aourNPprE17prp97c0ayx0KtG2ZEjkHKJ7Us911iZl2YRqjNxKk8dxm0Y35Lq9jmlLlpU23sluziYGAv3Z1PVeqnZ+f0NoGlQ+YX6NikkI+SrJu7fuA+/NCT2imFCscFGViNg30Xp8Cr96hIyzfmRi8X9Tf+VWvdtHSuEz1c1GC/xOn7JN+tUc62xlvX2i6nufjrFT5p7hSCbfLiIR2yK6k1730qz1akMi78pa8RhaQbAASIHKdtvRQe+S1Ho/f+M59eu/ht76fQg8YxmZIxjGAMYxgDGMYAzIzGel88A7R1Jr2nUdE6Tis6JW1SU6PZnSS3d1CKKMS63qgZBXpSxBm3jBLFjvuBt2yE0n2rw1Gdq3TPT0RlgnqyEJqrl69mMxTRMZNQO4ZGKk+fc9xmp7WDtp3SK+o6dYkeoDa5rBU/mM55kOKkqewOh/7pNQeXSnTIP3wam38G1DbMr7T0XunTXSyH0P0XLLt/ZntMp/MZzrGSDr3Sf+EBrumTNJVTSoonXga8GkUKsW3IEHlUijkZhsduTsO57ZEdSdbdQXuVhda1WzC25aL36yPA37lWhjcKqjfswXiQB5eQ53n1r2HjbkjFWHkQSCP3ZguHgpvJBJSlVut67+R1Yc0FFwyK0+q0afh3XgfS1ZnkJ8SSVyT8XN3Yk+u/I9zl19i4LT6rDx5eN09ri9gNx4VCSyp8v2oBlVXqC1+s6v8A85HHIf3upOWn2f8AtX1PQ3syUVpBrUBrymWlC/wnfYqVAII3Pbup9QdhmfFLLLG1CKb6W6X0LSx8MlcZS8nFL58zKIFJ7Dfv6Df1yVr6OygSWm8CPzAbvK4/ycXmfxOy/fnk9QWR9lkj++KGKM/vjUH+ORs0zOSzMWJ7kk77n883/G/D5l1Lhseq5pPs1S9dW38je1TUfEAjjHh149/DjB9T+u5/WkPqfyGwyNwcb5dJJaHNmzSyycpP/bwS6JHnGMZJiMYxgDGMYB6X/Uf7jnQv8Int1FbXyEdfSolHlssWkUI1Xb02C5QacDyyJFGpZ5GWNFHmzuQqgfeSQPzy9/4RFhJOp9Z4EMsNv3UkdwWpwxVH2+7nA2Ac+xjGAMYxgG3RtyQuHjYofL7iD5qwPYqfke2TzdSxSx2UnrcmtNC8ssUxjJeEtxbiwZfJ28th5ZWMzvlHBN2bRzyUeXRq06aTpqtr22Lh9PU2tteKTxyuJQQGSRQZIGg7DZT2Db+fpmmtykKxreJYZDOtg/VRqxZImjC8uZAHxk77HK1vjK/CXdl1mhp/Zw0SW3bbYsWp9USOdq6CsPBhgLKxaVooEREVpD5D4AdlA75Xj37+eYwcuoqOxnPLKSSey2WyXoecYxljIYxjAGdE/wAHFAeqNHZvKK01g/d7tXnsb/l4e/5ZzvOh/wCDwduoax9RT1kj8RouoEHAOfyMSSSdye5J9Se5P8c8Z6b/AFD+4Z5wD0Dk/ofU09ZDXkCWqbHeSnY3aE/NoiDygl+TxkH8fLK+cZeM3F2mVlBSVNFm1rRYJK5v6czvWVlWzXkIaxRdzsniMoAmrseyzADv8LAHbetZK9Naw9KwJlVXUq0c0L7+HYgkHGWCQDzRl/cQCO4GSOu9Ogxm7p5azQPdu4aekTv9VcjXuhHkJduDjYgg7qNJRU1zR36r9UZxk4Pllt0b+jPv017R9c02Fa9PUrMNdAwWvyWSuAzF2HgSqyEFiT3HmclP92LXD9uTT5T+1LomjSMfxZqe5zn2fWrXeV1SNWeR2CoiAszMx2VVUdyxJ8s4JcFgnK5Y4tvrSt/I6lmnFaSdeZ13pL2j2rPvE16jostSpA8tiQ6NQikPL4IYIngjQLLJKVUHY7Dke/E5HSe2e2xJbStAZm+27aWpdz6ln8Tdifnla6vk90r19KjZSYd575jYMr3pNx4TOpIfwY+MfY7BjLt55U80y8Dw6SxqK038/wDYph4rM5PJzvsten++5ZesurDqQiBoaZS8IuSdPqCs0vPj+mIdjIBx7fLc/PKzjGWhBQVR2Dk27ZjGMZYgYxjAGMYwBjGMAYxjAGMYwDat3ZphEs00sogiEEAkkdxDCHeQQxBifDiDySNxGw3dj6nNXGMAYxjAGMYwBjGMAYxjAGMYwBjGMAYxjAGMYwD71Z3idJYneOSNleOSNijo6EMjo6ndWDAEEdwQMzbsSTSPLK7yyyO0kkkjM8kkjks7u7ElnLEkk9ySc18YAxjGAMYxgDGMYAxjGAMYxgDGMYAxjGAM2tOvTVpBNXmlglCuolhkeKQLKjRSKHQghWR3Uj1DEHsc1cYAxjGAMYxgGc29O1Ceu/OvNLA+xXnDI8TcW+0vJCDxPyzUxkptaoNJ7n0llZ2LOzMx7ksSxJ+ZJ88+2n3pq7+JBLLDJsV5xSNG+zDZhyQg7Edts1RmMJtOxSqjO+YxjIAxjGAMYxgDGMYAxjGAMYxgDGMYAxjGAMYxgDGMYAxjGAMYxgDGMYAxjGAMYxgDGMYAxjGAMYxgDGMYAxjGAMYxgDGMYAxjGAMYxgDGMYAxjGAMYxgDGMYAxjGAMYxgDGMYAxjGAMYxgDGMYAxjGAMYxgDGMYAxjGAMYxgDGMYAxjGAMYxgDGMYAxjGAMYxgDGMYAxjGAMYxgDGMYAxjGAMYxgDGMYAxjGAMYxgDGMYAxjGAMYxgDGMYAxjGAMYxgDGMYAxjGAMYxgDGMYAxjGAMYxgH//Z\n"
+     },
+     "metadata": {},
+     "execution_count": 7
+    }
+   ],
+   "source": [
+    "#@title Video: PID Controller Explained\n",
+    "#@markdown Understanding proportional-integral-derivative control.\n",
+    "YouTubeVideo('UR0hOmjaHp0', width=600, height=400)"
+   ],
+   "id": "pid_explained"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "AC_mHX3FdkzX"
+   },
+   "source": [
+    "## Process control theory\n",
+    "Process control keeps process variables such as pressure, flow or level close to desired setpoints. The process itself is described by dynamic mass and energy balances that respond to changes in manipulated variables. Feedback controllers (P, PI and PID) compare a measured value with the setpoint and manipulate an actuator to reduce the error. The proportional term gives an immediate correction, the integral term removes any steady-state offset by accumulating error over time, and the derivative term anticipates future error by considering the rate of change. Proper tuning of these terms is essential to maintain stability and achieve fast, well-damped responses.\n"
+   ],
+   "id": "AC_mHX3FdkzX"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "re3RX1JVdkzZ"
+   },
+   "source": [
+    "## Control options in NeqSim\n",
+    "NeqSim supports dynamic simulation with measurement devices (transmitters) and controller devices. Each unit operation exposes variables that can be measured and manipulated, enabling the construction of control loops. Controllers can be attached to valves or other equipment and tuned by specifying proportional (K$_p$), integral (T$_i$) and derivative (T$_d$) parameters. The simulator integrates the underlying differential equations so that closed-loop behaviour, interaction between loops and the effect of disturbances can be studied in detail.\n"
+   ],
+   "id": "re3RX1JVdkzZ"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "oPimuGy_dkza"
+   },
+   "source": [
+    "## Example: controlling separator level and pressure\n",
+    "The example below shows a simple separator with control of both liquid level and gas outlet pressure. A level transmitter and a pressure transmitter provide measurements which are used by PID controllers connected to outlet valves. The level controller manipulates the liquid valve to balance inflow and outflow, while the pressure controller manipulates the gas valve to match gas generation with export capacity. The two loops illustrate typical process control concepts such as controlled variables, manipulated variables and the potential for loop interaction.\n"
+   ],
+   "id": "oPimuGy_dkza"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "id": "55jIS1xZdkzb",
+    "outputId": "6550ef3e-d15f-4a8d-e4d7-dfc69bcba317",
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 449
+    }
+   },
+   "execution_count": 28,
+   "outputs": [
+    {
+     "output_type": "display_data",
+     "data": {
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ],
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAhYAAAGwCAYAAAD16iy9AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAARVhJREFUeJzt3XlcVXX+x/H3BWSRVURBFFDLrVxyScNKzTTLMm1zMkaxRafS1GlqzMq0mWm0+jWNLZrVpE2jWc6Ureo4pqXmguaapmYkmiIusbkgcL+/P45cuSwKerhX8PV8PI6Xe9bP+QrcN+d8zzkOY4wRAACADXy8XQAAAKg5CBYAAMA2BAsAAGAbggUAALANwQIAANiGYAEAAGxDsAAAALbx8/QGnU6n9u3bp9DQUDkcDk9vHgAAnANjjHJychQbGysfn/KPS3g8WOzbt09xcXGe3iwAALDBnj171KhRo3KnezxYhIaGSrIKCwsL8/TmAQDAOcjOzlZcXJzrc7w8Hg8WRac/wsLCCBYAAFQzZ+vGQOdNAABgG4IFAACwDcECAADYxuN9LACgsgoLC5Wfn+/tMoAarVatWvL19T3v9RAsAFywjDFKT09XZmamt0sBLgoRERGKiYk5r/tMESwAXLCKQkX9+vVVu3ZtbqoHVBFjjI4dO6aMjAxJUoMGDc55XQQLABekwsJCV6ioW7eut8sBarygoCBJUkZGhurXr3/Op0XovAngglTUp6J27dpergS4eBT9vJ1PnyaCBYALGqc/AM+x4+eNYAEAAGxTqWAxceJEORwOt6Fly5ZVVRsAAKhmKn3E4vLLL9f+/ftdw/Lly6uiLgBADTVx4kRdccUVHt3mzJkzFRER4dFtXqwqHSz8/PwUExPjGqKioqqirnPndEp5OVL2filrr5RzQDp2xBqXf0IqLJCM8XaVAGqogwcP6qGHHlJ8fLwCAgIUExOjPn36aMWKFd4urcKGDh2qAQMGeLsMVFOVvtx0586dio2NVWBgoBITEzVp0iTFx8eXO39eXp7y8vJc77Ozs8+t0rN5vYuUvc8KEKpAcPCpJfnWknz8rMG3ljXOx7fY+FPvXdP9Tr93Db6Sw9f9vdu44u/LePXxlRw+xcb7WEPx8W7vyxscp1/lcB8nx5m/lsNaf/3LJD//qvn/AS4Sd9xxh06ePKl3331XTZs21YEDB7R48WIdPnzY26UpPz9ftWrV8tj2Tp48KX9/fqdcbCoVLLp06aKZM2eqRYsW2r9/v5599llde+212rJlS7nPZ580aZKeffZZW4o9o7xcKa9YaCn6UHaWc8mMM7/8aReryKZS/9elhK7ergQokzFGx/MLPb7doFq+Feotn5mZqWXLlmnp0qXq3r27JCkhIUGdO3cuNd9jjz2mTz75RHl5eerUqZNefvlltWvXTpJ1qmDevHl66KGH9Je//EWHDx/WLbfcorfeekvh4eGSpJSUFD355JNav3698vPzdcUVV+jll19Whw4dXNtxOByaOnWq5s+fr8WLF+vxxx/X+PHjNXz4cH311VdKT09XfHy8Hn74YY0ePdq17Xfffde1vCQtWbJEPXr00ObNmzV69GitXLlStWvX1h133KG//e1vCgkJkWQd6cjMzNSVV16p119/XQEBAUpNTa1QG7/99tt66aWXlJqaqsaNG2vUqFF6+OGHJUldu3bVtddeq+eff941/8GDBxUbG6vFixerW7duysvL01NPPaX3339fmZmZat26tZ5//nn16NGjQtuHfSoVLG666SbX123btlWXLl2UkJCgDz/8UPfff3+Zy4wbN06PPvqo6312drbi4uLOsdwz+O2/JV9/yT9ECgiVagVZf40bIzkLrRBRmC85C6yh8FSwcBYW+7rAOlXiLCjx/tR8zoLT63K9Lzg93hSfp8R04yw2T9Grs9j7kl87iy3jPD3dGPdpMu7zG3PqVI8p9t7p/r7U15JOZEpHfpJm9JW6/E66/hnJP9j+/yfgPBzPL9Rlzyz0+Ha3/qmPavuf/ddlSEiIQkJCNG/ePF111VUKCAgoc7677rpLQUFBmj9/vsLDwzV9+nRdf/312rFjhyIjIyVJP/74oz788EN99tlnys7O1v3336+HH35Ys2bNkiTl5OQoOTlZr776qowxeumll9S3b1/t3LnT7Q+9iRMnavLkyfr73/8uPz8/OZ1ONWrUSHPnzlXdunX17bffavjw4WrQoIEGDhyoxx57TNu2bVN2drZmzJghSYqMjNTRo0fVp08fJSYmKiUlRRkZGXrggQc0cuRIzZw507W9xYsXKywsTIsWLapw+86aNUvPPPOMXnvtNbVv317r16/XsGHDFBwcrOTkZCUlJemFF17Q5MmTXWHngw8+UGxsrK699lpJ0siRI7V161bNmTNHsbGx+vjjj3XjjTdq8+bNatasWYVrwfk7rztvRkREqHnz5vrxxx/LnScgIKDcHy5b1W9V9niHQ/L1s4ZaQVVfR3V1Ikta+JS0/j1p9RvSjgXSgDekhERvVwZUG35+fpo5c6aGDRumN954Qx06dFD37t119913q23btpKk5cuXa82aNcrIyHD9bvy///s/zZs3T//+9781fPhwSdKJEyf0z3/+Uw0bNpQkvfrqq7r55pv10ksvKSYmRj179nTb9ptvvqmIiAh9/fXXuuWWW1zj77nnHt17771u8xY/itykSROtXLlSH374oQYOHKiQkBAFBQUpLy9PMTExrvneffddV03BwdYfHa+99pr69eun559/XtHR0ZKk4OBgvf3225U6BTJhwgS99NJLuv322101bd26VdOnT1dycrIGDhyoMWPGaPny5a4gMXv2bA0aNEgOh0NpaWmaMWOG0tLSFBsbK0l67LHHtGDBAs2YMUN//etfK1wLzt95BYvc3Fzt2rVLgwcPtqseeEtguNT/NenyAdKno6Vff5Zm9pWufUzqPtYKZoCXBdXy1dY/9fHKdivqjjvu0M0336xly5Zp1apVmj9/vl544QW9/fbbGjp0qDZu3Kjc3NxStyk/fvy4du3a5XofHx/vChWSlJiYKKfTqe3btysmJkYHDhzQ008/raVLlyojI0OFhYU6duyY0tLS3NbbqVOnUjW+/vrreuedd5SWlqbjx4/r5MmTZ71KY9u2bWrXrp0rVEjS1Vdf7aqpKFi0adOmUqHi6NGj2rVrl+6//34NGzbMNb6goMB12qdevXq64YYbNGvWLF177bVKTU3VypUrNX36dEnS5s2bVVhYqObNm7utOy8vj9vBe0GlPi0ee+wx9evXTwkJCdq3b58mTJggX19fDRo0qKrqg6dd2kt6eKU0f6y0cbb0zQvST0uk29+0+mAAXuRwOCp0SsLbAgMD1bt3b/Xu3Vvjx4/XAw88oAkTJmjo0KHKzc1VgwYNtHTp0lLLVeZyyOTkZB0+fFhTpkxRQkKCAgIClJiYqJMnT7rNVzwISNKcOXP02GOP6aWXXlJiYqJCQ0P14osvavXq1eeyq6WU3N7Z5ObmSpLeeustdenSxW1a8WdVJCUladSoUXr11Vc1e/ZstWnTRm3atHGtw9fXV+vWrSv1fIui/h/wnEr9hO7du1eDBg3S4cOHVa9ePV1zzTVatWqV6tWrV1X1wRsCw6TbpknNekmf/V7amyK9ca3Ub4rU5k5vVwdUO5dddpnmzZsnSerQoYPS09Pl5+enxo0bl7tMWlqa9u3b5zq0v2rVKvn4+KhFixaSpBUrVmjq1Knq27evJGnPnj06dOjQWWtZsWKFunbt6uoYKcntSIkk+fv7q7DQvZNsq1atNHPmTB09etQVHlasWOFW07mIjo5WbGysfvrpJyUlJZU7X//+/TV8+HAtWLBAs2fP1pAhQ1zT2rdvr8LCQmVkZLhOlcB7KnUfizlz5mjfvn3Ky8vT3r17NWfOHF1yySVVVRu8rfUd0kMrpPiu0slc6T/3S5//3rofCIBSDh8+rJ49e+pf//qXNm3apNTUVM2dO1cvvPCC+vfvL0nq1auXEhMTNWDAAP33v//Vzz//rG+//VZPPfWU1q5d61pXYGCgkpOTtXHjRi1btkyjRo3SwIEDXf0emjVrpvfee0/btm3T6tWrlZSU5Ho65Zk0a9ZMa9eu1cKFC7Vjxw6NHz9eKSkpbvM0btxYmzZt0vbt23Xo0CHl5+crKSnJVdOWLVu0ZMkSPfLIIxo8eLDrNMi5evbZZzVp0iS98sor2rFjhzZv3qwZM2bob3/7m2ue4OBgDRgwQOPHj9e2bdvcjpQ3b95cSUlJGjJkiD766COlpqZqzZo1mjRpkr744ovzqg2Vx7NCcGYRcVLyZ1K3x633a9+R/tFbOrzrzMsBF6GQkBB16dJFL7/8srp166bWrVtr/PjxGjZsmF577TVJ1umcL7/8Ut26ddO9996r5s2b6+6779bu3bvdPqAvvfRS3X777erbt69uuOEGtW3bVlOnTnVN/8c//qFff/1VHTp00ODBgzVq1CjVr1//rDX+7ne/0+23367f/OY36tKliw4fPux29EKShg0bphYtWqhTp06qV6+eVqxYodq1a2vhwoU6cuSIrrzySt155526/vrrXft1Ph544AG9/fbbmjFjhtq0aaPu3btr5syZatKkidt8SUlJ2rhxo6699tpS90+aMWOGhgwZoj/84Q9q0aKFBgwYoJSUlDPeZwlVw2GMZ29DmZ2drfDwcGVlZSksLMyTm8b52vk/6aNh0vEjUkCYdNsbUsubvV0VaqgTJ04oNTVVTZo0UWBgoLfL8aii+1hs2LDB26XgInOmn7uKfn5zxAIV16yX9OByKe4q62Zkc+6RvvrLqftpAABAsEBlhTeUhn4udXnQev/Ni9Ksu6znsQAALnoEC1Seby3ppuel296U/IKkXYulN3tIB773dmVAjTBx4kROg6DaIljg3LX7jfTAIqlOYylzt/R2b2nrJ96uCgDgRQQLnJ+YNtKwJVLTHlL+UenDIdJXz1nPQQEAXHQIFjh/tSOlpP9IV42w3n/zgvTBb089wh4AcDEhWMAevn7SjX+1HlzmGyBt/0L6xw3WM0cAABcNggXsdcUg6d4vpZBoKWOr9OZ10s/LvV0VAMBDCBawX6NOVr+LBu2sm2n9s7+07l1vVwUAF5Tx48dr+PDhrvc9evTQmDFjqmRbb7zxhvr161cl6y6JYIGqEd5QuneBdPntkrNA+myUtOBJbqaFGu/gwYN66KGHFB8fr4CAAMXExKhPnz5asWKFt0ursKFDh2rAgAHeLqNGS09P15QpU/TUU095ZHv33XefvvvuOy1btqzKt0WwQNXxry3d+Y7U40nr/arXpffvlk5ke7cuoArdcccdWr9+vd59913t2LFDn376qXr06KHDhw97uzTl5+d7dHslH+F+oazLLudT09tvv62uXbsqISHBxopKM8aooKBA/v7+uueee/TKK69U6fYkggWqmsMh9Rgr3TXTupnWzv9aDzGjUydqoMzMTC1btkzPP/+8rrvuOiUkJKhz584aN26cbr31Vrf5HnjgAdWrV09hYWHq2bOnNm7c6Jo+ceJEXXHFFZo+fbri4uJUu3ZtDRw4UFlZWa55UlJS1Lt3b0VFRSk8PFzdu3fXd99951aPw+HQtGnTdOuttyo4OFjPPfecCgsLdf/996tJkyYKCgpSixYtNGXKFLdtv/vuu/rkk0/kcDjkcDi0dOlSSdLmzZvVs2dPBQUFqW7duho+fLhyc3NdyxYd6XjuuecUGxtb7uPUK7J/5a1rz549GjhwoCIiIhQZGan+/fvr559/di23dOlSde7cWcHBwYqIiNDVV1+t3bt3S5I2btyo6667TqGhoQoLC1PHjh1dT5Qtqqm4v//9726Ptj/XmsoyZ86cMk9NFBQUaOTIkQoPD1dUVJTGjx+v4o/0eu+999SpUyeFhoYqJiZG99xzjzIyMtz23+FwaP78+erYsaMCAgK0fLnVz61fv3769NNPdfz48TPWdr4IFvCMy2+zOnWGNpAO/iC91VPavdLbVaG6MUY6edTzQwWf1RgSEqKQkBDNmzdPeXl55c531113KSMjQ/Pnz9e6devUoUMHXX/99Tpy5PSt8X/88Ud9+OGH+uyzz7RgwQKtX7/e7SmkOTk5Sk5O1vLly7Vq1So1a9ZMffv2VU6O+2XeEydO1G233abNmzfrvvvuk9PpVKNGjTR37lxt3bpVzzzzjJ588kl9+OGHkqTHHntMAwcO1I033qj9+/dr//796tq1q44ePao+ffqoTp06SklJ0dy5c/W///1PI0eOdNve4sWLtX37di1atEiff/55uW1wtv0ra135+fnq06ePQkNDtWzZMq1YsUIhISG68cYbdfLkSRUUFGjAgAHq3r27Nm3apJUrV2r48OFyOBySrKejNmrUSCkpKVq3bp2eeOIJ1apV6yz/q+4qW1NZjhw5oq1bt6pTp06lpr377rvy8/PTmjVrNGXKFP3tb3/T22+/7Zqen5+vP//5z9q4caPmzZunn3/+WUOHDi21nieeeEKTJ0/Wtm3b1LZtW0lSp06dVFBQoNWrV1dqnyvNeFhWVpaRZLKysjy9aVwIsn4x5o1uxkwIM+bZusasn+XtinCBOn78uNm6das5fvz46ZF5udb3jqeHvNwK1/3vf//b1KlTxwQGBpquXbuacePGmY0bN7qmL1u2zISFhZkTJ064LXfJJZeY6dOnG2OMmTBhgvH19TV79+51TZ8/f77x8fEx+/fvL3O7hYWFJjQ01Hz22WeucZLMmDFjzlrziBEjzB133OF6n5ycbPr37+82z5tvvmnq1KljcnNPt8UXX3xhfHx8THp6umu56Ohok5eXd8btVWT/ylrXe++9Z1q0aGGcTqdrXF5engkKCjILFy40hw8fNpLM0qVLy9xuaGiomTlzZrk1tWvXzm3cyy+/bBISElzvz6Wmsqxfv95IMmlpaW7ju3fvblq1auW2rrFjx5pWrVqVuR5jjElJSTGSTE5OjjHGmCVLlhhJZt68eWXOX6dOnXLbwJhyfu5OqejnN0cs4FlhsdK986XL+kvOfGneQ9KiCdypEzXGHXfcoX379unTTz/VjTfeqKVLl6pDhw6aOXOmJOtwfG5ururWres6whESEqLU1FTt2rXLtZ74+Hg1bNjQ9T4xMVFOp1Pbt2+XJB04cEDDhg1Ts2bNFB4errCwMOXm5iotLc2tnrL+Kn799dfVsWNH1atXTyEhIXrzzTdLLVfStm3b1K5dOwUHB7vGXX311W41SVKbNm3k7+9/1nY62/6Vta6NGzfqxx9/VGhoqKvdIiMjdeLECe3atUuRkZEaOnSo+vTpo379+mnKlCnav3+/a/lHH31UDzzwgHr16qXJkye7tXdFVbamshSdiij5WHJJuuqqq1xHWIraZefOnSostDq+r1u3Tv369VN8fLxCQ0PVvXt3SarQ/7skBQUF6dixY5XY48rzq9K1A2Xxry3dOVNa+lfr6agr/i4d2ind/qYUEOLt6nAhq1VbenKfd7ZbCYGBgerdu7d69+6t8ePH64EHHtCECRM0dOhQ5ebmqkGDBq5+C8VFRERUeBvJyck6fPiwpkyZooSEBAUEBCgxMbHU4ffiQUCyzu0/9thjeumll5SYmKjQ0FC9+OKLth0eL7k9O9eVm5urjh07atasWaXmrVevniRpxowZGjVqlBYsWKAPPvhATz/9tBYtWqSrrrpKEydO1D333KMvvvhC8+fP14QJEzRnzhzddttt8vHxcevLIJXd2fVcaiopKipKkvTrr7+WO09Zik5H9enTR7NmzVK9evWUlpamPn36nPX/vciRI0cqtc1zQbCAd/j4SD2flqJaSJ+MsO7U+U4fadD7UkS8t6vDhcrhkPzt++DylMsuu0zz5s2TJHXo0EHp6eny8/Nz6xhYUlpamvbt26fY2FhJ0qpVq+Tj4+PqMLhixQpNnTpVffv2lWR1IDx06NBZa1mxYoW6du3q1p+h5F/W/v7+rr+Qi7Rq1UozZ87U0aNHXR9aK1ascKupMs62f2Xp0KGDPvjgA9WvX19hYWHlzte+fXu1b99e48aNU2JiombPnq2rrrpKktS8eXM1b95cv//97zVo0CDNmDFDt912m+rVq6f09HQZY1xHDCryhNmK1lTcJZdcorCwMG3dulXNmzd3m1Yy4BX1n/H19dUPP/ygw4cPa/LkyYqLi5MkV+fTiti1a5dOnDih9u3bV3iZc8GpEHhX27usTp3B9aUDW6xOnWlV3LEIqCKHDx9Wz5499a9//UubNm1Samqq5s6dqxdeeEH9+/eXJPXq1UuJiYkaMGCA/vvf/+rnn3/Wt99+q6eeesrtQyIwMFDJycnauHGjli1bplGjRmngwIGKiYmRJDVr1kzvvfeetm3bptWrVyspKUlBQUFnrbFZs2Zau3atFi5cqB07dmj8+PFKSUlxm6dx48batGmTtm/frkOHDik/P19JSUmumrZs2aIlS5bokUce0eDBgxUdHV3ptjrb/pUlKSlJUVFR6t+/v5YtW6bU1FQtXbpUo0aN0t69e5Wamqpx48Zp5cqV2r17t/773/9q586datWqlY4fP66RI0dq6dKl2r17t1asWKGUlBS1atVKknVzqoMHD+qFF17Qrl279Prrr2v+/Pln3Y+z1VQWHx8f9erVy3W1RnFpaWl69NFHtX37dr3//vt69dVXNXr0aEnW6SN/f3+9+uqr+umnn/Tpp5/qz3/+c0WaW5K0bNkyNW3aVJdcckmFlzknZ+yBUQXovIkyZe4xZurVVke5P0XRqRNn7ER2oTpx4oR54oknTIcOHUx4eLipXbu2adGihXn66afNsWPHXPNlZ2ebRx55xMTGxppatWqZuLg4k5SU5OrMV9SRcOrUqSY2NtYEBgaaO++80xw5csS1ju+++8506tTJBAYGmmbNmpm5c+eahIQE8/LLL7vmkWQ+/vjjUjUOHTrUhIeHm4iICPPQQw+ZJ554wq3jYkZGhundu7cJCQkxksySJUuMMcZs2rTJXHfddSYwMNBERkaaYcOGuToNGlN2p8+yVGT/ylvX/v37zZAhQ0xUVJQJCAgwTZs2NcOGDTNZWVkmPT3dDBgwwDRo0MD4+/ubhIQE88wzz5jCwkKTl5dn7r77bhMXF2f8/f1NbGysGTlypNv317Rp00xcXJwJDg42Q4YMMc8991ypzpuVrak8X375pWnYsKEpLCx0jevevbt5+OGHzYMPPmjCwsJMnTp1zJNPPunWmXP27NmmcePGJiAgwCQmJppPP/3USDLr1683xpzuvPnrr7+W2uYNN9xgJk2aVG5NxtjTedNhTAWvo7JJdna2wsPDlZWVVeHDRrhI5OVKH/9O+uHUJWpdR0m9Jko+vl4tC95x4sQJpaamqkmTJmV2cqvJJk6cqHnz5lXoUHx1VNP3ryKMMerSpYvrlExV+/7779WzZ0/t2LFD4eHh5c53pp+7in5+cyoEF46AEGnge1K3P1rvv31Fen8Qd+oEUOM4HA69+eabKigo8Mj29u/fr3/+859nDBV2ofMmLiw+PlLPp6R6pzp17lwovd3L6tRZt4rPCwKAB11xxRWl7vZZVXr16uWR7UgSp0Jw4frlO2lOkpSzTwoMt547cqnnfjjgXRfzqRDAWzgVgpqtYQdp+FKpUWfpRJY06y7p21crfHtlAIDnESxwYQuNloZ+LrX/rWSc0n+flj4aLp2s2jvH4cLh4YOqwEXNjp83ggUufH4B0q2vSTe9IDl8pc0fSu/cIP2629uVoQoVPRyqqm8/DOC0op+3yj6crTg6b6J6cDikLr+Toi+XPkyW0jdLb/aQ7pohNe3h7epQBXx9fRUREeF6JHTt2rXdnqEAwD7GGB07dkwZGRmKiIiQr++5X+ZP501UP1l7pQ9+K+1bLzl8pOsnSFePtsIHahRjjNLT05WZmentUoCLQkREhGJiYsoM8RX9/CZYoHrKPy598Qdpw6kH/7S8RRow1bp6BDVOYWFhmQ+EAmCfWrVqnfFIRUU/vzkVguqpVpDU/3WpUSdp/ljrbp1vbpN+8y8p+jJvVweb+fr6ntehWQCeQ+dNVF8Oh9TpPuneBVJYI+nILunt66UN73u7MgC4aBEsUP016ij97hup6XVS/jFp3oPSJyOt0yUAAI8iWKBmCK4r/fY/Uo8nJTmk9e9Jb10vHdrp7coA4KJCsEDN4eMr9RgrDZknBdeTMr6Xpnfn1AgAeBDBAjVP0x7Sg8ulxtdK+UetUyMfDZfycrxdGQDUeAQL1EyhMdKQT6TrnrbudbHpA2l6N+vBZgCAKkOwQM3l4yt1f1wa+uWpq0Z+kv7RW1r2kuQs9HZ1AFAjESxQ8yUkSg8uky4bIDkLpMV/kmbeImWmebsyAKhxCBa4ONSOlO6aKQ2YJvmHSGnfStOuljbM5jHsAGAjggUuHg6HdMU9VsfORp2lvGxp3kPS+4OknAPerg4AagSCBS4+kU2ke+dbDy/zqSXtmC9N7SJt+Q9HLwDgPBEscHHy9ZOufVQavlSKaSMd/1X6933WU1Nz0r1dHQBUWwQLXNxiWksPfCV1Hyv5+FkPM3u9s7T+Xxy9AIBzQLAA/Pyl656Uhn8tNbhCOpElfTJCem+AdHiXt6sDgGqFYAEUiWktPbBY6v0nyS9Q+mmpNDVR+voFqSDP29UBQLVAsACK8/WTrh4tPbxSuqSnVJgnLXnOujT1p6+9XR0AXPAIFkBZIptKv/1IuuMfUnB96fBO6Z+3Sh8OkTL3eLs6ALhgESyA8jgcUps7pZEpUufh1jNHtn4ivXaldXok/7i3KwSACw7BAjiboAip74vS776R4rtKBcet0yOvXSlt/jdXjwBAMQQLoKJi2kj3fmmdHglrKGXtkf5zv/T29VLaKm9XBwAXBIIFUBmu0yNrpZ5PS7WCpV/WSe/0sW4NfmCrtysEAK8iWADnwr+21O1xadR6qUOy1f9i+5fStK7SR7+Tfv3Z2xUCgFcQLIDzERot3fqK9PBq6bL+koy0aY70aifps9E8mh3ARYdgAdihXnNp4D+lYV9JTXtIznxp3UzplQ7SZ2MIGAAuGgQLwE4NO0pDPrGentqk+6mAMUOacoV1iiRjm7crBIAq5TDGs9fKZWdnKzw8XFlZWQoLC/PkpgHP2/2ttHSylFrsrp0t+kpdR0nxV1mdQQGgGqjo5zfBAvCEX9ZJy/8ubftM0qkfudj20lUjpMsHSL61vFgcAJwdwQK4EB3cIa18Vdr4gfUcEkkKjZU63Sd1GGJ1BgWACxDBAriQHT0krX1HWvOWdDTDGufjJ7XqJ3W6X2p8DadJAFxQCBZAdVCQJ30/T1r7D2nP6tPjI5tK7X8rtRskhcV6rTwAKEKwAKqb9M1Syj+kzXOlk7nWOIePdGkvqc1AqWVfyT/YuzUCuGgRLIDq6uRR6yjG+vektJWnx9cKllrdIrW+07pXhp+/tyoEcBGq6Of3ed3HYvLkyXI4HBozZsz5rAZAcf7BUvsk6b4F0sh1Urc/SnUaS/lHpU0fSLPvkv7vUunjh6QdC63TKQBwgfA71wVTUlI0ffp0tW3b1s56ABQXdanU8ynpuielvSnSpg+lbZ9KuQekjbOtwT9EuqSndX+MZjdIwXW9XTWAi9g5BYvc3FwlJSXprbfe0l/+8pczzpuXl6e8vNN/UWVnZ5/LJoGLm8MhxXW2hpuetx7TvvUTK2Tk7Ldet31q9clo2NHql3FpL+teGT6+3q4ewEXknPpYJCcnKzIyUi+//LJ69OihK664Qn//+9/LnHfixIl69tlnS42njwVgA6dT2r9B2j7fGg5sdp8eGCE1uda6vXiTblJUcy5jBXBOqqzz5pw5c/Tcc88pJSVFgYGBZw0WZR2xiIuLI1gAVSFrr/TjYunH/0k/fS3lZblPD65v3Uq8aIhpy10/AVRIRYNFpU6F7NmzR6NHj9aiRYsUGBhYoWUCAgIUEBBQmc0AOFfhjaSOydZQWCDtW289p+TnZdbpk6MZp0+bSJJfoNSgnXX6pGFHqcEV1j00fHg+IVAtnTwqHf7R+rn2kkodsZg3b55uu+02+fqePmdbWFgoh8MhHx8f5eXluU0rC5ebAl5SkCft2yClfWuFjLRV0onM0vP5h0gxbayh/mVS9OVSvZZSID+vwAUlJ13av0lK32TdB+fAFunwLmvak7/Yft+bKjlicf3112vzZvdzuPfee69atmypsWPHnjVUAPAivwApvos1SJIx1i+hX9ZJv6y1Xg98b92cK22l+z00JCmsoRTVTKrbzHqNvESKbCKFx3FPDaAqGSNl/2L9YbB/g/Wavsm6OqwsIdFS1i9SveYeLPK0SgWL0NBQtW7d2m1ccHCw6tatW2o8gAucw2Fdzhp1qdTuN9a4wgLp8M7TfwUd/EHK2Gb9UisaflpaYj0+UlgjqU6CdSomPM56DYuVQmOk0AZS7bp0GgUqKjdD+uU7ad931unMfeulowdLz+fwsYJ+g7bWEcbo1tZrSH3P11zMOd/HAkAN5Osn1W9lDUVhQ5KO/yod2ikd2nHqdaf0a6p0JFUqOC5lpVlDeXxqScFRUnA965de7SgpqI5UO9J6DaojBYRJgeHWKRf/ECkgxHqlcylqspPHpP0braOGe08dOczaU3o+Hz+pXisptp3VF6rBFdZpSv/anq74rLilN4BzZ4x1OPZIqnVFSlbaqde91v01ctLL/kurMnz9pVpBkl+QVCvQevWtZZ3a8fW3fuEWHxwO6y85h4/1tetXnLGCS9fR1lEawNOMkX79Wdqzxrrh3d4Uq1+Es6DEjA6pXgsptoN1L5qGHayjEbUqdtFEVamSPhYA4MbhOHW6I6b8eQpOWlej5GZYj4s/miEdOywdOyIdP2K9nsiS8rKt1xNZVs/2wpPW8oUnT32dVf42KmPLR1K/KVKbO+1ZH1Ce/BNWn4g9q60wsWd12UE7JFpqdKV1ZVajTtbRiGrcWZpgAaBq+fmf6nvRqHLLFZy0OpKePCoVnJDyj59+Lcw/FTjyrH4hptD6q68wXzJOScb669A4JZ3q2+FwSN9/LO1eIf3nfusS3BsnW0dDADscPWyFh7SV1uu+9acDchGfWtaloHGdrTDR6ErrZ6MG9UHiVAiAi0dhgfT1ZOmb/5NkpPqXS7e9YXV+AyrDGClzt7R75emrqA7tKD1fcD0prsvpoUE7r5/SOFc8Nh0AyrPrK+k/w6Rjh6x+Gd0el655lMtmUT6nUzq4Tdr9rRUidq+UcvaVni+qxek728Z1sW44V0OORhAsAOBMcjOkz38v/fC59T66jTTgda/esRAXkMICKX2jFSSKhpI3lPPxszpXxieeGq6yrnSqoQgWAHA2xkjffyR98ZjVkdThI105zHpMfVCEt6uDJxXkWZd67l5hhYg9a6w+PsXVqm31iUi4WkpIlBp2uiAv96wqBAsAqKjcDGn+H63OnZJ1Xrz3n6S2d/PclJrq5FErPBQdjdibYnUGLi4wXIrvKiV0tcJEg4v7oX0ECwCorF1LpC8ft+4+Kln3Eeg1UWra3atlwQbHf5XSVlvPyvl5hXUZaMn7RwTXt45EJFxjhYn6lxEsiyFYAMC5KDgprZ4mff3C6UPhl/S0Agb9L6qPnANWiNi90joicWCLpBIfd2GNrADR+GorTNS9pMZ0tKwKBAsAOB+5GdI3L0prZ0jOfGtcy1usq0cadfRubXBX9EC9tJWnntz7rXTkp9Lz1b3U6mTZ+NQRiYh4z9dajREsAMAOR1KlJX+VNs+V6y/eJt2ka34vNb2Ov3C9oeCk9XyNPausIFHmHS0d1m2wExKtEBHfVQqN9kq5NQXBAgDsdHC7tGKKtOmD0+fm67WUrnxAavuban0L5gte7kFp75pTt8VeYz31s+CE+zy+AdYtseO7WCEirjNX9tiMYAEAVSFzj/Ttq9L6f0n5R61x/iFS24FSu0HW5YgcxTh3BSelA5utJ33uXWtdrfFraun5giJP34Qq/irrfhJ+AZ6v9yJCsACAqnQiS9o4R0p52/1WzpFNrSMYre/kKapn4yy02m7fBusoxC/rpPTNpZ+vIVmPDI+70goSjTpLUc0IcB5GsAAATzBGSv1G2jBL2vaZlH/s9LSoFlLLm6VWt0gN2l/cly4W5EkHf7CCw/5N1uWe6Zvd26tIUKT1lM+GnU69duS0xgWAYAEAnpaXK/3whdUPI/Vr9/sk1I6yOn027WHdFyMioWb+xW2MlLXXChEHvreGjK1WH5Wiq2uKqxVs3XiqYUfrdEbDjlKdxjWzbao5ggUAeNPxTOnH/1nPItm5qPTtoUMbWH+NN7rS+ss8+vLq9Vf5yWPWJZ2Hfzw9HPxBOrSz9L4WCQyXYtpaQ4O2VpCoe6nk4+vZ2nFOCBYAcKEoOGn1H/hpqXUkY29K6bs+SlJ4nHW3x/otrb4akU2lOk2ksFjPfvgaY92pMnuflP2LdQQie5+UmSb9+rP1uPDcA+Uv71PLutlU/cuswBR9ufV1RDxHIqoxggUAXKhOHrP6GOxNOXX55AYpe2/58zt8pJBoKTTGOtJRO1IKjJCC6lhHAWrVlmoFSn5B1pURDoe1jMNHMk6pMN8anPnWtk/mWs/KOJlrHVk5/qs1HDts3Q8iN6Ps0xYlBUZYnSjrXipFXiLVa2FdghvZ5KJ+pkZNVdHPbz8P1gQAkKwnYiacerhVkeOZVl+EA99bpxOO/GRdZvnrbutDPme/NWi95+oMqmPd9jq8oRTWUIqIs/o/1Gls9RGpwY8Ix7kjWADAhSAoonTYkKxLMo8etEJF9qlwcfxX6UTmqdcsKf+ElH9cKjhuXX1hjCRjHa2Qwzp64OtvvdYKsu674R9iBZygOqeGSOs1pL41BNfjvhA4JwQLALiQ+fieOgUSY3V2BC5wF/FF1QAAwG4ECwAAYBuCBQAAsA3BAgAA2IZgAQAAbEOwAAAAtiFYAAAA2xAsAACAbQgWAADANgQLAABgG4IFAACwDcECAADYhmABAABsQ7AAAAC2IVgAAADbECwAAIBtCBYAAMA2BAsAAGAbggUAALANwQIAANiGYAEAAGxDsAAAALYhWAAAANsQLAAAgG0IFgAAwDYECwAAYBuCBQAAsA3BAgAA2IZgAQAAbEOwAAAAtiFYAAAA2xAsAACAbQgWAADANgQLAABgG4IFAACwDcECAADYhmABAABsQ7AAAAC2IVgAAADbECwAAIBtCBYAAMA2lQoW06ZNU9u2bRUWFqawsDAlJiZq/vz5VVUbAACoZioVLBo1aqTJkydr3bp1Wrt2rXr27Kn+/fvr+++/r6r6AABANeIwxpjzWUFkZKRefPFF3X///WVOz8vLU15enut9dna24uLilJWVpbCwsPPZNAAA8JDs7GyFh4ef9fP7nPtYFBYWas6cOTp69KgSExPLnW/SpEkKDw93DXFxcee6SQAAcIGr9BGLzZs3KzExUSdOnFBISIhmz56tvn37ljs/RywAAKj+KnrEwq+yK27RooU2bNigrKws/fvf/1ZycrK+/vprXXbZZWXOHxAQoICAgMpuBgAAVEPn3ceiV69euuSSSzR9+vQKzV/RxAMAAC4cVd7HoojT6XQ71QEAAC5elToVMm7cON10002Kj49XTk6OZs+eraVLl2rhwoVVVR8AAKhGKhUsMjIyNGTIEO3fv1/h4eFq27atFi5cqN69e1dVfQAAoBqpVLD4xz/+UVV1AACAGoBnhQAAANsQLAAAgG0IFgAAwDYECwAAYBuCBQAAsA3BAgAA2IZgAQAAbEOwAAAAtiFYAAAA2xAsAACAbQgWAADANgQLAABgG4IFAACwDcECAADYhmABAABsQ7AAAAC2IVgAAADbECwAAIBtCBYAAMA2BAsAAGAbggUAALANwQIAANiGYAEAAGxDsAAAALYhWAAAANsQLAAAgG0IFgAAwDYECwAAYBuCBQAAsA3BAgAA2IZgAQAAbEOwAAAAtiFYAAAA2xAsAACAbQgWAADANgQLAABgG4IFAACwDcECAADYhmABAABsQ7AAAAC2IVgAAADbECwAAIBtCBYAAMA2BAsAAGAbggUAALANwQIAANiGYAEAAGxDsAAAALYhWAAAANsQLAAAgG0IFgAAwDYECwAAYBuCBQAAsA3BAgAA2IZgAQAAbEOwAAAAtiFYAAAA2xAsAACAbQgWAADANgQLAABgG4IFAACwDcECAADYhmABAABsU6lgMWnSJF155ZUKDQ1V/fr1NWDAAG3fvr2qagMAANVMpYLF119/rREjRmjVqlVatGiR8vPzdcMNN+jo0aNVVR8AAKhGHMYYc64LHzx4UPXr19fXX3+tbt26VWiZ7OxshYeHKysrS2FhYee6aQAA4EEV/fz2O5+NZGVlSZIiIyPLnScvL095eXluhQEAgJrpnDtvOp1OjRkzRldffbVat25d7nyTJk1SeHi4a4iLizvXTQIAgAvcOZ8KeeihhzR//nwtX75cjRo1Kne+so5YxMXFcSoEAIBqpEpPhYwcOVKff/65vvnmmzOGCkkKCAhQQEDAuWwGAABUM5UKFsYYPfLII/r444+1dOlSNWnSpKrqAgAA1VClgsWIESM0e/ZsffLJJwoNDVV6erokKTw8XEFBQVVSIAAAqD4q1cfC4XCUOX7GjBkaOnRohdbB5aYAAFQ/VdLH4jxueQEAAC4CPCsEAADYhmABAABsQ7AAAAC2IVgAAADbECwAAIBtCBYAAMA2BAsAAGAbggUAALANwQIAANiGYAEAAGxDsAAAALYhWAAAANsQLAAAgG0IFgAAwDYECwAAYBuCBQAAsA3BAgAA2IZgAQAAbEOwAAAAtiFYAAAA2xAsAACAbQgWAADANgQLAABgG4IFAACwDcECAADYhmABAABsQ7AAAAC2IVgAAADbECwAAIBtCBYAAMA2BAsAAGAbggUAALANwQIAANiGYAEAAGxDsAAAALYhWAAAANsQLAAAgG0IFgAAwDYECwAAYBuCBQAAsA3BAgAA2IZgAQAAbEOwAAAAtiFYAAAA2xAsAACAbQgWAADANgQLAABgG4IFAACwDcECAADYhmABAABsQ7AAAAC2IVgAAADbECwAAIBtCBYAAMA2BAsAAGAbggUAALANwQIAANiGYAEAAGxDsAAAALYhWAAAANsQLAAAgG0IFgAAwDYECwAAYJtKB4tvvvlG/fr1U2xsrBwOh+bNm1cFZQEAgOqo0sHi6NGjateunV5//fWqqAcAAFRjfpVd4KabbtJNN91UFbUAAIBqrtLBorLy8vKUl5fnep+dnV3VmwQAAF5S5Z03J02apPDwcNcQFxdX1ZsEAABeUuXBYty4ccrKynINe/bsqepNAgAAL6nyUyEBAQEKCAio6s0AAIALAPexAAAAtqn0EYvc3Fz9+OOPrvepqanasGGDIiMjFR8fb2txAACgeql0sFi7dq2uu+461/tHH31UkpScnKyZM2faVhgAAKh+Kh0sevToIWNMVdQCAACqOfpYAAAA2xAsAACAbQgWAADANgQLAABgG4IFAACwDcECAADYhmABAABsQ7AAAAC2IVgAAADbECwAAIBtCBYAAMA2BAsAAGAbggUAALANwQIAANiGYAEAAGxDsAAAALYhWAAAANsQLAAAgG0IFgAAwDYECwAAYBuCBQAAsA3BAgAA2IZgAQAAbEOwAAAAtiFYAAAA2xAsAACAbQgWAADANgQLAABgGz9vF2CXHzNydLLAyMjIGMmY09McjtOvDjlOf13yvWtea5yPQ3I4HMXGW/O7ra/YdLdpp/5xyFFqPQ5rQrFtll6H29en5ilaDwAAF6oaEywGvbVaB3PyvF2Gx5QMJT6nRhR9XXK6HO7ji76WK/icGle0TLH5y1rOej21bZ/TAUqnApBPibp83NbjcAtlbtOKLVe0XrnVdvprldiOj481smStxffJUWx/i7eN2/hi+1J6PafDnaNEXe6h89T63LZ9ep2lg2OxwFns/614+6vE+JLLSyX211Vv6TYvubxKvi9Rd/H1l7/PZwrG7vVJpb8fXOs4S42lgnoZ3+/l1Vb0vebjU1QFALvVmGARFRIgSaV+qRgj11EMSSo6kGG9P3V0Q5Ix5tRr0XTrvcqYXmp9xcaVta6qULSt0xupwo0BNZCPQ/L1cbhCoI/D4RaciwJM8SDjNt6nRNApFmhLBWWf0sHdPbS6B7KidZcMWm6hrozweaZlSobH0zVaE8sL5DrDtkuu0317ZQfEolBXXrguO0SXDug+5SxfVjg/07qL75eKz1POOspcv4r+GClZUwXD/zkG9DOto0F4kHy9FKBrTLCYP/pab5dQLmPKDh3FT9uUG0yKTXNWdNkS408vd3o+ZxnzFZ/39HTrfaHTlF5nsdey1mFc81jTnafWV3zbJZd3uq3r9DJWTdbXOlWfs9jykuR0ureP89SbonFu7VesRmeJdpDKrkvF9rF4mztPfVH6/7f4tLLap9g6y1i2+L6Wtd0zBVpXzCy5/yXWXd733pkCdcnwXXodZ9ivEusv9f1zlv2yk9NIzsJTP2RADbPmqetVPzTQK9uuMcHiQlaUWk+982YpQLVXMqgXD6PW9HKCifN0qLOCslFhsYDsdLoH66KgWnyadDoMFS2rUyG2eLAtHpiKArBKBvJi+1J8H8oM28UCWfFg6nSNLz9AlhfcS7Zl8eWKr6/ksq5Q6Cw9j4q39xkCp3uN7ustK2CXCpzF2raiAb1kOC7z6zKWL6stqjKgO4tNq2hAL2v9Di9+1hAsAFQrBHXgwsblpgAAwDYECwAAYBuCBQAAsA3BAgAA2IZgAQAAbEOwAAAAtiFYAAAA2xAsAACAbQgWAADANgQLAABgG4IFAACwDcECAADYhmABAABsQ7AAAAC28fhj04ueX5+dne3pTQMAgHNU9Lld9DleHo8Hi5ycHElSXFycpzcNAADOU05OjsLDw8ud7jBnix42czqd2rdvn0JDQ+VwOGxbb3Z2tuLi4rRnzx6FhYXZtt6aivaqHNqr4miryqG9Kof2qhw728sYo5ycHMXGxsrHp/yeFB4/YuHj46NGjRpV2frDwsL4ZqsE2qtyaK+Ko60qh/aqHNqrcuxqrzMdqShC500AAGAbggUAALBNjQkWAQEBmjBhggICArxdSrVAe1UO7VVxtFXl0F6VQ3tVjjfay+OdNwEAQM1VY45YAAAA7yNYAAAA2xAsAACAbQgWAADANjUmWLz++utq3LixAgMD1aVLF61Zs8bbJXncpEmTdOWVVyo0NFT169fXgAEDtH37drd5Tpw4oREjRqhu3boKCQnRHXfcoQMHDrjNk5aWpptvvlm1a9dW/fr19fjjj6ugoMCTu+JxkydPlsPh0JgxY1zjaCt3v/zyi37729+qbt26CgoKUps2bbR27VrXdGOMnnnmGTVo0EBBQUHq1auXdu7c6baOI0eOKCkpSWFhYYqIiND999+v3NxcT+9KlSssLNT48ePVpEkTBQUF6ZJLLtGf//xnt2csXMzt9c0336hfv36KjY2Vw+HQvHnz3Kbb1TabNm3Stddeq8DAQMXFxemFF16o6l2rEmdqr/z8fI0dO1Zt2rRRcHCwYmNjNWTIEO3bt89tHR5tL1MDzJkzx/j7+5t33nnHfP/992bYsGEmIiLCHDhwwNuleVSfPn3MjBkzzJYtW8yGDRtM3759TXx8vMnNzXXN8+CDD5q4uDizePFis3btWnPVVVeZrl27uqYXFBSY1q1bm169epn169ebL7/80kRFRZlx48Z5Y5c8Ys2aNaZx48ambdu2ZvTo0a7xtNVpR44cMQkJCWbo0KFm9erV5qeffjILFy40P/74o2ueyZMnm/DwcDNv3jyzceNGc+utt5omTZqY48ePu+a58cYbTbt27cyqVavMsmXLzKWXXmoGDRrkjV2qUs8995ypW7eu+fzzz01qaqqZO3euCQkJMVOmTHHNczG315dffmmeeuop89FHHxlJ5uOPP3abbkfbZGVlmejoaJOUlGS2bNli3n//fRMUFGSmT5/uqd20zZnaKzMz0/Tq1ct88MEH5ocffjArV640nTt3Nh07dnRbhyfbq0YEi86dO5sRI0a43hcWFprY2FgzadIkL1blfRkZGUaS+frrr40x1jdgrVq1zNy5c13zbNu2zUgyK1euNMZY38A+Pj4mPT3dNc+0adNMWFiYycvL8+wOeEBOTo5p1qyZWbRokenevbsrWNBW7saOHWuuueaacqc7nU4TExNjXnzxRde4zMxMExAQYN5//31jjDFbt241kkxKSoprnvnz5xuHw2F++eWXqiveC26++WZz3333uY27/fbbTVJSkjGG9iqu5AelXW0zdepUU6dOHbefxbFjx5oWLVpU8R5VrbKCWElr1qwxkszu3buNMZ5vr2p/KuTkyZNat26devXq5Rrn4+OjXr16aeXKlV6szPuysrIkSZGRkZKkdevWKT8/362tWrZsqfj4eFdbrVy5Um3atFF0dLRrnj59+ig7O1vff/+9B6v3jBEjRujmm292axOJtirp008/VadOnXTXXXepfv36at++vd566y3X9NTUVKWnp7u1V3h4uLp06eLWXhEREerUqZNrnl69esnHx0erV6/23M54QNeuXbV48WLt2LFDkrRx40YtX75cN910kyTa60zsapuVK1eqW7du8vf3d83Tp08fbd++Xb/++quH9sY7srKy5HA4FBERIcnz7eXxh5DZ7dChQyosLHT75S5J0dHR+uGHH7xUlfc5nU6NGTNGV199tVq3bi1JSk9Pl7+/v+ubrUh0dLTS09Nd85TVlkXTapI5c+bou+++U0pKSqlptJW7n376SdOmTdOjjz6qJ598UikpKRo1apT8/f2VnJzs2t+y2qN4e9WvX99tup+fnyIjI2tcez3xxBPKzs5Wy5Yt5evrq8LCQj333HNKSkqSJNrrDOxqm/T0dDVp0qTUOoqm1alTp0rq97YTJ05o7NixGjRokOuhY55ur2ofLFC2ESNGaMuWLVq+fLm3S7kg7dmzR6NHj9aiRYsUGBjo7XIueE6nU506ddJf//pXSVL79u21ZcsWvfHGG0pOTvZydReeDz/8ULNmzdLs2bN1+eWXa8OGDRozZoxiY2NpL1SZ/Px8DRw4UMYYTZs2zWt1VPtTIVFRUfL19S3VW//AgQOKiYnxUlXeNXLkSH3++edasmSJ2yPqY2JidPLkSWVmZrrNX7ytYmJiymzLomk1xbp165SRkaEOHTrIz89Pfn5++vrrr/XKK6/Iz89P0dHRtFUxDRo00GWXXeY2rlWrVkpLS5N0en/P9HMYExOjjIwMt+kFBQU6cuRIjWuvxx9/XE888YTuvvtutWnTRoMHD9bvf/97TZo0SRLtdSZ2tc3F9PMpnQ4Vu3fv1qJFi9weke7p9qr2wcLf318dO3bU4sWLXeOcTqcWL16sxMREL1bmecYYjRw5Uh9//LG++uqrUoe1OnbsqFq1arm11fbt25WWluZqq8TERG3evNntm7Dom7TkB0t1dv3112vz5s3asGGDa+jUqZOSkpJcX9NWp1199dWlLl3esWOHEhISJElNmjRRTEyMW3tlZ2dr9erVbu2VmZmpdevWueb56quv5HQ61aVLFw/sheccO3ZMPj7uv159fX3ldDol0V5nYlfbJCYm6ptvvlF+fr5rnkWLFqlFixY17jRIUajYuXOn/ve//6lu3bpu0z3eXpXu7nkBmjNnjgkICDAzZ840W7duNcOHDzcRERFuvfUvBg899JAJDw83S5cuNfv373cNx44dc83z4IMPmvj4ePPVV1+ZtWvXmsTERJOYmOiaXnQJ5Q033GA2bNhgFixYYOrVq1cjL6EsqfhVIcbQVsWtWbPG+Pn5meeee87s3LnTzJo1y9SuXdv861//cs0zefJkExERYT755BOzadMm079//zIvEWzfvr1ZvXq1Wb58uWnWrFmNuHyypOTkZNOwYUPX5aYfffSRiYqKMn/84x9d81zM7ZWTk2PWr19v1q9fbySZv/3tb2b9+vWuqxjsaJvMzEwTHR1tBg8ebLZs2WLmzJljateuXS0vNz1Te508edLceuutplGjRmbDhg1uv/uLX+HhyfaqEcHCGGNeffVVEx8fb/z9/U3nzp3NqlWrvF2Sx0kqc5gxY4ZrnuPHj5uHH37Y1KlTx9SuXdvcdtttZv/+/W7r+fnnn81NN91kgoKCTFRUlPnDH/5g8vPzPbw3nlcyWNBW7j777DPTunVrExAQYFq2bGnefPNNt+lOp9OMHz/eREdHm4CAAHP99deb7du3u81z+PBhM2jQIBMSEmLCwsLMvffea3Jycjy5Gx6RnZ1tRo8ebeLj401gYKBp2rSpeeqpp9x+0V/M7bVkyZIyf1clJycbY+xrm40bN5prrrnGBAQEmIYNG5rJkyd7ahdtdab2Sk1NLfd3/5IlS1zr8GR78dh0AABgm2rfxwIAAFw4CBYAAMA2BAsAAGAbggUAALANwQIAANiGYAEAAGxDsAAAALYhWAAAANsQLICL3NChQzVgwACPb3fmzJlyOBxyOBwaM2ZMhZYZOnSoa5l58+ZVaX0Azg2PTQdqMIfDccbpEyZM0JQpU+StG/CGhYVp+/btCg4OrtD8U6ZM0eTJk9WgQYMqrgzAuSJYADXY/v37XV9/8MEHeuaZZ9yeUhoSEqKQkBBvlCbJCj6VeSRzeHi4wsPDq7AiAOeLUyFADRYTE+MawsPDXR/kRUNISEipUyE9evTQI488ojFjxqhOnTqKjo7WW2+9paNHj+ree+9VaGioLr30Us2fP99tW1u2bNFNN92kkJAQRUdHa/DgwTp06FCla546daqaNWumwMBARUdH68477zzfZgDgQQQLAKW8++67ioqK0po1a/TII4/ooYce0l133aWuXbvqu+++0w033KDBgwfr2LFjkqTMzEz17NlT7du319q1a7VgwQIdOHBAAwcOrNR2165dq1GjRulPf/qTtm/frgULFqhbt25VsYsAqginQgCU0q5dOz399NOSpHHjxmny5MmKiorSsGHDJEnPPPOMpk2bpk2bNumqq67Sa6+9pvbt2+uvf/2rax3vvPOO4uLitGPHDjVv3rxC201LS1NwcLBuueUWhYaGKiEhQe3bt7d/BwFUGY5YACilbdu2rq99fX1Vt25dtWnTxjUuOjpakpSRkSFJ2rhxo5YsWeLqsxESEqKWLVtKknbt2lXh7fbu3VsJCQlq2rSpBg8erFmzZrmOigCoHggWAEqpVauW23uHw+E2ruhqE6fTKUnKzc1Vv379tGHDBrdh586dlTqVERoaqu+++07vv/++GjRooGeeeUbt2rVTZmbm+e8UAI/gVAiA89ahQwf95z//UePGjeXnd36/Vvz8/NSrVy/16tVLEyZMUEREhL766ivdfvvtNlULoCpxxALAeRsxYoSOHDmiQYMGKSUlRbt27dLChQt17733qrCwsMLr+fzzz/XKK69ow4YN2r17t/75z3/K6XSqRYsWVVg9ADsRLACct9jYWK1YsUKFhYW64YYb1KZNG40ZM0YRERHy8an4r5mIiAh99NFH6tmzp1q1aqU33nhD77//vi6//PIqrB6AnRzGW7fcA3BRmzlzpsaMGXNO/SccDoc+/vhjr9yKHMCZccQCgNdkZWUpJCREY8eOrdD8Dz74oFfvFArg7DhiAcArcnJydODAAUnWKZCoqKizLpORkaHs7GxJUoMGDSr8jBEAnkOwAAAAtuFUCAAAsA3BAgAA2IZgAQAAbEOwAAAAtiFYAAAA2xAsAACAbQgWAADANgQLAABgm/8HaiFPJfUmuLcAAAAASUVORK5CYII=\n"
+     },
+     "metadata": {}
+    }
+   ],
+   "source": [
+    "# define the feed fluid\n",
+    "fluid1 = jneqsim.thermo.system.SystemSrkEos(298.15, 10.0)\n",
+    "fluid1.addComponent(\"methane\", 0.9)\n",
+    "fluid1.addComponent(\"ethane\", 0.1)\n",
+    "fluid1.addComponent(\"n-heptane\", 1.0)\n",
+    "fluid1.setMixingRule('classic')\n",
+    "\n",
+    "# build process equipment\n",
+    "feed = jneqsim.process.equipment.stream.Stream(\"Feed\", fluid1)\n",
+    "feed.setFlowRate(50.0, \"kg/hr\")\n",
+    "feed.setPressure(10.0, \"bara\")\n",
+    "\n",
+    "inlet_valve = jneqsim.process.equipment.valve.ThrottlingValve(\"inlet valve\", feed)\n",
+    "inlet_valve.setOutletPressure(5.0)\n",
+    "inlet_valve.setPercentValveOpening(30)\n",
+    "inlet_valve.setCalculateSteadyState(False)\n",
+    "\n",
+    "sep = jneqsim.process.equipment.separator.Separator(\"Separator\")\n",
+    "sep.addStream(inlet_valve.getOutletStream())\n",
+    "sep.setSeparatorLength(0.3)\n",
+    "sep.setInternalDiameter(1.0)\n",
+    "sep.setLiquidLevel(0.5)\n",
+    "sep.setCalculateSteadyState(False)\n",
+    "\n",
+    "\n",
+    "liq_valve = jneqsim.process.equipment.valve.ThrottlingValve(\"liquid valve\", sep.getLiquidOutStream())\n",
+    "liq_valve.setOutletPressure(1.0)\n",
+    "liq_valve.setPercentValveOpening(50)\n",
+    "liq_valve.setCalculateSteadyState(False)\n",
+    "\n",
+    "gas_valve = jneqsim.process.equipment.valve.ThrottlingValve(\"gas valve\", sep.getGasOutStream())\n",
+    "gas_valve.setOutletPressure(1.0)\n",
+    "gas_valve.setPercentValveOpening(50)\n",
+    "gas_valve.setCalculateSteadyState(False)\n",
+    "\n",
+    "# measurement devices\n",
+    "level_trans = jneqsim.process.measurementdevice.LevelTransmitter(sep)\n",
+    "level_trans.setMaximumValue(0.8)\n",
+    "level_trans.setMinimumValue(0.2)\n",
+    "\n",
+    "pressure_trans = jneqsim.process.measurementdevice.PressureTransmitter(sep.getGasOutStream())\n",
+    "pressure_trans.setUnit(\"bar\")\n",
+    "pressure_trans.setMaximumValue(10.0)\n",
+    "pressure_trans.setMinimumValue(1.0)\n",
+    "\n",
+    "# controllers\n",
+    "level_contr = jneqsim.process.controllerdevice.ControllerDeviceBaseClass()\n",
+    "level_contr.setReverseActing(False)\n",
+    "level_contr.setTransmitter(level_trans)\n",
+    "level_contr.setControllerSetPoint(0.45)\n",
+    "level_contr.setControllerParameters(1.0, 200.0, 0.0)\n",
+    "\n",
+    "pressure_contr = jneqsim.process.controllerdevice.ControllerDeviceBaseClass()\n",
+    "pressure_contr.setReverseActing(False)\n",
+    "pressure_contr.setTransmitter(pressure_trans)\n",
+    "pressure_contr.setControllerSetPoint(5.0)\n",
+    "pressure_contr.setControllerParameters(1.0, 50.0, 0.0)\n",
+    "\n",
+    "liq_valve.setController(level_contr)\n",
+    "gas_valve.setController(pressure_contr)\n",
+    "\n",
+    "# assemble and run process\n",
+    "p = jneqsim.process.processmodel.ProcessSystem()\n",
+    "p.add(feed)\n",
+    "p.add(inlet_valve)\n",
+    "p.add(sep)\n",
+    "p.add(liq_valve)\n",
+    "p.add(gas_valve)\n",
+    "p.add(level_trans)\n",
+    "p.add(pressure_trans)\n",
+    "p.run()\n",
+    "\n",
+    "# dynamic simulation\n",
+    "p.setTimeStep(10.0)\n",
+    "\n",
+    "time=[]; level=[]; pressure=[]\n",
+    "for i in range(20):\n",
+    "    time.append(p.getTime())\n",
+    "    level.append(level_trans.getMeasuredValue())\n",
+    "    pressure.append(pressure_trans.getMeasuredValue())\n",
+    "    p.runTransient()\n",
+    "\n",
+    "pressure_contr.setControllerSetPoint(4.0)\n",
+    "\n",
+    "for i in range(50):\n",
+    "    time.append(p.getTime())\n",
+    "    level.append(level_trans.getMeasuredValue())\n",
+    "    pressure.append(pressure_trans.getMeasuredValue())\n",
+    "    p.runTransient()\n",
+    "\n",
+    "feed.setPressure(8.0, \"bara\")\n",
+    "level_contr.setControllerSetPoint(0.5)\n",
+    "\n",
+    "for i in range(50):\n",
+    "    time.append(p.getTime())\n",
+    "    level.append(level_trans.getMeasuredValue())\n",
+    "    pressure.append(pressure_trans.getMeasuredValue())\n",
+    "    p.runTransient()\n",
+    "\n",
+    "\n",
+    "plt.plot(time, level, label='Separator level')\n",
+    "plt.plot(time, pressure, label='Separator pressure (bar)')\n",
+    "plt.xlabel('Time [s]')\n",
+    "plt.legend()\n",
+    "plt.show()\n"
+   ],
+   "id": "55jIS1xZdkzb"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "-jlZNo-sdkzd"
+   },
+   "source": [
+    "The plot shows how the PID controllers keep level and pressure close to their setpoints and how the pressure responds when the setpoint is changed from 5 to 4 bar. The transient reveals the characteristic behaviour of a tuned PI loop with a moderate overshoot followed by exponential decay toward the new steady state.\n"
+   ],
+   "id": "-jlZNo-sdkzd"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Two-stage separation with recompression\n",
+    "The following example extends the previous case by adding a second-stage separator. Flash gas from this stage is recompressed and mixed with gas from the inlet separator to form the export gas stream. Multi-stage separation improves liquid recovery by sequentially flashing the mixture at lower pressures, while recompressing the second-stage gas maintains overall gas throughput.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "#@title Two-stage separation with recompression\n",
+    "# build feed fluid\n",
+    "fluid2 = jneqsim.thermo.system.SystemSrkEos(298.15, 20.0)\n",
+    "fluid2.addComponent('methane', 0.9)\n",
+    "fluid2.addComponent('ethane', 0.1)\n",
+    "fluid2.addComponent('n-heptane', 1.0)\n",
+    "fluid2.setMixingRule('classic')\n",
+    "\n",
+    "feed2 = jneqsim.process.equipment.stream.Stream('Feed', fluid2)\n",
+    "feed2.setFlowRate(50.0, 'kg/hr')\n",
+    "feed2.setPressure(20.0, 'bara')\n",
+    "\n",
+    "# first stage separation\n",
+    "valve1 = jneqsim.process.equipment.valve.ThrottlingValve('inlet valve', feed2)\n",
+    "valve1.setOutletPressure(10.0)\n",
+    "valve1.setCalculateSteadyState(False)\n",
+    "\n",
+    "sep1 = jneqsim.process.equipment.separator.Separator('1st stage')\n",
+    "sep1.addStream(valve1.getOutletStream())\n",
+    "sep1.setSeparatorLength(0.3)\n",
+    "sep1.setInternalDiameter(1.0)\n",
+    "sep1.setCalculateSteadyState(False)\n",
+    "\n",
+    "# second stage separation\n",
+    "valve2 = jneqsim.process.equipment.valve.ThrottlingValve('interstage valve', sep1.getLiquidOutStream())\n",
+    "valve2.setOutletPressure(5.0)\n",
+    "valve2.setCalculateSteadyState(False)\n",
+    "\n",
+    "sep2 = jneqsim.process.equipment.separator.Separator('2nd stage')\n",
+    "sep2.addStream(valve2.getOutletStream())\n",
+    "sep2.setSeparatorLength(0.3)\n",
+    "sep2.setInternalDiameter(1.0)\n",
+    "sep2.setCalculateSteadyState(False)\n",
+    "\n",
+    "# recompress flash gas\n",
+    "comp = jneqsim.process.equipment.compressor.Compressor('recompressor', sep2.getGasOutStream())\n",
+    "comp.setOutletPressure(10.0)\n",
+    "comp.setCalculateSteadyState(False)\n",
+    "\n",
+    "# mix export gas\n",
+    "mixer = jneqsim.process.equipment.mixer.Mixer('export mixer')\n",
+    "mixer.addStream(sep1.getGasOutStream())\n",
+    "mixer.addStream(comp.getOutletStream())\n",
+    "\n",
+    "# level control in both separators\n",
+    "level1_trans = jneqsim.process.measurementdevice.LevelTransmitter(sep1)\n",
+    "level1_trans.setMaximumValue(0.8)\n",
+    "level1_trans.setMinimumValue(0.2)\n",
+    "level2_trans = jneqsim.process.measurementdevice.LevelTransmitter(sep2)\n",
+    "level2_trans.setMaximumValue(0.8)\n",
+    "level2_trans.setMinimumValue(0.2)\n",
+    "\n",
+    "level1_ctrl = jneqsim.process.controllerdevice.ControllerDeviceBaseClass()\n",
+    "level1_ctrl.setReverseActing(False)\n",
+    "level1_ctrl.setTransmitter(level1_trans)\n",
+    "level1_ctrl.setControllerSetPoint(0.5)\n",
+    "level1_ctrl.setControllerParameters(1.0, 200.0, 0.0)\n",
+    "\n",
+    "level2_ctrl = jneqsim.process.controllerdevice.ControllerDeviceBaseClass()\n",
+    "level2_ctrl.setReverseActing(False)\n",
+    "level2_ctrl.setTransmitter(level2_trans)\n",
+    "level2_ctrl.setControllerSetPoint(0.5)\n",
+    "level2_ctrl.setControllerParameters(1.0, 200.0, 0.0)\n",
+    "\n",
+    "liq1_valve = jneqsim.process.equipment.valve.ThrottlingValve('1st stage liquid valve', sep1.getLiquidOutStream())\n",
+    "liq1_valve.setOutletPressure(1.0)\n",
+    "liq1_valve.setPercentValveOpening(50)\n",
+    "liq1_valve.setCalculateSteadyState(False)\n",
+    "liq1_valve.setController(level1_ctrl)\n",
+    "\n",
+    "liq2_valve = jneqsim.process.equipment.valve.ThrottlingValve('2nd stage liquid valve', sep2.getLiquidOutStream())\n",
+    "liq2_valve.setOutletPressure(1.0)\n",
+    "liq2_valve.setPercentValveOpening(50)\n",
+    "liq2_valve.setCalculateSteadyState(False)\n",
+    "liq2_valve.setController(level2_ctrl)\n",
+    "\n",
+    "# assemble process\n",
+    "p2 = jneqsim.process.processmodel.ProcessSystem()\n",
+    "p2.add(feed2)\n",
+    "p2.add(valve1)\n",
+    "p2.add(sep1)\n",
+    "p2.add(valve2)\n",
+    "p2.add(sep2)\n",
+    "p2.add(comp)\n",
+    "p2.add(mixer)\n",
+    "p2.add(liq1_valve)\n",
+    "p2.add(liq2_valve)\n",
+    "p2.add(level1_trans)\n",
+    "p2.add(level2_trans)\n",
+    "p2.run()\n",
+    "\n",
+    "# dynamic simulation and step response\n",
+    "p2.setTimeStep(10.0)\n",
+    "\n",
+    "s_time = []\n",
+    "s_pressure = []\n",
+    "for i in range(20):\n",
+    "    s_time.append(p2.getTime())\n",
+    "    s_pressure.append(mixer.getOutletStream().getPressure('bara'))\n",
+    "    p2.runTransient()\n",
+    "\n",
+    "comp.setOutletPressure(12.0)\n",
+    "\n",
+    "for i in range(50):\n",
+    "    s_time.append(p2.getTime())\n",
+    "    s_pressure.append(mixer.getOutletStream().getPressure('bara'))\n",
+    "    p2.runTransient()\n",
+    "\n",
+    "plt.plot(s_time, s_pressure, label='Export gas pressure')\n",
+    "plt.xlabel('Time [s]')\n",
+    "plt.ylabel('Pressure [bar]')\n",
+    "plt.legend()\n",
+    "plt.show()\n",
+    "\n"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The recompressed flash gas from the second stage is mixed with the gas from the inlet separator to produce the export stream. The plot above shows how the export gas pressure responds when the compressor set point is stepped from 10 to 12 bar. This step response illustrates how compressor dynamics and downstream volume determine the speed and damping of the pressure change.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Advanced control options and step responses\n",
+    "NeqSim supports advanced control strategies such as cascade or ratio control in addition to basic PID loops. In cascade control a primary controller sets the setpoint of a faster secondary loop, thereby rejecting disturbances more quickly. Ratio control maintains a specified relationship between two flows or compositions by adjusting a secondary stream. Step response tests, sometimes called spring responses, can be performed by introducing set-point changes or disturbances and observing the transient behaviour. These responses are useful for tuning controllers, deriving approximate transfer functions and understanding process dynamics.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Cascade and ratio control examples\n",
+    "The following examples demonstrate cascade control and ratio control using NeqSim's dynamic simulation capabilities. The cascade example shows an outer pressure loop that adjusts the setpoint of an inner flow loop, while the ratio example manipulates one stream to maintain a desired flow ratio to a reference stream.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Cascade control example\n",
+    "fluid_c = jneqsim.thermo.system.SystemSrkEos(298.15, 10.0)\n",
+    "fluid_c.addComponent('methane', 1.0)\n",
+    "fluid_c.setMixingRule('classic')\n",
+    "\n",
+    "feed_c = jneqsim.process.equipment.stream.Stream('Feed', fluid_c)\n",
+    "feed_c.setFlowRate(50.0, 'kg/hr')\n",
+    "feed_c.setPressure(10.0, 'bara')\n",
+    "\n",
+    "inlet_c = jneqsim.process.equipment.valve.ThrottlingValve('inlet valve', feed_c)\n",
+    "inlet_c.setOutletPressure(5.0)\n",
+    "inlet_c.setCalculateSteadyState(False)\n",
+    "\n",
+    "sep_c = jneqsim.process.equipment.separator.Separator('Separator')\n",
+    "sep_c.addStream(inlet_c.getOutletStream())\n",
+    "sep_c.setSeparatorLength(0.3)\n",
+    "sep_c.setInternalDiameter(1.0)\n",
+    "sep_c.setCalculateSteadyState(False)\n",
+    "\n",
+    "gas_valve_c = jneqsim.process.equipment.valve.ThrottlingValve('gas valve', sep_c.getGasOutStream())\n",
+    "gas_valve_c.setOutletPressure(1.0)\n",
+    "gas_valve_c.setPercentValveOpening(50.0)\n",
+    "gas_valve_c.setCalculateSteadyState(False)\n",
+    "\n",
+    "# inner flow control\n",
+    "flow_trans = jneqsim.process.measurementdevice.VolumeFlowTransmitter(gas_valve_c.getOutletStream())\n",
+    "flow_trans.setMaximumValue(200.0)\n",
+    "flow_trans.setMinimumValue(0.0)\n",
+    "flow_ctrl = jneqsim.process.controllerdevice.ControllerDeviceBaseClass()\n",
+    "flow_ctrl.setReverseActing(True)\n",
+    "flow_ctrl.setTransmitter(flow_trans)\n",
+    "flow_ctrl.setControllerSetPoint(100.0)\n",
+    "flow_ctrl.setControllerParameters(1.0, 50.0, 0.0)\n",
+    "gas_valve_c.setController(flow_ctrl)\n",
+    "\n",
+    "# outer pressure control\n",
+    "press_trans = jneqsim.process.measurementdevice.PressureTransmitter(sep_c.getGasOutStream())\n",
+    "press_trans.setUnit('bar')\n",
+    "press_trans.setMaximumValue(10.0)\n",
+    "press_trans.setMinimumValue(1.0)\n",
+    "\n",
+    "p_c = jneqsim.process.processmodel.ProcessSystem()\n",
+    "p_c.add(feed_c)\n",
+    "p_c.add(inlet_c)\n",
+    "p_c.add(sep_c)\n",
+    "p_c.add(gas_valve_c)\n",
+    "p_c.add(flow_trans)\n",
+    "p_c.add(press_trans)\n",
+    "p_c.run()\n",
+    "p_c.setTimeStep(5.0)\n",
+    "\n",
+    "outer_set = 5.0\n",
+    "Kp_outer = 10.0\n",
+    "time_c = []\n",
+    "pressure_c = []\n",
+    "for i in range(40):\n",
+    "    time_c.append(p_c.getTime())\n",
+    "    pressure_c.append(press_trans.getMeasuredValue())\n",
+    "    p_c.runTransient()\n",
+    "    error = outer_set - press_trans.getMeasuredValue()\n",
+    "    flow_ctrl.setControllerSetPoint(100.0 + Kp_outer * error)\n",
+    "\n",
+    "feed_c.setPressure(12.0, 'bara')\n",
+    "for i in range(40):\n",
+    "    time_c.append(p_c.getTime())\n",
+    "    pressure_c.append(press_trans.getMeasuredValue())\n",
+    "    p_c.runTransient()\n",
+    "    error = outer_set - press_trans.getMeasuredValue()\n",
+    "    flow_ctrl.setControllerSetPoint(100.0 + Kp_outer * error)\n",
+    "\n",
+    "plt.figure()\n",
+    "plt.plot(time_c, pressure_c, label='Separator pressure')\n",
+    "plt.xlabel('Time [s]')\n",
+    "plt.ylabel('Pressure [bar]')\n",
+    "plt.legend()\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Ratio control example\n",
+    "fluid_r = jneqsim.thermo.system.SystemSrkEos(298.15, 20.0)\n",
+    "fluid_r.addComponent('methane', 1.0)\n",
+    "fluid_r.setMixingRule('classic')\n",
+    "\n",
+    "a_stream = jneqsim.process.equipment.stream.Stream('A', fluid_r)\n",
+    "a_stream.setFlowRate(100.0, 'kg/hr')\n",
+    "a_stream.setPressure(20.0, 'bara')\n",
+    "\n",
+    "b_stream = jneqsim.process.equipment.stream.Stream('B', fluid_r)\n",
+    "b_stream.setFlowRate(50.0, 'kg/hr')\n",
+    "b_stream.setPressure(20.0, 'bara')\n",
+    "\n",
+    "b_valve = jneqsim.process.equipment.valve.ThrottlingValve('B valve', b_stream)\n",
+    "b_valve.setOutletPressure(20.0)\n",
+    "b_valve.setPercentValveOpening(50.0)\n",
+    "b_valve.setCalculateSteadyState(False)\n",
+    "\n",
+    "mixer_r = jneqsim.process.equipment.mixer.Mixer('mix')\n",
+    "mixer_r.addStream(a_stream)\n",
+    "mixer_r.addStream(b_valve.getOutletStream())\n",
+    "\n",
+    "a_trans = jneqsim.process.measurementdevice.VolumeFlowTransmitter(a_stream)\n",
+    "a_trans.setMaximumValue(200.0)\n",
+    "a_trans.setMinimumValue(0.0)\n",
+    "b_trans = jneqsim.process.measurementdevice.VolumeFlowTransmitter(b_valve.getOutletStream())\n",
+    "b_trans.setMaximumValue(200.0)\n",
+    "b_trans.setMinimumValue(0.0)\n",
+    "\n",
+    "p_r = jneqsim.process.processmodel.ProcessSystem()\n",
+    "p_r.add(a_stream)\n",
+    "p_r.add(b_stream)\n",
+    "p_r.add(b_valve)\n",
+    "p_r.add(mixer_r)\n",
+    "p_r.add(a_trans)\n",
+    "p_r.add(b_trans)\n",
+    "p_r.run()\n",
+    "p_r.setTimeStep(5.0)\n",
+    "\n",
+    "ratio_set = 0.5\n",
+    "Kp_ratio = 20.0\n",
+    "time_r = []\n",
+    "ratio = []\n",
+    "for i in range(40):\n",
+    "    fa = a_trans.getMeasuredValue()\n",
+    "    fb = b_trans.getMeasuredValue()\n",
+    "    ratio.append(fb/fa)\n",
+    "    time_r.append(p_r.getTime())\n",
+    "    error = ratio_set - fb/fa\n",
+    "    opening = b_valve.getPercentValveOpening() + Kp_ratio * error\n",
+    "    opening = max(0.0, min(100.0, opening))\n",
+    "    b_valve.setPercentValveOpening(opening)\n",
+    "    p_r.runTransient()\n",
+    "\n",
+    "a_stream.setFlowRate(70.0, 'kg/hr')\n",
+    "for i in range(40):\n",
+    "    fa = a_trans.getMeasuredValue()\n",
+    "    fb = b_trans.getMeasuredValue()\n",
+    "    ratio.append(fb/fa)\n",
+    "    time_r.append(p_r.getTime())\n",
+    "    error = ratio_set - fb/fa\n",
+    "    opening = b_valve.getPercentValveOpening() + Kp_ratio * error\n",
+    "    opening = max(0.0, min(100.0, opening))\n",
+    "    b_valve.setPercentValveOpening(opening)\n",
+    "    p_r.runTransient()\n",
+    "\n",
+    "plt.figure()\n",
+    "plt.plot(time_r, ratio, label='B/A ratio')\n",
+    "plt.axhline(ratio_set, color='r', linestyle='--', label='Setpoint')\n",
+    "plt.xlabel('Time [s]')\n",
+    "plt.ylabel('Flow ratio')\n",
+    "plt.legend()\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Step response tuning of PID regulators\n",
+    "Step (spring) responses are often used to tune PID regulators. By introducing a set-point change and observing the transient behaviour, tuning parameters can be adjusted to obtain a faster yet stable response. The example below compares an untuned controller with a tuned one controlling valve outlet pressure.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Step response tuning example\n",
+    "def run_step(Kp, Ki):\n",
+    "    fluid = jneqsim.thermo.system.SystemSrkEos(298.15, 50.0)\n",
+    "    fluid.addComponent('methane', 1.0)\n",
+    "    fluid.setMixingRule('classic')\n",
+    "    feed = jneqsim.process.equipment.stream.Stream('feed', fluid)\n",
+    "    feed.setFlowRate(100.0, 'kg/hr')\n",
+    "    feed.setPressure(50.0, 'bara')\n",
+    "    valve = jneqsim.process.equipment.valve.ThrottlingValve('valve', feed)\n",
+    "    valve.setOutletPressure(40.0)\n",
+    "    valve.setCalculateSteadyState(False)\n",
+    "    pt = jneqsim.process.measurementdevice.PressureTransmitter(valve.getOutletStream())\n",
+    "    pt.setUnit('bar')\n",
+    "    pt.setMaximumValue(60.0)\n",
+    "    pt.setMinimumValue(30.0)\n",
+    "    ctrl = jneqsim.process.controllerdevice.ControllerDeviceBaseClass()\n",
+    "    ctrl.setTransmitter(pt)\n",
+    "    ctrl.setControllerSetPoint(40.0)\n",
+    "    ctrl.setControllerParameters(Kp, Ki, 0.0)\n",
+    "    ctrl.setReverseActing(True)\n",
+    "    valve.setController(ctrl)\n",
+    "    p = jneqsim.process.processmodel.ProcessSystem()\n",
+    "    p.add(feed)\n",
+    "    p.add(valve)\n",
+    "    p.add(pt)\n",
+    "    p.run()\n",
+    "    p.setTimeStep(1.0)\n",
+    "    time = []\n",
+    "    pressure = []\n",
+    "    for i in range(20):\n",
+    "        time.append(p.getTime())\n",
+    "        pressure.append(pt.getMeasuredValue())\n",
+    "        p.runTransient()\n",
+    "    ctrl.setControllerSetPoint(45.0)\n",
+    "    for i in range(80):\n",
+    "        time.append(p.getTime())\n",
+    "        pressure.append(pt.getMeasuredValue())\n",
+    "        p.runTransient()\n",
+    "    return time, pressure\n",
+    "\n",
+    "time_u, pressure_u = run_step(0.5, 0.0)\n",
+    "time_t, pressure_t = run_step(5.0, 1.0)\n",
+    "plt.figure()\n",
+    "plt.plot(time_u, pressure_u, label='Before tuning')\n",
+    "plt.plot(time_t, pressure_t, label='After tuning')\n",
+    "plt.xlabel('Time [s]')\n",
+    "plt.ylabel('Pressure [bar]')\n",
+    "plt.legend()\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Noise generation and filtering\n",
+    "NeqSim transmitters can generate measurement noise. The example below adds Gaussian noise to a pressure transmitter and applies a simple moving average filter to illustrate noise handling.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Noise generation and filtering example\n",
+    "fluid_n = jneqsim.thermo.system.SystemSrkEos(298.15, 10.0)\n",
+    "fluid_n.addComponent('methane', 1.0)\n",
+    "fluid_n.setMixingRule('classic')\n",
+    "feed_n = jneqsim.process.equipment.stream.Stream('feed', fluid_n)\n",
+    "feed_n.setFlowRate(100.0, 'kg/hr')\n",
+    "feed_n.setPressure(10.0, 'bara')\n",
+    "valve_n = jneqsim.process.equipment.valve.ThrottlingValve('valve', feed_n)\n",
+    "valve_n.setOutletPressure(1.0)\n",
+    "valve_n.setCalculateSteadyState(False)\n",
+    "pt_n = jneqsim.process.measurementdevice.PressureTransmitter(valve_n.getOutletStream())\n",
+    "pt_n.setUnit('bar')\n",
+    "pt_n.setMaximumValue(10.0)\n",
+    "pt_n.setMinimumValue(0.0)\n",
+    "pt_n.setNoiseStdDev(0.2)\n",
+    "p_n = jneqsim.process.processmodel.ProcessSystem()\n",
+    "p_n.add(feed_n)\n",
+    "p_n.add(valve_n)\n",
+    "p_n.add(pt_n)\n",
+    "p_n.run()\n",
+    "p_n.setTimeStep(1.0)\n",
+    "time_n = []\n",
+    "meas = []\n",
+    "filtered = []\n",
+    "for i in range(60):\n",
+    "    p_n.runTransient()\n",
+    "    time_n.append(p_n.getTime())\n",
+    "    val = pt_n.getMeasuredValue()\n",
+    "    meas.append(val)\n",
+    "    filtered.append(sum(meas[-5:]) / min(len(meas), 5))\n",
+    "plt.figure()\n",
+    "plt.plot(time_n, meas, label='Noisy measurement')\n",
+    "plt.plot(time_n, filtered, label='Filtered')\n",
+    "plt.xlabel('Time [s]')\n",
+    "plt.ylabel('Pressure [bar]')\n",
+    "plt.legend()\n",
+    "plt.show()\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12"
+  },
+  "colab": {
+   "provenance": [],
+   "name": "process_control_with_neqsim.ipynb",
+   "include_colab_link": true
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }


### PR DESCRIPTION
## Summary
- extend process control notebook with a step-response demo illustrating PID tuning before and after controller adjustment
- demonstrate NeqSim's measurement noise generation and simple filtering

## Testing
- `pytest`
- `pip install nbformat` *(fails: Could not find a version that satisfies the requirement nbformat)*

------
https://chatgpt.com/codex/tasks/task_e_68c590fa8a80832daf5b86d9cb289608