### PR TITLE
Add notebook on ML-based heat exchanger unit

### DIFF
--- a/notebooks/process/heat_exchanger_ml_external_unit.ipynb
+++ b/notebooks/process/heat_exchanger_ml_external_unit.ipynb
@@ -1,0 +1,590 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/EvenSol/NeqSim-Colab/blob/master/notebooks/process/heat_exchanger_ml_external_unit.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Machine-learning-driven heat exchanger unit operations in NeqSim\n",
+        "\n",
+        "This notebook explores how to create a machine-learning-based surrogate for a heat exchanger, using NeqSim to generate training data and scikit-learn to fit the model. The surrogate is then embedded as an external unit operation so that it can exchange streams with the rest of a process flowsheet. The workflow is aimed at students who want to combine first-principles simulation with data-driven modeling."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Learning objectives\n",
+        "\n",
+        "By the end of this notebook you will be able to:\n",
+        "\n",
+        "* configure and run a shell-and-tube heat exchanger model in NeqSim;\n",
+        "* generate synthetic plant data by sampling the rigorous model over a range of operating conditions;\n",
+        "* train a regression model with scikit-learn to predict outlet stream properties and heat duty;\n",
+        "* package the regression model as an external NeqSim unit operation with hot and cold inlet/outlet streams;\n",
+        "* compare the surrogate model with the rigorous heat exchanger to understand benefits and limitations."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Background and recommended reading\n",
+        "\n",
+        "The idea of combining first-principles models with data-driven surrogates is a recurring theme in process systems engineering. Rigorous process simulators such as NeqSim provide detailed physical fidelity, while machine learning models can approximate unit operations at a fraction of the computational cost once they have been trained on high-quality data. Hybrid modelling approaches allow engineers to blend mechanistic insight with plant or simulation data to support online optimization, real-time digital twins, and advanced control.\n",
+        "\n",
+        "You can find more context and theory in the following resources:\n",
+        "\n",
+        "* [Cengel, Y. A., & Ghajar, A. J. (2015). *Heat and Mass Transfer: Fundamentals & Applications*. McGraw-Hill.](https://www.mheducation.com/highered/product/heat-mass-transfer-fundamentals-applications-cengel-ghajar/M9780073398198.html)\n",
+        "* [Thompson, M. L., & Kramer, M. A. (1994). Modeling chemical processes using prior knowledge and neural networks. *AIChE Journal*, 40(8), 1328-1340.](https://doi.org/10.1002/aic.690400803)\n",
+        "* [Qin, S. J. (2012). Survey on data-driven industrial process monitoring and diagnosis. *Annual Reviews in Control*, 36(2), 220-234.](https://doi.org/10.1016/j.arcontrol.2012.09.004)\n",
+        "* [Pedregosa, F., et al. (2011). Scikit-learn: Machine learning in Python. *Journal of Machine Learning Research*, 12, 2825-2830.](https://doi.org/10.1145/1953048.2078195)\n",
+        "* [NeqSim documentation portal](https://neqsim.com) for thermodynamic and process simulation background."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 1. Set up the Python environment\n",
+        "\n",
+        "Run the following cell if you are executing the notebook in a fresh environment (for example on Google Colab) to install the required packages."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "install-cell"
+      },
+      "outputs": [],
+      "source": [
+        "# %pip install neqsim==2.5.35 scikit-learn pandas matplotlib"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 2. Import libraries and define helper functions\n",
+        "\n",
+        "We will use NeqSim for process simulation, pandas and NumPy for data handling, matplotlib for quick visualisation, and scikit-learn for the machine learning workflow."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "imports"
+      },
+      "outputs": [],
+      "source": [
+        "import json\n",
+        "import numpy as np\n",
+        "import pandas as pd\n",
+        "import matplotlib.pyplot as plt\n",
+        "\n",
+        "from sklearn.model_selection import train_test_split\n",
+        "from sklearn.ensemble import RandomForestRegressor\n",
+        "from sklearn.metrics import mean_absolute_error, r2_score\n",
+        "\n",
+        "from neqsim.thermo import fluid, TPflash\n",
+        "from neqsim.process import clearProcess, stream, heatExchanger, runProcess\n",
+        "from neqsim import jNeqSim\n",
+        "from neqsim.process.unitop import unitop\n",
+        "\n",
+        "plt.style.use('seaborn-v0_8')\n",
+        "pd.options.display.float_format = '{:,.3f}'.format\n",
+        "np.random.seed(42)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "helpers"
+      },
+      "outputs": [],
+      "source": [
+        "def make_natural_gas_fluid():\n",
+        "    gas = fluid('srk')\n",
+        "    gas.addComponent('methane', 0.88)\n",
+        "    gas.addComponent('ethane', 0.06)\n",
+        "    gas.addComponent('propane', 0.03)\n",
+        "    gas.addComponent('n-butane', 0.02)\n",
+        "    gas.addComponent('n-pentane', 0.01)\n",
+        "    gas.setMixingRule(2)\n",
+        "    return gas\n",
+        "\n",
+        "\n",
+        "def make_cooling_water_fluid():\n",
+        "    water = fluid('srk')\n",
+        "    water.addComponent('water', 1.0)\n",
+        "    water.setMixingRule(2)\n",
+        "    return water\n",
+        "\n",
+        "\n",
+        "def simulate_case(case_id, hot_temp_C, hot_press_bara, hot_flow_MSm3_day,\n",
+        "                  cold_temp_C, cold_press_bara, cold_flow_kg_hr, ua_value):\n",
+        "    clearProcess()\n",
+        "    hot_fluid = make_natural_gas_fluid()\n",
+        "    hot_fluid.setTemperature(hot_temp_C, 'C')\n",
+        "    hot_fluid.setPressure(hot_press_bara, 'bara')\n",
+        "    hot_fluid.setTotalFlowRate(hot_flow_MSm3_day, 'MSm3/day')\n",
+        "\n",
+        "    cold_fluid = make_cooling_water_fluid()\n",
+        "    cold_fluid.setTemperature(cold_temp_C, 'C')\n",
+        "    cold_fluid.setPressure(cold_press_bara, 'bara')\n",
+        "    cold_fluid.setTotalFlowRate(cold_flow_kg_hr, 'kg/hr')\n",
+        "\n",
+        "    hot_stream = stream(f'hot_{case_id}', hot_fluid)\n",
+        "    cold_stream = stream(f'cold_{case_id}', cold_fluid)\n",
+        "\n",
+        "    hx = heatExchanger(f'HX_{case_id}', hot_stream, cold_stream)\n",
+        "    hx.setUAvalue(ua_value)\n",
+        "    runProcess()\n",
+        "\n",
+        "    hot_out = hx.getOutStream(0)\n",
+        "    cold_out = hx.getOutStream(1)\n",
+        "\n",
+        "    record = {\n",
+        "        'case_id': case_id,\n",
+        "        'hot_in_T_C': hot_temp_C,\n",
+        "        'hot_in_p_bara': hot_press_bara,\n",
+        "        'hot_in_massflow_kg_per_hr': hot_stream.getFlowRate('kg/hr'),\n",
+        "        'cold_in_T_C': cold_temp_C,\n",
+        "        'cold_in_p_bara': cold_press_bara,\n",
+        "        'cold_in_massflow_kg_per_hr': cold_stream.getFlowRate('kg/hr'),\n",
+        "        'UA_W_per_K': ua_value,\n",
+        "        'hot_out_T_C': hot_out.getTemperature('C'),\n",
+        "        'cold_out_T_C': cold_out.getTemperature('C'),\n",
+        "        'duty_kW': hx.getDuty() / 1e3,\n",
+        "    }\n",
+        "    return record\n",
+        "\n",
+        "\n",
+        "def describe_case(record):\n",
+        "    display(pd.DataFrame([record]).set_index('case_id').T)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 3. Inspect a single rigorous NeqSim heat exchanger simulation\n",
+        "\n",
+        "We first run the built-in NeqSim heat exchanger model for one operating point to understand the inputs and outputs that we want our surrogate to learn."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "single-case"
+      },
+      "outputs": [],
+      "source": [
+        "baseline_case = simulate_case(\n",
+        "    case_id='baseline',\n",
+        "    hot_temp_C=130.0,\n",
+        "    hot_press_bara=55.0,\n",
+        "    hot_flow_MSm3_day=1.1,\n",
+        "    cold_temp_C=15.0,\n",
+        "    cold_press_bara=5.0,\n",
+        "    cold_flow_kg_hr=220_000.0,\n",
+        "    ua_value=120_000.0,\n",
+        ")\n",
+        "describe_case(baseline_case)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 4. Generate a training data set from NeqSim\n",
+        "\n",
+        "To train a machine learning model we need examples that cover the relevant range of operation. The loop below perturbs hot-side temperature, pressure, and flow rate together with cold-side inlet temperature and flow rate, and different overall heat transfer coefficients (expressed as UA values). Each combination is simulated with the rigorous NeqSim heat exchanger, and the resulting data are stored in a pandas `DataFrame`."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "generate-data"
+      },
+      "outputs": [],
+      "source": [
+        "hot_temps = [100.0, 130.0, 160.0]\n",
+        "hot_pressures = [40.0, 55.0]\n",
+        "hot_flows = [0.8, 1.1, 1.4]\n",
+        "cold_temps = [5.0, 15.0, 25.0]\n",
+        "cold_flows = [180_000.0, 220_000.0, 260_000.0]\n",
+        "ua_values = [90_000.0, 130_000.0]\n",
+        "\n",
+        "records = []\n",
+        "case_counter = 0\n",
+        "for hot_temp in hot_temps:\n",
+        "    for hot_pressure in hot_pressures:\n",
+        "        for hot_flow in hot_flows:\n",
+        "            for cold_temp in cold_temps:\n",
+        "                for cold_flow in cold_flows:\n",
+        "                    for ua in ua_values:\n",
+        "                        record = simulate_case(\n",
+        "                            case_id=f'case_{case_counter}',\n",
+        "                            hot_temp_C=float(hot_temp),\n",
+        "                            hot_press_bara=float(hot_pressure),\n",
+        "                            hot_flow_MSm3_day=float(hot_flow),\n",
+        "                            cold_temp_C=float(cold_temp),\n",
+        "                            cold_press_bara=5.0,\n",
+        "                            cold_flow_kg_hr=float(cold_flow),\n",
+        "                            ua_value=float(ua),\n",
+        "                        )\n",
+        "                        records.append(record)\n",
+        "                        case_counter += 1\n",
+        "\n",
+        "training_data = pd.DataFrame(records)\n",
+        "training_data.head()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "data-summary"
+      },
+      "outputs": [],
+      "source": [
+        "training_data.describe()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 5. Train a machine learning surrogate\n",
+        "\n",
+        "We now split the data set into training and test subsets, fit a random forest regressor that predicts hot outlet temperature, cold outlet temperature, and heat duty, and evaluate the performance with the coefficient of determination ($R^2$) and mean absolute error (MAE)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "train-model"
+      },
+      "outputs": [],
+      "source": [
+        "feature_columns = [\n",
+        "    'hot_in_T_C',\n",
+        "    'hot_in_p_bara',\n",
+        "    'hot_in_massflow_kg_per_hr',\n",
+        "    'cold_in_T_C',\n",
+        "    'cold_in_p_bara',\n",
+        "    'cold_in_massflow_kg_per_hr',\n",
+        "    'UA_W_per_K',\n",
+        "]\n",
+        "target_columns = ['hot_out_T_C', 'cold_out_T_C', 'duty_kW']\n",
+        "\n",
+        "X = training_data[feature_columns]\n",
+        "y = training_data[target_columns]\n",
+        "\n",
+        "X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)\n",
+        "\n",
+        "regressor = RandomForestRegressor(n_estimators=300, random_state=42)\n",
+        "regressor.fit(X_train, y_train)\n",
+        "\n",
+        "y_pred = regressor.predict(X_test)\n",
+        "r2 = r2_score(y_test, y_pred, multioutput='raw_values')\n",
+        "mae = mean_absolute_error(y_test, y_pred, multioutput='raw_values')\n",
+        "\n",
+        "metrics = pd.DataFrame({\n",
+        "    'Target': target_columns,\n",
+        "    'R2 score': r2,\n",
+        "    'Mean absolute error': mae,\n",
+        "})\n",
+        "metrics"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "parity-plot"
+      },
+      "outputs": [],
+      "source": [
+        "y_pred_df = pd.DataFrame(y_pred, columns=target_columns, index=y_test.index)\n",
+        "fig, axes = plt.subplots(1, 3, figsize=(15, 4))\n",
+        "for idx, target in enumerate(target_columns):\n",
+        "    ax = axes[idx]\n",
+        "    ax.scatter(y_test[target], y_pred_df[target], alpha=0.6)\n",
+        "    lims = [\n",
+        "        min(y_test[target].min(), y_pred_df[target].min()),\n",
+        "        max(y_test[target].max(), y_pred_df[target].max()),\n",
+        "    ]\n",
+        "    ax.plot(lims, lims, 'k--', linewidth=1)\n",
+        "    ax.set_xlabel('NeqSim reference')\n",
+        "    ax.set_ylabel('ML prediction')\n",
+        "    ax.set_title(target)\n",
+        "    ax.grid(True)\n",
+        "plt.tight_layout()\n",
+        "plt.show()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 6. Create an external machine-learning heat exchanger unit\n",
+        "\n",
+        "The class below extends the NeqSim `unitop` interface and wraps the trained scikit-learn regressor. The unit accepts hot and cold inlet streams, uses their thermodynamic states to build the feature vector, predicts outlet conditions and heat duty, and returns outlet `Stream` objects just like the rigorous heat exchanger. This makes it possible to plug the surrogate into any `ProcessSystem`."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "ml-unit"
+      },
+      "outputs": [],
+      "source": [
+        "class MachineLearningHeatExchanger(unitop):\n",
+        "    def __init__(self, model, feature_names, target_names):\n",
+        "        super().__init__()\n",
+        "        self.model = model\n",
+        "        self.feature_names = list(feature_names)\n",
+        "        self.target_names = list(target_names)\n",
+        "        self.ua_value = None\n",
+        "        self.hot_inletstream = None\n",
+        "        self.cold_inletstream = None\n",
+        "        self.hot_outletstream = None\n",
+        "        self.cold_outletstream = None\n",
+        "        self.duty = None\n",
+        "        self.latest_results = None\n",
+        "        self.setName('ML Heat Exchanger')\n",
+        "\n",
+        "    def setUAvalue(self, ua_value):\n",
+        "        self.ua_value = ua_value\n",
+        "\n",
+        "    def setHotInletStream(self, stream_in):\n",
+        "        self.hot_inletstream = stream_in\n",
+        "        self.hot_outletstream = stream_in.clone()\n",
+        "        self.hot_outletstream.setName(f'{stream_in.getName()}_out')\n",
+        "\n",
+        "    def setColdInletStream(self, stream_in):\n",
+        "        self.cold_inletstream = stream_in\n",
+        "        self.cold_outletstream = stream_in.clone()\n",
+        "        self.cold_outletstream.setName(f'{stream_in.getName()}_out')\n",
+        "\n",
+        "    def getOutStream(self, index):\n",
+        "        if index == 0:\n",
+        "            return self.hot_outletstream\n",
+        "        if index == 1:\n",
+        "            return self.cold_outletstream\n",
+        "        raise IndexError('Heat exchanger has two outlet streams: 0 for hot, 1 for cold.')\n",
+        "\n",
+        "    def getDuty(self):\n",
+        "        return self.duty\n",
+        "\n",
+        "    def toJson(self):\n",
+        "        snapshot = {\n",
+        "            'name': self.getName(),\n",
+        "            'UA_W_per_K': self.ua_value,\n",
+        "            'duty_kW': None if self.duty is None else self.duty / 1e3,\n",
+        "        }\n",
+        "        if self.hot_outletstream is not None:\n",
+        "            snapshot['hot_out_T_C'] = self.hot_outletstream.getTemperature('C')\n",
+        "        if self.cold_outletstream is not None:\n",
+        "            snapshot['cold_out_T_C'] = self.cold_outletstream.getTemperature('C')\n",
+        "        return json.dumps(snapshot)\n",
+        "\n",
+        "    def run(self, identifier):\n",
+        "        if self.hot_inletstream is None or self.cold_inletstream is None:\n",
+        "            raise ValueError('Both hot and cold inlet streams must be set before running the ML heat exchanger.')\n",
+        "        if self.ua_value is None:\n",
+        "            raise ValueError('Please provide a UA value with setUAvalue before running the ML heat exchanger.')\n",
+        "        self.serialVersionUID = identifier\n",
+        "\n",
+        "        hot_features = {\n",
+        "            'hot_in_T_C': self.hot_inletstream.getTemperature('C'),\n",
+        "            'hot_in_p_bara': self.hot_inletstream.getPressure('bara'),\n",
+        "            'hot_in_massflow_kg_per_hr': self.hot_inletstream.getFlowRate('kg/hr'),\n",
+        "        }\n",
+        "        cold_features = {\n",
+        "            'cold_in_T_C': self.cold_inletstream.getTemperature('C'),\n",
+        "            'cold_in_p_bara': self.cold_inletstream.getPressure('bara'),\n",
+        "            'cold_in_massflow_kg_per_hr': self.cold_inletstream.getFlowRate('kg/hr'),\n",
+        "        }\n",
+        "        feature_vector = {**hot_features, **cold_features, 'UA_W_per_K': self.ua_value}\n",
+        "        X = [[feature_vector[name] for name in self.feature_names]]\n",
+        "        predictions = self.model.predict(X)[0]\n",
+        "        results = dict(zip(self.target_names, predictions))\n",
+        "        self.latest_results = {**feature_vector, **results}\n",
+        "\n",
+        "        hot_fluid = self.hot_inletstream.getFluid().clone()\n",
+        "        hot_fluid.setTemperature(float(results['hot_out_T_C']), 'C')\n",
+        "        hot_fluid.setPressure(float(hot_features['hot_in_p_bara']), 'bara')\n",
+        "        TPflash(hot_fluid)\n",
+        "        self.hot_outletstream.setFluid(hot_fluid)\n",
+        "\n",
+        "        cold_fluid = self.cold_inletstream.getFluid().clone()\n",
+        "        cold_fluid.setTemperature(float(results['cold_out_T_C']), 'C')\n",
+        "        cold_fluid.setPressure(float(cold_features['cold_in_p_bara']), 'bara')\n",
+        "        TPflash(cold_fluid)\n",
+        "        self.cold_outletstream.setFluid(cold_fluid)\n",
+        "\n",
+        "        self.duty = float(results['duty_kW']) * 1e3\n",
+        "        return self.latest_results"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 7. Validate the surrogate inside a NeqSim process system\n",
+        "\n",
+        "We now compare the surrogate with the rigorous model for a new operating point that was not part of the training set. The surrogate is added to a `ProcessSystem`, receives the hot and cold inlet streams, and produces outlet streams and duty predictions."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "validation"
+      },
+      "outputs": [],
+      "source": [
+        "validation_conditions = {\n",
+        "    'hot_in_T_C': 142.0,\n",
+        "    'hot_in_p_bara': 58.0,\n",
+        "    'hot_in_flow_MSm3_day': 1.25,\n",
+        "    'cold_in_T_C': 12.0,\n",
+        "    'cold_in_p_bara': 5.0,\n",
+        "    'cold_in_flow_kg_per_hr': 235_000.0,\n",
+        "    'UA_W_per_K': 125_000.0,\n",
+        "}\n",
+        "\n",
+        "physics_record = simulate_case(\n",
+        "    case_id='validation_reference',\n",
+        "    hot_temp_C=validation_conditions['hot_in_T_C'],\n",
+        "    hot_press_bara=validation_conditions['hot_in_p_bara'],\n",
+        "    hot_flow_MSm3_day=validation_conditions['hot_in_flow_MSm3_day'],\n",
+        "    cold_temp_C=validation_conditions['cold_in_T_C'],\n",
+        "    cold_press_bara=validation_conditions['cold_in_p_bara'],\n",
+        "    cold_flow_kg_hr=validation_conditions['cold_in_flow_kg_per_hr'],\n",
+        "    ua_value=validation_conditions['UA_W_per_K'],\n",
+        ")\n",
+        "\n",
+        "clearProcess()\n",
+        "hot_fluid_val = make_natural_gas_fluid()\n",
+        "hot_fluid_val.setTemperature(validation_conditions['hot_in_T_C'], 'C')\n",
+        "hot_fluid_val.setPressure(validation_conditions['hot_in_p_bara'], 'bara')\n",
+        "hot_fluid_val.setTotalFlowRate(validation_conditions['hot_in_flow_MSm3_day'], 'MSm3/day')\n",
+        "\n",
+        "cold_fluid_val = make_cooling_water_fluid()\n",
+        "cold_fluid_val.setTemperature(validation_conditions['cold_in_T_C'], 'C')\n",
+        "cold_fluid_val.setPressure(validation_conditions['cold_in_p_bara'], 'bara')\n",
+        "cold_fluid_val.setTotalFlowRate(validation_conditions['cold_in_flow_kg_per_hr'], 'kg/hr')\n",
+        "\n",
+        "hot_stream_ml = stream('validation_hot_in', hot_fluid_val)\n",
+        "cold_stream_ml = stream('validation_cold_in', cold_fluid_val)\n",
+        "\n",
+        "ml_hex = MachineLearningHeatExchanger(regressor, feature_columns, target_columns)\n",
+        "ml_hex.setName('ML Heat Exchanger (validation)')\n",
+        "ml_hex.setHotInletStream(hot_stream_ml)\n",
+        "ml_hex.setColdInletStream(cold_stream_ml)\n",
+        "ml_hex.setUAvalue(validation_conditions['UA_W_per_K'])\n",
+        "\n",
+        "process_ml = jNeqSim.processSimulation.processSystem.ProcessSystem()\n",
+        "process_ml.add(hot_stream_ml)\n",
+        "process_ml.add(cold_stream_ml)\n",
+        "process_ml.add(ml_hex)\n",
+        "\n",
+        "hot_out_stream_ml = jNeqSim.processSimulation.processEquipment.stream.Stream('validation_hot_out')\n",
+        "hot_out_stream_ml.setStream(ml_hex.getOutStream(0))\n",
+        "cold_out_stream_ml = jNeqSim.processSimulation.processEquipment.stream.Stream('validation_cold_out')\n",
+        "cold_out_stream_ml.setStream(ml_hex.getOutStream(1))\n",
+        "\n",
+        "process_ml.add(hot_out_stream_ml)\n",
+        "process_ml.add(cold_out_stream_ml)\n",
+        "process_ml.run()\n",
+        "\n",
+        "comparison = pd.DataFrame({\n",
+        "    'Quantity': [\n",
+        "        'Hot outlet temperature [\u00b0C]',\n",
+        "        'Cold outlet temperature [\u00b0C]',\n",
+        "        'Heat duty [kW]',\n",
+        "    ],\n",
+        "    'NeqSim rigorous model': [\n",
+        "        physics_record['hot_out_T_C'],\n",
+        "        physics_record['cold_out_T_C'],\n",
+        "        physics_record['duty_kW'],\n",
+        "    ],\n",
+        "    'ML surrogate': [\n",
+        "        ml_hex.getOutStream(0).getTemperature('C'),\n",
+        "        ml_hex.getOutStream(1).getTemperature('C'),\n",
+        "        ml_hex.getDuty() / 1e3,\n",
+        "    ],\n",
+        "})\n",
+        "comparison['Absolute error'] = np.abs(comparison['NeqSim rigorous model'] - comparison['ML surrogate'])\n",
+        "comparison['Relative error [%]'] = 100.0 * comparison['Absolute error'] / np.maximum(np.abs(comparison['NeqSim rigorous model']), 1e-6)\n",
+        "comparison"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "json-output"
+      },
+      "outputs": [],
+      "source": [
+        "ml_hex.toJson()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 8. Next steps\n",
+        "\n",
+        "* Replace the random forest with other regressors (for example Gaussian process regression or gradient boosting) and compare accuracy and computational cost.\n",
+        "* Augment the feature set with additional measurements such as inlet enthalpies, pressures drops, or fouling factors if they are important in your plant.\n",
+        "* Combine the surrogate unit operation with online plant data to build soft sensors or to calibrate the model continuously.\n",
+        "* Deploy the surrogate in optimisation or control studies where a fast-running model is advantageous."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## References\n",
+        "\n",
+        "* Cengel, Y. A., & Ghajar, A. J. (2015). *Heat and Mass Transfer: Fundamentals & Applications*. McGraw-Hill.\n",
+        "* Thompson, M. L., & Kramer, M. A. (1994). Modeling chemical processes using prior knowledge and neural networks. *AIChE Journal*, 40(8), 1328-1340. https://doi.org/10.1002/aic.690400803\n",
+        "* Qin, S. J. (2012). Survey on data-driven industrial process monitoring and diagnosis. *Annual Reviews in Control*, 36(2), 220-234. https://doi.org/10.1016/j.arcontrol.2012.09.004\n",
+        "* Pedregosa, F., et al. (2011). Scikit-learn: Machine learning in Python. *Journal of Machine Learning Research*, 12, 2825-2830. https://doi.org/10.1145/1953048.2078195\n",
+        "* NeqSim documentation: https://neqsim.com"
+      ]
+    }
+  ],
+  "metadata": {
+    "colab": {},
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.x"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add a new process notebook that demonstrates how to generate NeqSim heat exchanger data and train a scikit-learn surrogate
- implement a MachineLearningHeatExchanger unit operation class that wraps the trained model and exposes hot/cold outlet streams and duty
- document validation steps, next steps, and literature references for hybrid modelling of heat exchangers

## Testing
- not run (scikit-learn is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68ce6a94b158832dbac4f74758b544a4