### PR TITLE
Move Cantera example to Power production

### DIFF
--- a/notebooks/examples_of_NeqSim_in_Colab.ipynb
+++ b/notebooks/examples_of_NeqSim_in_Colab.ipynb
@@ -77,7 +77,6 @@
         "* **Intermediate** - [Hydrate, wax, and water margin screening](flowassurance/hydrate_wax_and_water_margin_screening.ipynb): screen operating margins before detailed flow-assurance analysis.\n",
         "* **Intermediate** - [CO2 chain from compression to pipeline](process/co2_chain_from_compression_to_pipeline.ipynb): simulate CO2 compression, cooling, dense-phase screening, and arrival pressure.\n",
         "* **Intermediate** - [Gas turbine emissions and process power](power/gas_turbine_emissions_and_process_power.ipynb): connect compressor power to fuel demand and CO2 emissions.\n",
-        "* **Advanced** - [Natural-gas combustion, burner devices, and NeqSim integration with Cantera](reactions/natural_gas_combustion_with_cantera.ipynb): compare fuel and oxidizer blends; boiler, furnace, low-NOx, gas-turbine, duct-burner, and flare cases; staged combustion; and a Cantera custom unit inside a NeqSim process.\\n",
         "* **Intermediate** - [Standards-based engineering checks](standards/standards_based_engineering_checks.ipynb): screen line velocity and pressure drop against public engineering checks.\n",
         "* **Advanced** - [Agentic NeqSim workflow demo](AI/agentic_neqsim_workflow_demo.ipynb): structure inputs, run NeqSim, validate results, and emit a machine-readable result object."
       ]
@@ -263,7 +262,7 @@
         "* [High Integrity Pressure Protection System (HIPPS) and process simulation](process/HIPPS_Safety_Simulations.ipynb)\n",
         "\n",
         "## Power production\n",
-        "* [Natural-gas combustion, burners, gas turbines, and NeqSim-Cantera integration](reactions/natural_gas_combustion_with_cantera.ipynb)\\n",
+        "* **Advanced** - [Natural-gas combustion, burner devices, and NeqSim integration with Cantera](reactions/natural_gas_combustion_with_cantera.ipynb): compare fuel and oxidizer blends; boiler, furnace, low-NOx, gas-turbine, duct-burner, and flare cases; staged combustion; and a Cantera custom unit inside a NeqSim process.\n",
         "* [Gas fired power plants](power/Gas_fired_power_plants.ipynb)\n",
         "* Combined cycle process\n",
         "\n",


### PR DESCRIPTION
## What changed

- remove the duplicate Cantera combustion entry from **New Capability Demonstration Notebooks**
- place the full **Advanced** entry and description under **Power production**
- fix the literal `\\n` rendering artifact in that catalog entry
- leave every other notebook page and link unchanged

## Why

The natural-gas combustion, burner, gas-turbine, flare, and NeqSim–Cantera integration example belongs in the subject-based Power production catalog rather than the temporary new-capabilities list.

## Validation

- parsed the updated front-page notebook as valid notebook JSON
- confirmed the Cantera entry is absent from New Capability and present once under Power production
- confirmed all 218 unique link targets are preserved
- confirmed no new or missing link target was introduced
- confirmed the catalog entry no longer contains a literal `\\n`