### PR TITLE
Repair NeqSim third-party integration notebook

### DIFF
--- a/notebooks/notebook_maintenance_ledger.json
+++ b/notebooks/notebook_maintenance_ledger.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "updated_at": "2026-08-02T14:15:40Z",
+  "updated_at": "2026-08-02T20:28:35.353Z",
   "notebooks": [
     {
       "path": "notebooks/AI/agentic_neqsim_workflow_demo.ipynb",
@@ -16580,7 +16580,7 @@
         "base_compressor_power_mw": 1.866389,
         "base_hot_discharge_temperature_c": 134.2514,
         "base_aftercooler_duty_mw": -2.610898,
-        "maximum_relative_mass_residual": 0.0,
+        "maximum_relative_mass_residual": 0,
         "base_fuel_lhv_kj_sm3": 38619.494472,
         "base_fuel_co2_kg_sm3": 2.249677,
         "base_turbine_annual_co2_tonnes": 9796.126256,
@@ -16694,12 +16694,12 @@
       "results": {
         "initial_gas_in_place_gsm3": 137.524,
         "produced_gas_gsm3": 80.725,
-        "recovery_percent": 58.70,
+        "recovery_percent": 58.7,
         "final_gas_rate_msm3_per_day": 6.666,
         "npv_before_tax_bn_nok": 22.77,
         "npv_after_tax_bn_nok": 4.91,
         "break_even_gas_price_nok_sm3": 0.651,
-        "maximum_relative_process_mass_residual": 3.135e-5,
+        "maximum_relative_process_mass_residual": 0.00003135,
         "fuel_lhv_mj_sm3": 37.931,
         "fuel_co2_kg_sm3": 2.157,
         "gas_turbine_compression_co2_tonnes": 1680360.333,
@@ -16802,8 +16802,8 @@
         "the Colab badge, public-PyPI setup, current ISO 6976 documentation, current NeqSim standards, phase-envelope and thermodynamic-model guides, and unique catalog target were checked"
       ],
       "results": {
-        "nominal_maximum_rich_gas_mol_percent": 47.0,
-        "uncertainty_aware_rich_gas_mol_percent": 42.0,
+        "nominal_maximum_rich_gas_mol_percent": 47,
+        "uncertainty_aware_rich_gas_mol_percent": 42,
         "uncertainty_aware_gcv_mj_m3": 41.601572,
         "uncertainty_aware_wobbe_mj_m3": 51.447621,
         "uncertainty_aware_dew_point_c_at_70_bara": 4.693335,
@@ -16812,7 +16812,7 @@
         "uncertainty_aware_mixer_outlet_temperature_c": 12.879959,
         "maximum_absolute_process_mass_residual_kg_s": 6.661e-16,
         "maximum_component_residual_mol_s": 2.132e-14,
-        "maximum_enthalpy_residual_j_s": 2.573e-05
+        "maximum_enthalpy_residual_j_s": 0.00002573
       },
       "summary": "Revalidated and extended the cataloged gas-blending notebook without removing any cell, calculation, or visual. The executed notebook now connects ISO 6976 energy quality, SRK dew-point constraints, nominal and heavy-end-aware blend optimization, pressure and standard-edition sensitivity, delivered energy, and a reusable metered NeqSim ProcessSystem with conservation and energy validation.",
       "documentation_impact": "The executed notebook is the user-facing gas-quality, blend-optimization, and process-integration documentation update. No NeqSim public API, default, or library implementation changed.",
@@ -16913,16 +16913,16 @@
         "the Colab badge, catalog target, and current NeqSim process, cost-estimation, and process-design documentation links were checked"
       ],
       "results": {
-        "base_feed_kg_h": 10000.0,
+        "base_feed_kg_h": 10000,
         "base_compressor_power_kw": 316.417,
-        "base_export_pressure_bara": 95.0,
-        "base_total_project_cost_usd": 1974477.0,
+        "base_export_pressure_bara": 95,
+        "base_total_project_cost_usd": 1974477,
         "base_annual_opex_usd": 1891507.019,
         "base_screening_npv_usd": 9303766.276,
         "capacity_scale_exponent": 0.642,
         "application_best_option": "North Sea 10 kt/h",
-        "application_best_npv_usd": 6471988.0,
-        "application_maximum_relative_mass_residual": 2.0e-30
+        "application_best_npv_usd": 6471988,
+        "application_maximum_relative_mass_residual": 2e-30
       },
       "summary": "Revalidated and extended the process-cost notebook without removing any cell, example, or visual. The notebook now connects a current NeqSim process model and mechanical design to auditable CAPEX/OPEX/economic calculations and a reusable, conservation-checked development-option selection workflow.",
       "documentation_impact": "The executed notebook is the user-facing process-cost, mechanical-design, and concept-screening documentation update. No NeqSim public API, default, or library implementation changed.",
@@ -17025,18 +17025,18 @@
         "the Colab badge, catalog target, Reaktoro reference, and current NeqSim home, thermodynamic-model, thermodynamics-index, thermodynamic-operations, and process documentation links were checked"
       ],
       "results": {
-        "reference_temperature_c": 10.0,
-        "reference_pressure_bara": 70.0,
-        "reference_solid_sulfur_ppm_mass": 14.570,
+        "reference_temperature_c": 10,
+        "reference_pressure_bara": 70,
+        "reference_solid_sulfur_ppm_mass": 14.57,
         "selective_s8_kg_per_kg_oxygen": 2.004,
-        "application_feed_kg_h": 10000.0,
-        "application_outlet_pressure_bara": 20.0,
+        "application_feed_kg_h": 10000,
+        "application_outlet_pressure_bara": 20,
         "application_unheated_outlet_temperature_c": -6.4451,
         "application_unheated_solid_sulfur_ppm_mass": 14.5766,
         "application_120c_heater_duty_kw": 730.9586,
         "application_120c_outlet_temperature_c": 107.7083,
-        "application_120c_solid_sulfur_ppm_mass": 0.0,
-        "application_maximum_relative_mass_residual": 0.0
+        "application_120c_solid_sulfur_ppm_mass": 0,
+        "application_maximum_relative_mass_residual": 0
       },
       "summary": "Modernized and expanded the elemental-sulfur notebook without removing any cell, example, or figure. The executed tutorial now connects corrected sulfur chemistry, current NeqSim S8 solid flashes, phase envelopes, enthalpy contours, deposition screening, and a reusable heater-valve mitigation process with conservation checks and five inspected figures.",
       "documentation_impact": "The executed notebook is the user-facing sulfur-chemistry, solid-equilibrium, phase-map, and pressure-station mitigation documentation update. No NeqSim public API, default, or library implementation changed.",
@@ -17046,6 +17046,130 @@
         "branch": "automation/repair-elemental-sulfur",
         "files": [
           "notebooks/material/elemental_sulfur.ipynb",
+          "notebooks/notebook_maintenance_ledger.json"
+        ]
+      }
+    },
+    {
+      "path": "notebooks/process/neqsimreaktoro.ipynb",
+      "verified_date": "2026-08-02",
+      "verified_at_utc": "2026-08-02T20:28:35.353Z",
+      "neqsim_version": "3.16.0",
+      "python_version": "3.12.13",
+      "java_version": "OpenJDK 17.0.19",
+      "execution_status": "passed",
+      "environment_resolution": {
+        "mode": "online-new-snapshot",
+        "bootstrap": "python scripts/bootstrap_neqsim_validation_env.py --venv /tmp/neqsim-validation-third-party-integration-20260802b --neqsim-version latest --extra-package CoolProp --extra-package thermopack --extra-package cantera --extra-package fluids --extra-package scipy --extra-package nbconvert --extra-package ipykernel --refresh",
+        "snapshot": "/workspace/.cache/neqsim-validation-wheelhouse/schema-1/cpython-312-linux-x86_64/neqsim-3.16.0/20260802T200846Z-9d408344780a",
+        "verified_public_pypi_wheels": 71,
+        "manifest_created_at_utc": "2026-08-02T20:08:46Z",
+        "integrity": "The complete public-PyPI wheel inventory, file sizes, SHA-256 hashes, Python runtime, Linux platform, and requested third-party notebook toolchain passed verification."
+      },
+      "cell_counts": {
+        "code": 26,
+        "markdown": 15,
+        "total": 41
+      },
+      "preservation": {
+        "original_cells": 31,
+        "original_cells_preserved": 31,
+        "original_code_cells": 21,
+        "original_code_cells_preserved": 21,
+        "pre_existing_examples": 5,
+        "pre_existing_examples_preserved": 5,
+        "pre_existing_figures": 1,
+        "pre_existing_figures_preserved": 1,
+        "pre_existing_figures_numerically_refreshed": 0,
+        "details": "Preserved every original cell and all five substantive third-party integration examples: Reaktoro-inspired carbonate and pH chemistry, CoolProp pure-CO2 properties, ThermoPack SAFT-VR Mie mixture properties, Cantera premixed flame speed, and fluids orifice pressure loss. The original embedded Cantera reactant/product illustration was retained with verified provenance and identified as a historical conceptual visual."
+      },
+      "repairs": [
+        "replaced the NeqSim 2.5.35 pin, deprecated jNeqSim/processSimulation/thermoTools paths, compressed code, and notebook-installed runtime replacement with current NeqSim 3.16.0 APIs and a public-PyPI-compatible setup cell",
+        "replaced inaccessible Conda-only Reaktoro execution with a transparent carbonate charge-balance screening model while preserving the original CO2-fugacity-to-aqueous-pH process contract and documenting when full Reaktoro is required",
+        "corrected CoolProp integration to use explicit SI inputs and independent pure-CO2 density comparison",
+        "corrected ThermoPack phase selection, current SAFT-VR Mie component identifiers, composition conversion, tuple return handling, and density units",
+        "removed notebook magics from the Cantera class, corrected equivalence-ratio semantics, bounded the FreeFlame solve, refreshed the flame calculation, and retained an interpreted temperature profile",
+        "replaced the assumed-pressure dP_orifice call with differential_pressure_meter_solver driven by NeqSim mass flow, density, viscosity, and heat-capacity ratio",
+        "fixed the cloned pre-run orifice outlet state by wiring the actual unit output stream into the ProcessSystem",
+        "added current documentation, explicit units, assumptions, validation assertions, model-boundary guidance, practical exercises, and a complete rich-gas conditioning application"
+      ],
+      "neqsim_capabilities": [
+        "current fluid helper and lower-case jneqsim gateway with SRK fluids, classic mixing rule, phase and physical-property initialization",
+        "named Stream and Python-defined unit operations participating in ProcessSystem execution",
+        "Stream, Cooler, ThrottlingValve, Separator, and ProcessSystem composition for three rich-gas delivery scenarios",
+        "temperature, pressure, fugacity coefficient, composition, density, viscosity, heat-capacity ratio, product flow, and mass-closure retrieval",
+        "cross-library model-boundary integration with CoolProp 8.0.0, ThermoPack 2.2.3, Cantera 3.2.0, fluids 1.3.1, and SciPy 1.18.0"
+      ],
+      "practical_application": "A reusable 30,000 kg/h rich-gas conditioning workflow builds a fresh SRK fluid and Stream-Cooler-ThrottlingValve-Separator-ProcessSystem graph, varies delivery pressure across 40, 55, and 70 bara, retrieves valve temperature and gas/liquid products, verifies finiteness and exact total-mass closure, and quantifies the coupled Joule-Thomson cooling and condensate-recovery trend.",
+      "figures": {
+        "previous_figures_preserved": 1,
+        "previous_figures_numerically_refreshed": 0,
+        "new_figures": 5,
+        "total_retained_figures": 6,
+        "purposes": [
+          "preserved original externally sourced Cantera reactant/product flame illustration with provenance",
+          "new calculated premixed fuel-gas flame temperature profile",
+          "new NeqSim-to-external-library model-boundary workflow overview",
+          "new pure-CO2 NeqSim SRK versus CoolProp pressure-density comparison",
+          "new orifice differential-pressure versus mass-flow sensitivity",
+          "new delivery-pressure comparison of condensed liquid and valve outlet temperature"
+        ],
+        "visual_inspection": "Passed after the final complete execution. The original embedded image and all five stored PNG outputs were extracted and inspected at original resolution for descriptive titles, readable labels, explicit units, legends where applicable, accessible colors, correct scales and trends, clipping, overlap, stale values, and consistency with stored tables and nearby interpretation."
+      },
+      "equation_rendering": {
+        "status": "passed",
+        "display_equations": 4,
+        "inline_expressions": 12,
+        "source_check": "Balanced inline delimiters, standalone display delimiters with surrounding blank lines, single-backslash commands, and absence of obsolete or doubled delimiters passed.",
+        "visual_preview": "All 16 expressions rendered through a Jupyter-compatible MathText path and were visually inspected for fractions, subscripts, superscripts, Greek symbols, units, and mass-flow notation. Jupyter nbconvert also produced a complete HTML/MathJax preview with retained outputs."
+      },
+      "key_checks": [
+        "valid nbformat 4.5 JSON with 26 code and 15 Markdown cells",
+        "26/26 code cells executed sequentially from cleared outputs with counts 1 through 26, zero exceptions, zero error outputs, and zero stderr",
+        "all 31 original cells, 21 original code cells, five substantive examples, and the original embedded visual were preserved",
+        "maximum Python code-line length was 93 characters with no semicolons, obsolete gateway paths, notebook magics, or compressed one-line compound bodies",
+        "the carbonate screen returned pH 5.69453 with finite calcite saturation index from NeqSim CO2 fugacity",
+        "CoolProp and NeqSim pure-CO2 densities and ThermoPack and NeqSim CO2-rich densities were positive and finite",
+        "the Cantera FreeFlame calculation returned 0.6217 m/s flame speed and 2292.7353 K maximum temperature",
+        "the repaired 3,000 kg/h methane orifice returned 0.30083 bara differential pressure and a lower connected outlet pressure",
+        "the eight-point orifice sweep was finite, positive, and strictly increasing with mass flow",
+        "all three rich-gas cases produced finite positive gas and liquid flows and maximum relative mass residual 0.0",
+        "valve outlet temperature increased from -13.838194 to 0.638373 degrees C as delivery pressure increased from 40 to 70 bara, while liquid recovery decreased from 10.835162 to 3.803336 wt%",
+        "four display equations and 12 inline expressions passed Colab-safe source, HTML/MathJax, and visual rendering inspection",
+        "all six figures passed final visual and numerical review",
+        "the Colab badge, catalog target, original Cantera provenance link, and current NeqSim, CoolProp, ThermoPack, Cantera, fluids, and Reaktoro documentation targets were checked"
+      ],
+      "results": {
+        "carbonate_pH": 5.69453,
+        "cantera_flame_speed_m_s": 0.6217,
+        "cantera_maximum_temperature_K": 2292.7353,
+        "orifice_differential_pressure_bara": 0.30083,
+        "application_feed_kg_h": 30000,
+        "application_delivery_pressures_bara": [
+          40,
+          55,
+          70
+        ],
+        "application_liquid_products_kg_h": [
+          3250.548711,
+          2566.39032,
+          1141.000653
+        ],
+        "application_valve_outlet_temperatures_c": [
+          -13.838194,
+          -6.007147,
+          0.638373
+        ],
+        "application_maximum_relative_mass_residual": 0
+      },
+      "summary": "Modernized and expanded the third-party integration notebook without removing any cell, example, or figure. The executed tutorial now connects current NeqSim process objects to auditable carbonate screening, CoolProp, ThermoPack, Cantera, and fluids calculations, then reuses native NeqSim equipment in a validated rich-gas conditioning study with six inspected figures.",
+      "documentation_impact": "The executed notebook is the user-facing third-party integration and model-boundary documentation update. It documents current NeqSim APIs and external-library scope; no NeqSim public API, default, or library implementation changed.",
+      "neqsim_defect_found": false,
+      "publication": {
+        "mode": "draft pull request",
+        "branch": "automation/repair-third-party-integrations",
+        "files": [
+          "notebooks/process/neqsimreaktoro.ipynb",
           "notebooks/notebook_maintenance_ledger.json"
         ]
       }

--- a/notebooks/notebook_maintenance_ledger.json
+++ b/notebooks/notebook_maintenance_ledger.json
@@ -16580,7 +16580,7 @@
         "base_compressor_power_mw": 1.866389,
         "base_hot_discharge_temperature_c": 134.2514,
         "base_aftercooler_duty_mw": -2.610898,
-        "maximum_relative_mass_residual": 0,
+        "maximum_relative_mass_residual": 0.0,
         "base_fuel_lhv_kj_sm3": 38619.494472,
         "base_fuel_co2_kg_sm3": 2.249677,
         "base_turbine_annual_co2_tonnes": 9796.126256,
@@ -16694,12 +16694,12 @@
       "results": {
         "initial_gas_in_place_gsm3": 137.524,
         "produced_gas_gsm3": 80.725,
-        "recovery_percent": 58.7,
+        "recovery_percent": 58.70,
         "final_gas_rate_msm3_per_day": 6.666,
         "npv_before_tax_bn_nok": 22.77,
         "npv_after_tax_bn_nok": 4.91,
         "break_even_gas_price_nok_sm3": 0.651,
-        "maximum_relative_process_mass_residual": 0.00003135,
+        "maximum_relative_process_mass_residual": 3.135e-5,
         "fuel_lhv_mj_sm3": 37.931,
         "fuel_co2_kg_sm3": 2.157,
         "gas_turbine_compression_co2_tonnes": 1680360.333,
@@ -16802,8 +16802,8 @@
         "the Colab badge, public-PyPI setup, current ISO 6976 documentation, current NeqSim standards, phase-envelope and thermodynamic-model guides, and unique catalog target were checked"
       ],
       "results": {
-        "nominal_maximum_rich_gas_mol_percent": 47,
-        "uncertainty_aware_rich_gas_mol_percent": 42,
+        "nominal_maximum_rich_gas_mol_percent": 47.0,
+        "uncertainty_aware_rich_gas_mol_percent": 42.0,
         "uncertainty_aware_gcv_mj_m3": 41.601572,
         "uncertainty_aware_wobbe_mj_m3": 51.447621,
         "uncertainty_aware_dew_point_c_at_70_bara": 4.693335,
@@ -16812,7 +16812,7 @@
         "uncertainty_aware_mixer_outlet_temperature_c": 12.879959,
         "maximum_absolute_process_mass_residual_kg_s": 6.661e-16,
         "maximum_component_residual_mol_s": 2.132e-14,
-        "maximum_enthalpy_residual_j_s": 0.00002573
+        "maximum_enthalpy_residual_j_s": 2.573e-05
       },
       "summary": "Revalidated and extended the cataloged gas-blending notebook without removing any cell, calculation, or visual. The executed notebook now connects ISO 6976 energy quality, SRK dew-point constraints, nominal and heavy-end-aware blend optimization, pressure and standard-edition sensitivity, delivered energy, and a reusable metered NeqSim ProcessSystem with conservation and energy validation.",
       "documentation_impact": "The executed notebook is the user-facing gas-quality, blend-optimization, and process-integration documentation update. No NeqSim public API, default, or library implementation changed.",
@@ -16913,16 +16913,16 @@
         "the Colab badge, catalog target, and current NeqSim process, cost-estimation, and process-design documentation links were checked"
       ],
       "results": {
-        "base_feed_kg_h": 10000,
+        "base_feed_kg_h": 10000.0,
         "base_compressor_power_kw": 316.417,
-        "base_export_pressure_bara": 95,
-        "base_total_project_cost_usd": 1974477,
+        "base_export_pressure_bara": 95.0,
+        "base_total_project_cost_usd": 1974477.0,
         "base_annual_opex_usd": 1891507.019,
         "base_screening_npv_usd": 9303766.276,
         "capacity_scale_exponent": 0.642,
         "application_best_option": "North Sea 10 kt/h",
-        "application_best_npv_usd": 6471988,
-        "application_maximum_relative_mass_residual": 2e-30
+        "application_best_npv_usd": 6471988.0,
+        "application_maximum_relative_mass_residual": 2.0e-30
       },
       "summary": "Revalidated and extended the process-cost notebook without removing any cell, example, or visual. The notebook now connects a current NeqSim process model and mechanical design to auditable CAPEX/OPEX/economic calculations and a reusable, conservation-checked development-option selection workflow.",
       "documentation_impact": "The executed notebook is the user-facing process-cost, mechanical-design, and concept-screening documentation update. No NeqSim public API, default, or library implementation changed.",
@@ -17025,18 +17025,18 @@
         "the Colab badge, catalog target, Reaktoro reference, and current NeqSim home, thermodynamic-model, thermodynamics-index, thermodynamic-operations, and process documentation links were checked"
       ],
       "results": {
-        "reference_temperature_c": 10,
-        "reference_pressure_bara": 70,
-        "reference_solid_sulfur_ppm_mass": 14.57,
+        "reference_temperature_c": 10.0,
+        "reference_pressure_bara": 70.0,
+        "reference_solid_sulfur_ppm_mass": 14.570,
         "selective_s8_kg_per_kg_oxygen": 2.004,
-        "application_feed_kg_h": 10000,
-        "application_outlet_pressure_bara": 20,
+        "application_feed_kg_h": 10000.0,
+        "application_outlet_pressure_bara": 20.0,
         "application_unheated_outlet_temperature_c": -6.4451,
         "application_unheated_solid_sulfur_ppm_mass": 14.5766,
         "application_120c_heater_duty_kw": 730.9586,
         "application_120c_outlet_temperature_c": 107.7083,
-        "application_120c_solid_sulfur_ppm_mass": 0,
-        "application_maximum_relative_mass_residual": 0
+        "application_120c_solid_sulfur_ppm_mass": 0.0,
+        "application_maximum_relative_mass_residual": 0.0
       },
       "summary": "Modernized and expanded the elemental-sulfur notebook without removing any cell, example, or figure. The executed tutorial now connects corrected sulfur chemistry, current NeqSim S8 solid flashes, phase envelopes, enthalpy contours, deposition screening, and a reusable heater-valve mitigation process with conservation checks and five inspected figures.",
       "documentation_impact": "The executed notebook is the user-facing sulfur-chemistry, solid-equilibrium, phase-map, and pressure-station mitigation documentation update. No NeqSim public API, default, or library implementation changed.",

--- a/notebooks/process/neqsimreaktoro.ipynb
+++ b/notebooks/process/neqsimreaktoro.ipynb
@@ -1,969 +1,1851 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "provenance": [],
-      "include_colab_link": true
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    },
-    "language_info": {
-      "name": "python"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "2ee98a91",
+   "metadata": {
+    "colab_type": "text",
+    "id": "view-in-github"
+   },
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/EvenSol/NeqSim-Colab/blob/master/notebooks/process/neqsimreaktoro.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
   },
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
-      },
-      "source": [
-        "<a href=\"https://colab.research.google.com/github/EvenSol/NeqSim-Colab/blob/master/notebooks/process/neqsimreaktoro.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
+  {
+   "cell_type": "markdown",
+   "id": "12f48ba0",
+   "metadata": {
+    "id": "s863d-bFHkjw"
+   },
+   "source": [
+    "# NeqSim with third-party engineering libraries\n",
+    "\n",
+    "This notebook shows how a Python-defined unit operation can participate in a real NeqSim\n",
+    "`ProcessSystem` while delegating a focused calculation to another public Python package.\n",
+    "The retained examples cover carbonate chemistry inspired by Reaktoro, CoolProp property\n",
+    "cross-checks, ThermoPack SAFT-VR Mie calculations, Cantera combustion, and `fluids` orifice\n",
+    "sizing.\n",
+    "\n",
+    "## Learning objectives\n",
+    "\n",
+    "After completing the notebook, you should be able to:\n",
+    "\n",
+    "- build and execute NeqSim streams and process systems with the current Python API;\n",
+    "- wrap a third-party calculation as a reusable NeqSim Python unit operation;\n",
+    "- pass temperature, pressure, composition, and flow between model boundaries with explicit units;\n",
+    "- compare independent thermodynamic models without assuming that they must agree exactly;\n",
+    "- check process mass balance, numerical finiteness, and expected engineering trends; and\n",
+    "- assemble the integrations into a reproducible gas-conditioning study.\n",
+    "\n",
+    "All numerical results are screening calculations. Model selection, property conventions,\n",
+    "chemical-speciation databases, and equipment standards must be reviewed before design use."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9f59854e",
+   "metadata": {
+    "id": "wk4-LsDJbqjL"
+   },
+   "source": [
+    "## 1. Carbonate chemistry at a NeqSim process boundary\n",
+    "\n",
+    "The original example used Reaktoro to calculate aqueous pH from the CO2 fugacity supplied by\n",
+    "a NeqSim gas stream. Reaktoro is not part of the public-PyPI-only Colab toolchain, so this\n",
+    "notebook preserves that engineering workflow with a transparent carbonate-equilibrium model.\n",
+    "It keeps the same process boundary and reports pH and calcite saturation, while making the\n",
+    "scope explicit. Install Reaktoro separately when mineral databases, activity models, or\n",
+    "reactive transport are required.\n",
+    "\n",
+    "For dissolved CO2 concentration $c_0$ in mol/L and hydrogen-ion concentration $h$ in mol/L,\n",
+    "the carbonate species are estimated from:\n",
+    "\n",
+    "$$\n",
+    "c_{\\mathrm{HCO_3^-}} = \\frac{K_1 c_0}{h}\n",
+    "$$\n",
+    "\n",
+    "$$\n",
+    "c_{\\mathrm{CO_3^{2-}}} = \\frac{K_1 K_2 c_0}{h^2}\n",
+    "$$\n",
+    "\n",
+    "The charge-balance residual is solved for a specified alkalinity. Temperature-dependent\n",
+    "equilibrium constants and non-ideal aqueous activity corrections are outside this compact\n",
+    "screening model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "db3fd751",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
     },
+    "id": "F1oAKqiybXFf",
+    "outputId": "49be52ee-f939-4451-8e57-4b303dc16a06"
+   },
+   "outputs": [
     {
-      "cell_type": "markdown",
-      "source": [
-        "# Use of third party libraries in NeqSim process simulations\n",
-        "In this workbook we will give examples of how to use third party tools such as Reaktoro, Refprop, CoolProp, Cantera and ThermoPack in a NeqSim process simulation.\n",
-        "\n",
-        "This documentation is part of [Introduction of Gas Processsing using NeqSim and Python](https://colab.research.google.com/github/EvenSol/NeqSim-Colab/blob/master/notebooks/examples_of_NeqSim_in_Colab.ipynb)."
-      ],
-      "metadata": {
-        "id": "s863d-bFHkjw"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "# Use of Reaktoro as a unit operation in NeqSim process simulation\n",
-        "In the following example we will integrate Reaktoro as an unit operation in a NeqSim process simulation"
-      ],
-      "metadata": {
-        "id": "wk4-LsDJbqjL"
-      }
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 78,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "F1oAKqiybXFf",
-        "outputId": "49be52ee-f939-4451-8e57-4b303dc16a06"
-      },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Requirement already satisfied: neqsim==2.5.35 in /usr/local/lib/python3.10/dist-packages (2.5.35)\n",
-            "Requirement already satisfied: JPype1<2.0.0,>=1.5.0 in /usr/local/lib/python3.10/dist-packages (from neqsim==2.5.35) (1.5.0)\n",
-            "Requirement already satisfied: numpy<2.0.0,>=1.25.2 in /usr/local/lib/python3.10/dist-packages (from neqsim==2.5.35) (1.26.4)\n",
-            "Requirement already satisfied: pandas<3.0.0,>=2.0.3 in /usr/local/lib/python3.10/dist-packages (from neqsim==2.5.35) (2.2.2)\n",
-            "Requirement already satisfied: packaging in /usr/local/lib/python3.10/dist-packages (from JPype1<2.0.0,>=1.5.0->neqsim==2.5.35) (24.1)\n",
-            "Requirement already satisfied: python-dateutil>=2.8.2 in /usr/local/lib/python3.10/dist-packages (from pandas<3.0.0,>=2.0.3->neqsim==2.5.35) (2.8.2)\n",
-            "Requirement already satisfied: pytz>=2020.1 in /usr/local/lib/python3.10/dist-packages (from pandas<3.0.0,>=2.0.3->neqsim==2.5.35) (2024.2)\n",
-            "Requirement already satisfied: tzdata>=2022.7 in /usr/local/lib/python3.10/dist-packages (from pandas<3.0.0,>=2.0.3->neqsim==2.5.35) (2024.2)\n",
-            "Requirement already satisfied: six>=1.5 in /usr/local/lib/python3.10/dist-packages (from python-dateutil>=2.8.2->pandas<3.0.0,>=2.0.3->neqsim==2.5.35) (1.16.0)\n"
-          ]
-        }
-      ],
-      "source": [
-        "!pip install neqsim==2.5.35"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "%%capture\n",
-        "!pip install -q condacolab\n",
-        "import condacolab\n",
-        "condacolab.install_from_url(\"https://repo.anaconda.com/miniconda/Miniconda3-py38_4.12.0-Linux-x86_64.sh\")\n",
-        "!conda config --remove channels defaults\n",
-        "!conda config --add channels conda-forge\n",
-        "!conda install reaktoro -y"
-      ],
-      "metadata": {
-        "id": "6R_27ps-b4le"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "# Implementing a Reaktoro unit operation in NeqSim"
-      ],
-      "metadata": {
-        "id": "158kYPMGc1hy"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "from neqsim.process.unitop import unitop\n",
-        "from neqsim import jNeqSim\n",
-        "from jpype import JImplements, JOverride\n",
-        "import reaktoro as rkt\n",
-        "import json\n",
-        "\n",
-        "class ReaktoroUnitOperation(unitop):\n",
-        "    def __init__(self):\n",
-        "        super().__init__()\n",
-        "        self.serialVersionUID = None\n",
-        "        self.name = \"\"\n",
-        "        self.inputstream = None\n",
-        "        self.aprops = None\n",
-        "        self.fugacity_co2 = None\n",
-        "\n",
-        "    def setInputStream(self, stream):\n",
-        "        self.inputstream = stream\n",
-        "\n",
-        "    def calc_reaktoro(self, pressure, temperature , fugacity_co2):\n",
-        "      db = rkt.PhreeqcDatabase(\"phreeqc.dat\")\n",
-        "      solution = rkt.AqueousPhase(rkt.speciate(\"H O Na Cl C Ca\"))\n",
-        "      solution.set(rkt.ActivityModelPhreeqc(db))\n",
-        "\n",
-        "      calcite = rkt.MineralPhase(\"Calcite\")\n",
-        "\n",
-        "      system = rkt.ChemicalSystem(db, solution, calcite)\n",
-        "\n",
-        "      specs = rkt.EquilibriumSpecs(system)\n",
-        "      specs.temperature()\n",
-        "      specs.pressure()\n",
-        "      specs.fugacity(\"CO2(g)\")\n",
-        "\n",
-        "      solver = rkt.EquilibriumSolver(specs)\n",
-        "\n",
-        "      state = rkt.ChemicalState(system)\n",
-        "      state.temperature(50.0, \"celsius\")\n",
-        "      state.pressure(10.0, \"bar\")\n",
-        "      state.set(\"H2O\", 1.0, \"kg\")\n",
-        "      state.set(\"Na+\", 1.0, \"mol\")\n",
-        "      state.set(\"Cl-\", 1.0, \"mol\")\n",
-        "      state.set(\"Calcite\", 10, \"g\")\n",
-        "\n",
-        "      conditions = rkt.EquilibriumConditions(specs)\n",
-        "      conditions.temperature(temperature, \"celsius\")\n",
-        "      conditions.pressure(pressure, \"bar\")\n",
-        "      conditions.fugacity(\"CO2(g)\", fugacity_co2, \"bar\")\n",
-        "\n",
-        "      result = solver.solve(state, conditions)\n",
-        "      return rkt.AqueousProps(state)\n",
-        "\n",
-        "    @JOverride\n",
-        "    def run(self, uuid):\n",
-        "      self.serialVersionUID = uuid\n",
-        "      print(\"ReaktoroUnitOperation.run()\")\n",
-        "      self.fugacity_co2 = self.inputstream.getFluid().getPhase(0).getFugacity('CO2')\n",
-        "      self.aprops = self.calc_reaktoro(self.inputstream.getPressure('bara'), self.inputstream.getTemperature('C'), self.fugacity_co2)\n",
-        "\n",
-        "    @JOverride\n",
-        "    def toJson(self):\n",
-        "      data_dict = {\n",
-        "            \"name\": self.name,\n",
-        "            \"pH\": self.aprops.pH()[0],\n",
-        "            \"fugacity CO2\": self.fugacity_co2\n",
-        "      }\n",
-        "      return json.dumps(data_dict)\n"
-      ],
-      "metadata": {
-        "id": "71qW9mH-dFEo"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "# Implement the Reaktoro unit operation in a NeqSim simulation\n",
-        "The unit operation will report the pH of an aqueous phase with some ions in equilibrium with the gas."
-      ],
-      "metadata": {
-        "id": "D5qdzKGdjxde"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "from neqsim.thermo import fluid\n",
-        "fluid1 = fluid(\"srk\")  # create a fluid using the SRK-EoS\n",
-        "fluid1.setTemperature(30.0, \"C\")\n",
-        "fluid1.setPressure(100.0, \"bara\")\n",
-        "fluid1.addComponent(\"methane\", 0.9)\n",
-        "fluid1.addComponent(\"CO2\", 0.1)\n",
-        "fluid1.setMixingRule(2)\n",
-        "\n",
-        "stream1 = jNeqSim.processSimulation.processEquipment.stream.Stream(fluid1)\n",
-        "stream1.setFlowRate(30000, \"kg/hr\")\n",
-        "\n",
-        "uop = ReaktoroUnitOperation()\n",
-        "uop.setName(\"Reaktoro Unit Operation\")\n",
-        "uop.setInputStream(stream1)\n",
-        "\n",
-        "example_process = jNeqSim.processSimulation.processSystem.ProcessSystem()\n",
-        "example_process.add(stream1)\n",
-        "example_process.add(uop)\n",
-        "\n",
-        "example_process.run()\n"
-      ],
-      "metadata": {
-        "id": "0_0qWw3EkAHe"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "json_report= str(jNeqSim.processSimulation.util.report.Report(example_process).generateJsonReport())\n",
-        "output = json.loads(json_report)\n",
-        "print(output['Reaktoro Unit Operation'])"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "WcuaEZXlkrtc",
-        "outputId": "b5971961-a1ee-421b-fdc7-98b6680b60a6"
-      },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "ReaktoroUnitOperation.run()\n",
-            "{'name': 'Reaktoro Unit Operation', 'pH': 5.520539435475417, 'fugacity CO2': 6.970782669382442}\n"
-          ]
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "# Use of CoolProp as a unit operation in NeqSim process simulation\n",
-        "In the following example we will integrate CoolProp as an unit operation in a NeqSim process simulation\n",
-        "\n",
-        "http://www.coolprop.org/coolprop/examples.html"
-      ],
-      "metadata": {
-        "id": "slLtdQV5IGZ8"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "!pip install CoolProp"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "iyd2CbqYINU4",
-        "outputId": "21c1e26c-0d07-4053-8896-09c5c60d08e7"
-      },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Requirement already satisfied: CoolProp in /usr/local/lib/python3.10/site-packages (6.6.0)\n"
-          ]
-        }
-      ]
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "from neqsim.process.unitop import unitop\n",
-        "from neqsim import jNeqSim\n",
-        "from jpype import JImplements, JOverride\n",
-        "import CoolProp.CoolProp as CP\n",
-        "from CoolProp.CoolProp import PropsSI\n",
-        "import json\n",
-        "\n",
-        "class CoolPropUnitOperation(unitop):\n",
-        "    def __init__(self):\n",
-        "        super().__init__()\n",
-        "        self.serialVersionUID = None\n",
-        "        self.name = \"\"\n",
-        "        self.inputstream = None\n",
-        "        self.densityCO2 = None\n",
-        "        self.densityCO2_neqsim = None\n",
-        "\n",
-        "\n",
-        "    def setInputStream(self, stream):\n",
-        "        self.inputstream = stream\n",
-        "\n",
-        "    def calc_cool_prop(self):\n",
-        "      return PropsSI('D', 'T', self.inputstream.getTemperature('K'), 'P', self.inputstream.getPressure('Pa'), 'CO2')\n",
-        "\n",
-        "    @JOverride\n",
-        "    def run(self, uuid):\n",
-        "      self.serialVersionUID = id\n",
-        "      self.inputstream.getFluid().initPhysicalProperties('Density')\n",
-        "      self.densityCO2 = self.calc_cool_prop()\n",
-        "      self.densityCO2_neqsim = self.inputstream.getFluid().getPhase(0).getDensity('kg/m3')\n",
-        "\n",
-        "    @JOverride\n",
-        "    def toJson(self):\n",
-        "      data_dict = {\n",
-        "            \"name\": self.name,\n",
-        "            \"densityCO2_CoolProp\": self.densityCO2,\n",
-        "            \"densityCO2_NeqSim\": self.densityCO2_neqsim\n",
-        "      }\n",
-        "      return json.dumps(data_dict)"
-      ],
-      "metadata": {
-        "id": "7TXXC6ehL18r"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "from neqsim.thermo import fluid\n",
-        "fluid1 = fluid(\"srk\")  # create a fluid using the SRK-EoS\n",
-        "fluid1.setTemperature(14.3, \"C\")\n",
-        "fluid1.setPressure(55.0, \"bara\")\n",
-        "fluid1.addComponent(\"CO2\", 0.1)\n",
-        "fluid1.setMixingRule(2)\n",
-        "\n",
-        "stream1 = jNeqSim.processSimulation.processEquipment.stream.Stream(fluid1)\n",
-        "stream1.setFlowRate(30000, \"kg/hr\")\n",
-        "\n",
-        "uop = CoolPropUnitOperation()\n",
-        "uop.setName(\"CoolProp Unit Operation\")\n",
-        "uop.setInputStream(stream1)\n",
-        "\n",
-        "example_process = jNeqSim.processSimulation.processSystem.ProcessSystem()\n",
-        "example_process.add(stream1)\n",
-        "example_process.add(uop)\n",
-        "\n",
-        "example_process.run()"
-      ],
-      "metadata": {
-        "id": "LrO_jcP-Rqs9"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "json_report= str(jNeqSim.processSimulation.util.report.Report(example_process).generateJsonReport())\n",
-        "output = json.loads(json_report)\n",
-        "print(output['CoolProp Unit Operation'])"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "c3Pxx5CnR0_7",
-        "outputId": "d857fc32-529e-4ead-ab77-4212056986ab"
-      },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "{'name': 'CoolProp Unit Operation', 'densityCO2_CoolProp': 837.1416548396195, 'densityCO2_NeqSim': 742.8594991083878}\n"
-          ]
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "# Use of ThermoPack as a unit operation in NeqSim process simulation\n",
-        "In the following example we will integrate ThermoPack as an unit operation in a NeqSim process simulation\n",
-        "\n",
-        "https://pypi.org/project/thermopack/"
-      ],
-      "metadata": {
-        "id": "I3Z_pMYGU178"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "!pip install thermopack"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "uHa-E5j3U9rf",
-        "outputId": "f1cdb0cb-d1c9-48b1-e16c-80a23c290a81"
-      },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Requirement already satisfied: thermopack in /usr/local/lib/python3.10/site-packages (2.2.3)\n"
-          ]
-        }
-      ]
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "from neqsim.process.unitop import unitop\n",
-        "from neqsim import jNeqSim\n",
-        "from jpype import JImplements, JOverride\n",
-        "from thermopack.saftvrmie import saftvrmie\n",
-        "import json\n",
-        "\n",
-        "class ThermoPackUnitOperation(unitop):\n",
-        "    def __init__(self):\n",
-        "        super().__init__()\n",
-        "        self.serialVersionUID = None\n",
-        "        self.name = \"\"\n",
-        "        self.inputstream = None\n",
-        "        self.densityCO2 = None\n",
-        "        self.densityCO2_neqsim = None\n",
-        "\n",
-        "    def setInputStream(self, stream):\n",
-        "        self.inputstream = stream\n",
-        "\n",
-        "    def calc_thermo_pack_prop(self):\n",
-        "      eos = saftvrmie('C1,CO2')\n",
-        "      T = 300 # Kelvin\n",
-        "      p = 1e5 # Pascal\n",
-        "      x = self.inputstream.getFluid().getzvector() # Molar composition\n",
-        "      vg, = eos.specific_volume(self.inputstream.getTemperature('K'), self.inputstream.getPressure('Pa'), x, eos.TWOPH) # Molar volume of gas phase (NB: Notice the comma)\n",
-        "      return self.inputstream.getFluid().getPhase(0).getMolarMass('kg/mol')/vg\n",
-        "\n",
-        "    @JOverride\n",
-        "    def run(self, uuid):\n",
-        "      self.serialVersionUID = uuid\n",
-        "      self.inputstream.getFluid().initPhysicalProperties('Density')\n",
-        "      self.densityCO2 = self.calc_thermo_pack_prop()\n",
-        "      self.densityCO2_neqsim = self.inputstream.getFluid().getPhase(0).getDensity('kg/m3')\n",
-        "\n",
-        "    @JOverride\n",
-        "    def toJson(self):\n",
-        "      data_dict = {\n",
-        "            \"name\": self.name,\n",
-        "            \"densityCO2_ThermoPack\": self.densityCO2,\n",
-        "            \"densityCO2_NeqSim\": self.densityCO2_neqsim\n",
-        "      }\n",
-        "      return json.dumps(data_dict)"
-      ],
-      "metadata": {
-        "id": "E78B61YsYKGG"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "from neqsim.thermo import fluid\n",
-        "fluid1 = fluid(\"srk\")  # create a fluid using the SRK-EoS\n",
-        "fluid1.setTemperature(14.3, \"C\")\n",
-        "fluid1.setPressure(65.0, \"bara\")\n",
-        "fluid1.addComponent(\"methane\", 0.01)\n",
-        "fluid1.addComponent(\"CO2\", 0.99)\n",
-        "fluid1.setMixingRule(2)\n",
-        "\n",
-        "stream1 = jNeqSim.processSimulation.processEquipment.stream.Stream(fluid1)\n",
-        "stream1.setFlowRate(30000, \"kg/hr\")\n",
-        "\n",
-        "uop = ThermoPackUnitOperation()\n",
-        "uop.setName(\"ThermoPack Unit Operation\")\n",
-        "uop.setInputStream(stream1)\n",
-        "\n",
-        "example_process = jNeqSim.processSimulation.processSystem.ProcessSystem()\n",
-        "example_process.add(stream1)\n",
-        "example_process.add(uop)\n",
-        "\n",
-        "example_process.run()"
-      ],
-      "metadata": {
-        "id": "rfniROMzZVT4"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "json_report= str(jNeqSim.processSimulation.util.report.Report(example_process).generateJsonReport())\n",
-        "output = json.loads(json_report)\n",
-        "print(output['ThermoPack Unit Operation'])"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "YgUwiNFAZccX",
-        "outputId": "f05b9255-54da-4a6a-fa34-c37450655ef8"
-      },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "{'name': 'ThermoPack Unit Operation', 'densityCO2_ThermoPack': 856.638171127874, 'densityCO2_NeqSim': 751.3317350536282}\n"
-          ]
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "**Use of Cantera as a unit operation in NeqSim process simulation**\n",
-        "\n",
-        "Cantera is an open-source collection of object-oriented software tools for problems involving chemical kinetics, thermodynamics, and transport processes.\n",
-        "\n",
-        "*   Evaluate thermodynamic and transport properties of mixtures\n",
-        "*   Evaluate species chemical production rates\n",
-        "*   Compute chemical equilibrium\n",
-        "*   Evaluate species chemical production rates\n",
-        "*   Conduct kinetics simulations with large reaction mechanisms\n",
-        "*   Simulate one-dimensional flames\n",
-        "*   Conduct reaction path analysis\n",
-        "*   Create process simulations using networks of stirred reactors\n",
-        "*   Model non-ideal fluids\n",
-        "\n",
-        "![image.png](data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAA0EAAAGACAYAAABr1mnhAAAgAElEQVR4AezdCZwcZZ3/8W9ARRFX1gOPFcUVXUVlRUQFBCdT7YHXH9EsZLJegFEJSbpaXW82632jiwiZeF9gFBWRSMhMV6WrUPAEMuN9IOuFnCoKKiT/+k366TxT09dkemb6+PB6Pa96uuupqud5d4Wq31TVr6Sd/10jaZtXrpTklysk+eVySX75viS/fE+SX74ryS/fkeSXb0vyy7ck+eUySX65VJJfvinJL9+Q5JdLJPklleSXRJJfKpL8slWSX2JJfokk+aUsyS/jkvwyJskvWyT55WJJftksyS8XSfLL1yX5ZZMkv1woyS9fk+SXCyT55auS/HK+JL98RZJfvizJL1+S5JfzJPnli5L88gVJftkoyS+fl+SXcyX55RxJfvmcJL98VpJfPiPJL5+W5JdPSfLLJyX55ROS/PJxSX75mCS/fFSSXz4iyS8bJPllVJJf1kvyy9mS/HKWJL98WJJfzpTklw9J8ssZkvzyv5L88kFJfvmAJL+cLskv75fkl/dJ8st7JfnlPZL88m5JfnmXJL+8U5Jf3iHJL2+X5Je3SfLLWyX55S2S/PJmSX75H0l+WZf9b9Mv/y3JL6dJ8subJPnljZL88gZJfnm9JL+8TpJfXivJL6+R5Jf/kuSXV0vyy6sk+eWVkvxSkuSXUJJfipL8slaSX9ZI8stqSX45VZJfVknyyymS/PIKSX55uSS/vEySX1ZK8stLJfnlZEl+OUmSX06U5JeXSPLLiyX55UWS/PJCSX55gSS//Kckv6yQ5JcRSX5ZLskvJ0jyy/GS/PIfkvyyTJJfni/JL8/Ljv1+OS47/vvludnx3y/HZsd/v/y/7Pjvl+dkx3+/PDs7/vvlWdnx3y/PzI7/fnlGdvz3yzHZ8d8vT8+O/355Wnb898tTs+O/X56SHf/9UsiO/34JsuO/X4az479flmbHf78MZcd/vzw5O/775ejs+O+Xo7Ljv1+elB3//XJkdvz3yxHZ8d8vh2fHf788MTv+++UJ2fHfL4/Pjv9+OSw7/vvlcdnx3y+HZsd/vzw2O/775ZDs+O+Xx2THf7/8e3b898vB2fHfL4/Ojv9+eVR2/PfLI7Pjv18Oyo7/fnlEdvz3y8Oz479f/i07/vvlYdnx3y8PzY7/fjkwO/775SHZ8d8v/5od//3y4Oz475cDsuO/Xx6UHf/98sDs+O+X/bPjv18ekB3//fIv2fHfL/fPjv9+uV92/PfLfbPjv1/ukx3//bJfdvz3y72z479f7pUd//1yz+z475d7ZMd/v/xzdvz3y77Z8d8vd8+O/375p+z475e7Zcd/v+yTHf/9ctfs+O+XvbPjv1/ukh3//XLn7Hi/VzV26dhkR3YQp2DAPsA+wD7APsA+wD7APsA+wD7APtCt+4BdtOnof906UPrFP0L2AfYB9gH2AfYB9gH2AfYB9gH2AdsH7E61jv7HjsWOxT7APsA+wD7APsA+wD7APsA+wD7QzfsAQRC373H7IvsA+wD7APsA+wD7APsA+wD7wEDtAwRB7PADtcN3818k6Bt/MWMfYB9gH2AfYB9gH2AfWJh9oONBkJ+pw+p+Jg+r+5k+rO5nArG6nynE6n4mEav7mUas7mcisbqfqcTqfiYTq/uZTqzuZ0Kxup8pxep+JhWr+5lWrO5nYrG6n6nF6n4mF6v7mV6s7meCsbqfKcbqfiYZq/uZZqzuZ6Kxup+pxup+Jhur+5lurO5nwrG6nynH6n4mHav7mXas7mfisbqfqcfqfiYfq/uZfqzuZwKyup8pyOp+JiGr+5mGrO5nIrK6n6nI6n4mI6v7mY6s7mdCsrqfKcnqfiYlq/uZlqzuZ2Kyup+pyep+Jier+5merO5ngrK6nynK6n4mKav7maas7meisrqfqcrqfiYrq/uZrqzuZ8Kyup8py+p+Ji2r+5m2rO5n4rK6n6nL6n4mL6v7mb6s7mcCs7qfKczqfiYxq/uZxqzuZyKzup+pzOp+JjOr+5nOrO5nQrO6nynN6n4mNav7mdas7mdis7qfqc3qfiY3q/uZ3qzuZ4Kzup8pzup+Jjmr+5nmrO5norO6n6nO6n4mO6v7me6s7mfCs7qfKc/qfiY9q/uZ9qzuZ+Kzup+pz+p+Jj+r+5n+rO5nArS6nynQ6n4mQav7mQat7mcitLqfqdDqfiZDq/uZDq3uZ0K0up8p0ep+JkWr+5kWre5nYrS6n6nR6n4mR6v7mR6t7meCtLqfKdLqfiZJq/uZJq3uZ6K0up+p0up+Jkur+5kure5nwrS6nynT6n4mTav7mTat7mfitLqfqdPqfiZPq/uZPq3uZwK1up8p1Op+JlGr+5lGre5nIrW6n6nU6n4mU6v7mU6t7mdCtbqfKdXqfiZVq/uZVq3uZ2K1up+p1ep+Jler+5lere5ngrW6nynW6n4mWav7mWat7meitbqfqdbqfiZbq/uZbq3uZ8K1up8p1+p+Jl2r+5l2re5n4rW6n6nX6n4mX6v7mX6t7mcCtrqfKdjqfiZhq9sJq1/8TMRWn8iVyewcwC8/yM4B/PLD7BzALz/KzgH88uPsHMAvP8nOAfzy0+wcwC8/y84B/PLz7BzAL7/IzgH88svsHMAvV2XnAH75VXYO4Jers3MAv/xfdg7gl19n5wB++U12DuCX32bnAH75XXYO4JffZ+cAfrFsz375Q3YO4Jdrs3MAv1yXnQP45frsHMAvN2TnAH65MTsH8MtN2TmAX/6YnQP45U/ZOYBf/pydA/jl5uwcwC9/yc4B/PLX7BzAL7dU9+mOPhPEyhBAAAEEEEAAAQQQQAABBBBAAAEEBkmgUEp3tFMGyYSxIoAAAggggAACCCCAQB8LtBMAWZs+JmBoCCCAAAIIIIAAAgggMEgCBEGD9GszVgQQQAABBBBAAAEEEBBBEDsBAggggAACCCCAAAIIDJQAQdBA/dwMFgEEEEAAAQQQQAABBAiC2AcQQAABBBBAAAEEEEBgoAQIggbq52awCCCAAAIIIIAAAgggQBDEPoAAAggggAACCCCAAAIDJUAQNFA/N4NFAAEEEEAAAQQQQAABgiD2AQQQQAABBBBAAAEEEBgoAYKggfq5GSwCCCCAAAIIIIAAAggQBLEPIIAAAggggAACCCCAwEAJEAQN1M/NYBFAAAEEEEAAAQQQQIAgiH0AAQQQQAABBBBAAAEEBkqAIGigfu6BHexGac+ydGg7ZYt0yJh00GbpwRuluwwCWiQ9xtmMSfcchDEzRgQQQAABBBAYYAGCoAH+8Qdo6F+T/jmWduxOiaSfRdJ/R9IB/UoWSzc4m0g6qZfHuVnazwK6Xh4DfUcAAQQQQACBeRYgCJpnYFbfFQJzCYJccBBL2yPpgn68OtQPQdA6aY9IWhVJN0ZSsSt2PDqBAAIIIIAAAt0pQBDUnb8LveqsQIeCoKkrSZF0bmd7t/hr64cgKJbGXcBKELT4+xQ9QAABBBBAoKsFCIK6+uehcx0SyAdBkfROu3JQr9jzQ3a1x56NiaTHlaX3R9It7gS7On1Th7rWFavpkyDoV+43Igjqit2KTiDQ3QJL1ySHzqYMrYkeVViTPLCwcsvdJS3p7tHROwQQaCVAENRKiPn9IFAnCHrHbMYVSYVIutU7yf5HJN1rNuvo5rYEQd3869A3BBDovMCyjXu2ewJUr11QSv9UKCUXDRfTVx268oK9O9/B/lnjES/fvJ8Fm/0zIqkfx9RPv0+7Y6n3b7ved+2uj3YIdKPAXIMgG1MsfdAFQTYtSyu7cay70yeCoN1RYxkEEOhdgTkGQdNOlMLkV4U1yZN6F2O+er5uj6CYrArC5MbhUtonD2r245jm6/fv/vVO+3dcSnc0+tz9I6GHCDQW6EQQNC491g+CLChqvMXpc2z7s02oYLfljUv/YrfsTV/b7n1qtr5uC4LMaov0wPXSHdsdbSzN6Xa4TdK9I2nfdrdHOwQQ6GWBXBAUlJJrgzD5brNSKKU/LITpX+qfKCU3BKuSh/UySaf7HoTpuLPqlyCoH8fU6d+9l9bn9s9W014aE31FIC/QiSBoi3T3XBD0eX87kfTi7Bmir1mJpWU2z6aRlMTS7dXsctssBXUk3cFf1tXHpKNi6fORtC2W/lbd3l9i6VuR9JEx6SmubTvT86W7RdKrYukHsfR3W59lT4ulC2Pp1ZukvWw9rYIgu+rlxhZJ72ln25ZAwi0zLh3Tapmy9ORY+mwk/d45R9JtsfSLSDqnLD0yv46ydKTbRu65rUnv+9Pzy9ln2yfK0utj6Xux9Ee3zVj6bSSNlaX/jaShesvyHQII9LpALggqlNIPtzuko1ZX7l0Ik9cWwvT66SdPSdLuOgahXcGukFX/ut4vQVA/jmkQ9sVGY3T7Z6tpo+X5HoFeEOhEEBRJB3onyhZMvNcfuyVb8Oa/LpJOsMDH+869p+gGF3y45TdL+1vQUKetW8afrrfgxi3baFoNqK5vts7sWafUEkC0CoJytwJe0mib/ve5db7Mn+fXqwkotjTrZ3Xe7RYI+gFkJD2/1XKR9G1/e1a3oCyS/txq2er8r26W7ppfB58RQKCXBeYQBLlhH33K1v3zgVC/Pfvixro7034MGPpxTLvz2/bLMq2CHze/X8bLOAZToBNBUFk6zj9ptis/vmYuCPpg9YqLH7xM1cvStD84jkn3yd5vc21u3XYF5IpY2hhLV1aviNTWFUm/HJMa3nlRPcnPZ7SzF6JuslTSuQDgJ7H0V7f9ei9Lna8gaLP04MzxKrft6vTvkfT9LOj8TLWvN/vzI+ks516WnhlJv64WM5syyrLD3eS+tzG79ja1F6lmV8dq66zaXmLWZelTsbTVT4Jh64ykL/jroI4AAr0u0IEgyAiGi5UXuxMlmwZh+j+9TtOp/vdjwNCPY+rU792L6/H/7Tar9+LY6DMCTmCuQZA9mxJL33Un2Ta1k2m3fpvmgiD/VrbPl6UTI+kMu7WrLD3BXy6Wzs+t92PZVaZ9/DabpH+KpE/77eKp83m/1c569Ra433lt/1ZN4lDL6GrPB9ntcNXb9GrBlS2zkEFQJE27AlSWPmdj9Ud1kXQ/e0mtNx7r7wv8NlZv95mgWLKAx435G+PSg/Lryq44PSCWLnbtLFCyfuTb8RkBBHpVoFNB0KrxB/knT0GYfnqWJEuOPPXi+2vZxj1nuVzT5kOnRPcdDsf/pVOZ6w4PN97F0oMfunJ92w9qdipg6PRYDM7GYVfyDly9aeqe8KaY3sy5jslupRwqRjx86pkuZtX/t9usvph9ZNsIzFVgLkFQ9STcrkq4E2cLFKJ8n3JBkLXdbs+55Nv5n7MrOi/KrXetPz9fz557eU2u/Yo6bfzb8ixYC/Jt3OdIOtZfn9UXKgiKpeX+tiPpLa5f+Wlme+fqsztTv4Hdxpdv004QdIG0t3s2qjrWA/LrcZ8tmLTng7w+vtrNY4oAAr0u0KEgKFg1ds9pJ09hcl4rmqEwelwhrJwRhGmlEKZ/tOWDUnJLIUy/HZTSDUEpXtpqHf5864Ol6g6KySeDMLmsUEpu8vsUhOnvC2Hy+aVrK0/zl2tVXxpWnlwIk89OLe8yZ4XJbYVS8osgTM5ZGqYzHtRcWqwcWQjTr1mZGlN1uaCUTLrvC8VK3Qc1rT+dGstwMVnutheUKv9p67ZAbsopTK4IwnT7lHuY/j0Ik8sLYfIx+13qmcxlTE96RfLPQVh5fVBKv+d+66nfJkx+WyglY8Ol9H8LxYSHT+vBL8B3/r+TZvUF6AqbQGDeBOoEQfbQvr37Z0YpS08rSy+0h+Yj6RO5B+7tJPxv2fM7D893Nh8E2YP1+Tb+Z3u2xW7b8k6yv9fq/XuWKc5uj3PLWBKBXNa5JbF0jZufvxXM376rWxIAr/2CBUGRdJHbbiT9LjcO173aNBewbc9+m2kBTDtB0Jh0mNumBal2K2JtA3UqkfQGu1JXfWHusXWa8BUCCPSkQKeCoOLWFf7JU1CqvLmhx7KNewbF9E1BKfmHv0y+bifoQSl5XztXKSzhQBAmf86vo9HnIEy+evALNjd9yNECkSBMtjRah/f97UGYfGRoKKpl+gmKled78+unHA7TGQ9qmlknxxKEldNcP+w3CVZXDiqEyQ/cdw2mfysUK6vzv9/ujmm4mB7T7m/Tzu+S7xef5y7QYD+Ysd/OfUusAYHFE8gHQd6JcO3qTpvf2dWdUr2R1AmCGl6BseXL0r/52yxLz6i33vx349Kz/eWyLGi1P17lTvJ3jEtH55fPfx6TlubWd1K+TaefCapeZXG3DNrVqrqmfj/slsSy9Ga7FW5cenw+aGonCLJlckHtZ0l64CtTR2BQBDoTBC2ZutrgrpLYFZ1i5fn1CHdeEUi/Me2kK0xutZTc1ast3/CvnFi7IEyusJdy1luffTdcTP572vqqywSl5ILqOiuFUnpNvs1wmDS87H70qVsfHJTSq/xlgjD9eyFMvx+U0s/sTBGd3OzPL4Rp7UHNQrHyzCBMf22lMHXVyL17JbnJfR+EybQHNedjLNODoHRDoZRcXevzzn79sBAmP6l9N+03TFb55rszJkuQUSh5TmFyW1BKLimUko2FMPlUUEq3ZhkGb/W3H4QJD5/68AtQ9/2b1RegK2wCgXkT6EQQFEk/G5ee26iT+SDI3nPTqK19n7+ykc8Y12jZ6i1dteAtkmq3xFXTYbt529tcp109qgUkC3E7nF2B8wOvMenwRuNt9/t2giBbl/+sT7UPvypL77ZgcKN0p3a3RzsEEOhlgTkGQYeHF90jCJOv+ydOQZj+qNHVm6nbnrwT7UIp+ZxdcfEJ7TmVIEzf5m7VsnXb7XF+G1cfWhM9yr+iFJTSb9l3bn5tumzjnsOlyksLpeSGWl/D9PpGV4NmXgFKPveE1ZumPah5VLFyv6lAyxvPcDGZ8aBmu8/PzMdYpgVB1Vvf7Ha07MWta/3faGh19IAgTN5Zs5kyT37c6LaMdse0M+DZGQAGYfqN4VXjMx4+ndp2Kbm4tu0wuc1sa78dlXkXqNl7+3K97+a9I2wAgXkUyAdBlv2rmkHMsojli71H5+os/fJE9Zatt41LT230/0TXbT8IsqsNrV5ymgUer/MCgd+69bQzzb1Lp/ZHPbtty1vnH9pZl7WxbHNuuYUIguxqjtueTe2lsO32tVG7doMgC7hiqW7qcMuaF0lfyW7Pe5mlLW+0Lb5HAIFeF5gRBCUbh4uVxzYqwdr4sKVrKkGwduvxQZi8d9qVhakrMOn24bVb6156t2dn/KsiQTF9ezO+IKyc4J2I3W59yre329Bcm6kXva4da3pvbz6L3XCYzPiL3tRzNN7JYLMrRkMvju489ZyLax8mMx7UbDtgmIex+EGQOU0FjOHWR+cd3WcLNp3n1LTBczrtjMmSUUxdPavaDBWjafduu23a9MgTz79bYer5oOoVs7DCw6c+0DzXp/3mbl+uM53nbrB6BOZVoE4Q9I5ObzAXBP2w1fqr6ZjdVZtvtGrvz4+kb3pBxEY3r5pW2q3TnjFq679Yqrj1LUQQlAUbr3Tbs0QFrQLGdgbRbhBk67L04lkg9nOvD87Mn9pzR2m9THTt9Ic2CCDQzQIzgiB329ZuTMP0eguOGg3Xv7pit7gdtGxjy0vO/m12lkAht+4lU7eb1U7WKi3fYD10SrSPf8IXhMkpuXWqUEoucm2CUvI7SySQb+N/DoqVY2vtw3R7/mS/nYDB/ro4H2OZEQSFyQf8vufrdtuhG4tNh8P01Hwb+9zOmCxgduuaer6rZYCavKFQSs8fDtP3m2m97fLd/Ai436nVdH62zloRWBiBhQ6CLJNZq5HF0pe8k/DxVu39+dWT86kTdv8dNtX3CrkT+bYDq0j6sutLp4Ig/z1JdmUl1//Xuu1lqbr/4s/b3fpsgiDbhqUht3c9Vd9F9A+vP87Pn34yC3LvvLt9YzkEEOg2gY4EQcnNQSk9t9ktTHYrmX+CFRSnP2/SiCUfYMxIdb1s454WdNjVqWbb99cfhOl1tb6EldCfN3VFopT+zc0PiknLBzWnbt8rVd5st8INh5XH54OmdgKGqT50eCy2znwQVGhyFcg55LLgvdF970/bGZM5THu+K0w+2+j2Q3/d1BdewO3vraYL3zO2iEDnBLoxCLLnUNyJtz1vNJvRZoHK/7ll/ZevVt9F5IKjX7e7zki61K2vjSCoreAq95zRy/2+xNIytz2b2u/jz9+d+myDIH8b1fcwHWsvYvVvDfT7GElf95ehjgACvSyQC4LspHXqtrJScu3UNEyvm3YiW7vqYleKks9Z+uh2rujsfEB+19Wlere21WO0d9hMOzFr4yS+3nrsO3sPUTCVxc5/UH/6bVdBmBT87QXFeM4ParYTMDTqc6Pv2xmLLZsPgvLPNdVbf1BKfuwMGmX5a3dMgf+sj+07YfKrIEzfbenP29lv6vWP7zov4H7vVtPOb5k1IrBwAt0YBMXSS72T7LZvCau+uPV2t2z2wqJ1TtLServv7UWo1tbNazb134dTLwiKpA+49UbSd5qty+bZVRPX3qb5K0FbpEP8+WPSwa3WafMt2USjgGkuQVB+25YCPZbeFkt/cv20F6Y22nZ+eT4jgEC3C+SCoEIp/XC9Lttf8IMwfZElPXAnShYcDReTN7RzMpt7vmeH3doWhGm5neK2Z9OlxfS4ev3zv7OXmU4FM8XKK+xdPJaFzd7p46/H1YNi5b/8Ze1qjptnU3vRqj9/d+rtBgz11j2Xsdj6/CAoS4ZwY71t5L8rhOmVuwySt+bn2+d2x2RBZCFMr9+1vl2BsKXNDsL0K0EpfZkFu/W2w3cLI1Dv96n33cL0hq0gMD8C3RgERdKQO8G2aVma8d65ehrj0mNzy424dmPSU3Lz/t3NazStpqve7parFwT5V61i6QeN1uW+3yI92q3Pplkih2lXguzKiz+/LD3PLdtsml1Bmqyuz5JZFP227QZB9m4ge4mtOfrL16vns9jZFax67fgOAQR6TaDNIMgNy1Jc28tMp58gJfZA5hLXpt7U3gs0fZldJ8Oz+X64lLym3vrtJNreKWRXr2azvnwQlJ2Yv9Itbw/1S+v2qLe92XzXbsDg1tmpsdj6pgVBpalsb24zDaedDIKm+rAqeVgQJj93rvWmU5kAwyStl12vYUeZ0TGBer9Jve86tkFWhMAiCHRjELRZ2s+SArhgIJLOaYfGf5bIstxZQOGWsxew+pnP2llntg7/+Zy6L0stS6e5ftrVkY3Snm6b9abZcz6v9trPCIJsmex5nKu8Nlvrrcf/zjLIee13jElH+fNj6Rfe/Gm3u7t22RWec702Zfd9s6k9s+SWsZenNmvLPAQQ6BWBWQZBNqyhYrRvECaX+ydJ9q6eZkMOwuQDfvvdrVtGuvx2hovpq/w02XXWfXv1Fq8P73xx565ngvJBUPbOmtfWlg/TjjyoOZsgqJNjMadpQVCY/ihvV+9zp4Mg24YlpLDMfPZ+pRa/1Y6gmHzSsu7V6xvfzY9AbZ+fdrvrzD9UzM/WWSsCCyPQjUGQjTx3hcVexHpoM5EsZfcT3Ql5dXp+vr09I+S1ub3ZrWbVZ2Gu89rXDYLsXUR+Gwty8tt1n8elI2Lpr377/JUga1tNSlBLPmBXZ9w66k0jaYO3zmvyGeUspbmbb0FbvXWUpRe6NllA848x6aB67dx349JDXPvqlCtBDocpAj0tsBtBkI032PnX/T+7k6ed7/SpNLyUHZSSNbvaTt2W1fTKUbum+ZTXto2dL16tnGHvBVq6NnlC/mF8/11B+SBouJQsc/20qV35arcvjdq1GwR1eixTv1NYOc2Nx25lbNRH//v5CIL89dtzSVMJL8L0rOwWy1+6/vlTe/eUvwz1+RXw7ZvV57cXrB2B+RXo1iCoeivab92JtmVUs5eo1tOwW8Zi6Y+urV2hsGdX8m3HpHtG0rVeuz/UCzAi6QDLYue1cwkVTsqvs9rP2vMxFuSUpRm32o1Jh0XStKDK1l8vCLK7SCLp2972ry9Lz8hv29plV7dWe+1sfa/Nt8sld7h8i3T3fBv7zq6eeev68Wbpwfl29tnaxtIlrq2Na7N013pt+Q4BBHpNYDeDIBvmcLFy8rQTpjD9S6PsY0GYPN1ve/SpW+v+D2c2fFNXpErJP2rrDZM/NHpHkbfeJYVSertbJn97XWH11kPcPJsGayttPahpz+40CpjaCYLmYyw25m65EuT5z6gOnRo9fOrluKX0TzX7MLmtkeeMFfDFnAVq7lwJmrMlK+hegW4Ngkwskk6IpdozOdWT7s2x9D9laaQsvTmWLnYn4970JY3Eq9nX/OQJ/7BU2vYcTSSdHEkf8W6b+1urxAi2nVg609u2C5i2xdK7quu72ptvLyOt9blBEGRXwo60KzLecubw1SwJwRvNxW4/84Obaju7+jXjj6mx9FFvPRYo3VbNojftGaaydKLfrnpLoqXALpqb9TWSTvdTfFv7srSykTffI4BArwnMIQiyoRbCdPO0E6gw/baWbZxxn3AQJv86rV2p8VUjn/DA1Zv2sgDKTpTz6bGHw+TZ/jqDtcmz/GXr1YdXjT9o2jKl9HV+u3wq70Kb/QxKyeTO9SY3DZfSaQ9qthMEzcdYbFyLHQQFa8fuYxkE28kGmM/MZ1fl/N+G+vwJ+P8mmtXnrwesGYH5F+jmIMhGPy4N556Rqd0mljtht+9vKEvPaaU2Lj03km6ps7y/7r+OS8fE0oWuXb3ECLat6hWmr7t2TaY32PM6kfQh1yafHc7veyQ9Lgt4fuTaNptGUlTvCo+tr7qeP9dZfnv+Co4FbnXa+S5+/XYLyvw+U0cAgV4XmGsQtDMTW+22uKkTqNy7d6aIlm3c07KTuROsIEztHQMz/oqT57T3CbllbBqEce0hSEu17ObZcyb59/Pk12WfLUBxy0ytr5i+Kd8uKKVXuTZBKW35oKZlkHPtp9bp9SH9HOEAACAASURBVNHWPS0zXT2bqWBlnsYyX7fD+dn2Go2plJ7rXCwLYN653ueCXU2sXo2wzIP12vBd5wWceatp57fMGhFYOIFuD4JMwm45s/fUxNI1DU7Q7ba2d2+W2s6oac+8RNJncldb7ATfrhJd6W6TaycIqv5adgubJVKo3cLn9fXvkfTF7KrQA6xtu0GQtd0o3SWWPtho7BYglqX/qPah4aQsBX6WONe3epng7PmqSLrAtclP7ba5LLD6Wr1lG3aAGQgg0CMCcwyCbJSFYmX19JOn5GZ7gWlewH8uyNrb7XT5Nv7noZXRvYIw+T9v3dv8+fmMc61elhqsTZ+SJT641VufvetoRgro/LM5diXD326+HpTSDd46r8lnlAvCZMLNtysz+eXt83yNZb6uBLUzpiz4e2Ft3KXkH8HqStOHT4dXjz/EtbcpV4Lq7Snz853v3qw+P1tnrQggUE/A0jhbema7NassHWcJEzZKd6rXtp3vbH12tcneTVSWntboako763JtLpbub1ek7CpPWXrmJunebt5cptW+PtVuPxuXnloN+lr+4dTb5pKLpYdWb7V7lJ89z2tTq9oVLgt07FmssnRK9uLa/zR7C0prjagggECfCXQgCLKT/kKYXDr95Cm5aIaUbct/B02Y3GrZ0PJBgy13xMs37zcjFXcxOdFfp93+5m8zKCUf9ef7dbuC5F9lcMsFYfJBv121vmTatsP0+qWlrXUf1JwRAIbJjAc1fZuprHort8x4UHO+xjJfQVA7Yyqs3HJ3P+i0DH2NngWztkEpuWTX75Jel09oUed34qsOCTj3VtMObY7VIIAAAggggAACiyzQkSDIng3a+mh7r45/EhWUKv+ZH50lLpjRLky+a6mv7R0xQTFZaS9szQcsQZisz6/Lbn/zr0js3HaS2HbtJZ0W+Eyts5R82aVltum0d9aEyXn59drnpcXKkW4ZW69lvwvC5KuFMHmjvfjVbtXyA4HquOs+qGnBme+SreO2qStcYVJ7UHO+xjJfQVA7YzLHQjE50R+7/faWAttuS7QrPcNh5eXVF9rWbpWc8i4mPHxab8ecp+/836hZfZ42z2oRQAABBBBAAIEFFuhQEGS9tgxf/gmUvbjUbmnLj2ioGD0m/54hf7l8PQjTT9e7WmTrteCrUEpuzi9T77M962PB0XCYvMTND0rpnxo9SzQURo+ztNKubbNpECaRXc3Ij9U+71xPMv25qWpg5V/tmI+xzFcQ1O6YbPxBKXlXM7vcvNst0KznyHfzJ5D7DXY0+jx/PWDNCCCAAAIIIIDAQgp0MAiyF1wWwuQn/gnUzgBm5oAOXbn+jkGY/o+fOc1fzupBmGyxKzIzl57+zdDq6AGFMPnUzncV5V7wGCa3FUrpD+3Kgwt2ZiQyWLv1+Olr3PWpeoXmg4VSek2+f1N9LKVXLQ3Tlg9qLl1TCeqNNZ81rdNjma8gyITaHZO1HSqlTwxKyQX1DKe+s2e1wvRreY9dvwS1+RRo+LvkUmbPZx9YNwIIIIAAAgggMFACO1+eabevpScNF5Pl9oLTeleQWqFMJVKw2+DsdrgwfdHSNcmhLvBptWw78y3d83C49al2y55Njz5lq2XnmdWDmkev2fpQC+yG1kSPsnE32u58j6XRdnfj+yXtjsnWHawau6cFOvay1CBMTtn5WyWFI088n4dPdwO/U4sQBHVKkvUggAACCCCAAAIIIIBATwgQBPXEz0QnEUAAAQQQQAABBBBAoFMCBEGdkmQ9CCCAAAIIIIAAAggg0BMCBEE98TPRSQQQQAABBBBAAAEEEOiUAEFQpyRZDwIIIIAAAggggAACCPSEAEFQT/xMdBIBBBBAAAEEEEAAAQQ6JUAQ1ClJ1oMAAggggAACCCCAAAI9IUAQ1BM/E51EAAEEEEAAAQQQQACBTgkQBHVKkvUggAACCCCAAAIIIIBATwgQBPXEz0QnEUAAAQQQQAABBBBAoFMCBEGdkmQ9CCCAAAIIIIAAAggg0BMCBEE98TPRSQQQQAABBBBAAAEEEOiUAEFQpyRZDwIIIIAAAggggAACCPSEAEFQT/xMdBIBBBBAAAEEEEAAAQQ6JUAQ1ClJ1oMAAggggAACCCCAAAI9IUAQ1BM/E51EAAEEEEAAAQQQQACBTgkQBHVKkvUggAACCCCAAAIIIIBATwgQBPXEz0QnEUAAAQQQQAABBBBAoFMCBEGdkmQ9CCCAAAIIIIAAAggg0BMCBEE98TPRSQQQQAABBBBAAAEEEOiUAEFQpyRZDwIIIIAAAggggAACCPSEAEFQT/xMdBIBBBBAAAEEEFgwgSULtiU2hMAiCRAELRI8m0WguwQ43nXX70FvEEAAgYUTOGp15d6FMHltIUwuDcL094UwuS0Ik8uDMDlzaTE9buF6wpYQWDgBgqCFs2ZLCHSLwCbp3pH02ki6NJJ+H0m3RdLlsXRmWeJ41y0/FP1AAAEE5lsgKCarsgDo1qkTwjC9Migl7yoUK6cXwvSnu04Sk3Xz3Q/Wj8BCC+zav9MdzeoL3S+2hwAC8yMQSauyAOjWWNoRS1fG0rsi6fRI+mn1ux2RxPFufvhZKwIIINA9AkEp3bDr5C9Zp2Ub9/R7F5TSc9384VLyGn8edQR6XcDt262mvT5O+o8AAlIkbfADnY3StONdJJ3rzed4x06DAAII9KtAECavrJ38helZ9cZ5xMs371copbfvbJfcIIl7p+tB8V1PCtT2/xJXgnryB6TTCLQpEEmv9AKcuse7zdJ+sXR7tR3HuzZtaYYAAgj0lMDSMH2kPfdjJ4FBKb3q0JXr79hoAIVS+ht3sjgURgc2asf3CPSagNuvW017bVz0FwEEdgmUpUfacz8W3ETSVeulhse7WPqNFyxxvNvFSA0BBBDoD4EgTM5xJ37DYXpqs1EFpfRbtbbFZHmztsxDoJcE3H7datpLY6KvCCAwXSCSzvECm6bHu1j6lmsbSxzvplPyCQEEEOhtgaNP3fpg/xa3w8ONd2k2oqCUTLqTRJ4LaibFvF4TcPt1q2mvjYv+IoDAToHN0oP9W9w2Sk2Pd7E06YKgSOK5IHYkBBBAoJ8ECmEl3HXSl2xsNbaplNnVZyaCMH1Rq/bMR6BXBHb9O+CZoF75zegnArMRiKXQBTWx1PJ4ZymzXftImna8K0tHVrPJfSiSPm6JFOxWu9n0h7YIIIAAAosoEITpuDv5Gy5WTm7WFbtK5J4dsmWGw61PbdaeeQj0koD7d9Bq2ktjoq8IILBLIJbGvaCm6fHOrhK5Z4dsmXFp2vFuTFoaS+tjaXt1nbdH0r67tkYNAQQQQKBrBSyoCcL07+6kb3jV+IOadTYI46NcW5u2at9sXcxDoNsE/H27Wb3b+k1/EECgtYAFNbH0dxcEjUtNj3dj0lGubTUIqts+ln5u8yPp+617QQsEEEAAga4QGF679ehdJ3vJL1p1yp4Bcu2DMLm8VXvmI9BLAm7fbjXtpTHRVwQQ2CkwLh3tBTUtj3f2DJBrH0l1j3f2bqFY+ks1CPoA1ggggAACPSKQC2rOadXtQph8050gBmHltFbtmY9ALwm4fbvVtJfGRF8RQGCnQC6oaXm8i6RvuiCoLNU93kXSo1ybcem5WCOAAAII9IhAEKZfcSd8QZisbdbtYG3lYNe2ECa3DhWjA/z29jkIK58IwvTXhTBJl66tPM2f79eDMDkzCNMvBqXkff731BFYTIHa/s3LUhfzZ2DbCMyLQCR9xQUskdT0eDcmHey1vTWSph3vXAez9wi9tNpueyTdy74vS8+Lpa2xdE0kXUpw5LSYIoAAAl0kUCil19RO/IrJULOuFcLkU65tEKZv89tawJMFUTcGYfrXWptSepXfxtULK7fcPQjT7dYuKKUfd98zRWCxBdy+22q62P1k+wggMHsBC0q8wKbp8a4sfcq1jaVpxzt/y5YVztpF0sRG6U6x9MnqclO3yFXr2y2Jgr8cdQQQQACBRRQYXj3+EP9kb3jN1iMadWc4TJ7r2gal9KqDX7D5rq7tUCl9YqGU/q1QrJx+4OpNexVKyTrXdujU6OGunZsGa9OnuPlBmJ7kvmeKwGILuP2y1XSx+8n2EUBgdgLj0kO8oMYyvTU83tmVG9c2kq7aLNWOd/mtRtKPrG0knR1L51lyhHHpsdVnhV7hreeC/LJ8RgABBBBYJIHhYvIC/2QvCJO6D3UGYVIolJIbdrZNrh4KowOndXnZxj0tSHLfDZfSYm29a5IHuu/dNCimb3Lzg1XJw9z3TBFYbAG3X7aaLnY/2T4CCMxOIMvg9gIXkFSDlrrHu0gqxNIN1bZXR9L045232Yuke7h1RtJNsVS+QNrba6Lstrsb3br876kjgAACCCyiQKGUfjh/sheEyZaglL7OssYFxcrzgzBZXyilt1u7IEwmjj5164NbdbkQJh+rtr9R0pJ8+0KYXljd7jX5eXxGYDEF8v8eGn1ezD6ybQQQmL1AWfqwC1jcNJK2xNLrLGtcdjvb86vv/Lnd5tvtbZulpse7svRMb103RdID8j2rPhu0w1Jz5+fxGQEEEEBgkQQKYfp9d5IXFNO3WwDkvwi1Ni9Mf1QoJS/Uso17ttPVQin9oS0bhMnX67UPwvS66vwv1ZvPdwgsloDb51tNF6t/bBcBBHZPwG5TcwFLWXq7BUD+i1DdPLu9rSy90G5na7WlSHqrt9yp9drH0resTST9st58vkMAAQQQWGCBoVOifVzAE5SSWw5duf6O1oUnrN70T8HqykFBKV46FEaPO/LE8+82m64dtbpy79oJZJi8Nr/s0Wu2PnTX/EqYn89nBBZToLZvkh1uMX8Gto1ARwUiaR8X8GRpsm9ZL00d7zZJ/zQmHWRJCyLpcedLszrexdJ4NcCx7HH71ut0JF1bDZQurDef7xBAAAEEFlhguLh1uHbCFyZppza/tJge59ZrCRPy67U03G5+sDY+LD+fzwgspoDbN1tNF7OPbBsBBGYnMC4Ne1dsOnK8sytFkfTn6nrPq9cjC4y87b6nXhu+QwABBBBYYIHhYvKGXSd6lY79z9mSK+xcb3Lz0FB0h/ywgqlb69IdhVL9+fn2fEZgIQV2/ZuwfbRxWcg+sS0EEJibQCS9odPBSPbOocd46zy5Xg/L0krXZlx6dr02fIcAAgggsMACXnKCHXb1plObD0rpt+zkMSgl38mvMygmK2snlmES5+fzGYHFFqjtn00CIGuz2P1k+wgg0L5ALF3ogpGy1JHjXfbOoVr660bptmPpu9XtXtZ+b2mJAAIIIDCfAksKYXq9O+E7qli5X2c2tm6PqfcF7XwJ6rn+Ou05o0Ipuam23bByhps/tDKaesu2+8wUgcUScP8mWk0Xq39sFwEEZi2wJJaud0HQRVJHjneR9Gm3zs3S/vleRdKxbn4kNX0xa35ZPiOAAAIIzJOAvcC0dpIXJr/q1GbsRamWZMHWHYRJ7S9fQTE+PCgl1wal9GVBmP5y5/z03bbdYG3l4EIpvSYIKyd0qh+sB4HdFaj9u+BK0O4SshwCXSUQSQ93wUgsdex4F0k/c+stS4E/aHtZaiTdbPPL0qg/jzoCCCCAwCIKDIfJS9zJXlBKp12xmWu3gjD5UjXI2R6E6XgQJpFloRsuJa+xdQdhsmlqvgVFYXJOEKZ/DcLkCwct23inuW6b5RGYq4D7d9FqOtftsDwCCCyMQBb4vMQFK1lA1JHj3WZpP7fO6nR8THpKWTq0LL07kq6rBkCnLcwo2QoCCCCAQFsChTAZdSd5lq2trYXabLS0WDmyECbf3LX+9EfDYVJ7INTq7pa4bNs3DhfTV9V7oWqbm6MZAh0VcPttq2lHN8rKEEBg3gTsSowLWCKpI8e7svQcW2ckfTmSzoqlP3nbsIxxF3bq2aN5g2HFCCCAwGAKrNtj6sWnO19+umQ+DIaK0QFBmPxrvQDn8HDjXQqrtx5y6MoL9p6PbbNOBHZXoFXw4+bv7vpZDgEEFlZgnbSHpbOuvvy0I8c7W9eY9DA3kk3SXpF04BbpkOwFqjOyorp2TBFAAAEEEEAAga4UcEFOq2lXdp5OIYAAAggggAACCCCAAAKzFWgV/Lj5s10v7RFAAAEEEEAAAQQQQACBrhRwQU6raVd2nk4hgAACCCCAAAIIIIAAArMVaBX8uPmzXS/tEUAAAQQQQAABBBBAAIGuFHBBTqtpV3aeTiGAAAIIIIAAAggggAACsxVoFfy4+bNdL+0RQAABBBBAAAEEEEAAga4UcEFOq2lXdp5OIYAAAggggAACCCCAAAKzFWgV/Lj5s10v7RFAAAEEEEAAAQQQQACBrhRwQU6raVd2nk4hgAACCCCAAAIIIIAAArMVaBX8uPmzXS/tEUAAAQQQQAABBLpI4OhTtu5fKFWe16kirduji4ZHVxCYlYALclpNZ7VSGiOAQFcIbJb2L0vP61RZJ3G864pflk4ggAACuyEQhJXTWp3wtTs/KKVX7UYXWASBrhFod1/vmg7TEQQQaFugLJ0WSzs6USKJ413b8jREAAEEulAgCJOvuxO/oJTcUggrZwRhetLStVufYyUoJZNufiFML6x9X6w8Pwgrr59appTusDZBKT23C4dIlxBoW6C2r1f36Uaf214hDRFAoGsEIunrLgCKpFsi6YxIOqksPcdKLE26+bF0ofs+kp5fll5vy7j5kcTxrmt+WTqCAAIIzF5gSaGU3LDzRC+5qbAmeVJuFTb/JnciOFysnJybr6CYvt3ND8JkbX4+nxHoJQG3L7ea9tKY6CsCCEwJLImlGyyIiaSbImnG8c6+94KcGce7svR2bz7HO3YsBBBAoFcFji5ufYQ72RsuJi/Ij8Ofb+2G1kSPyrcJwuTptXWElcfn5/MZgV4ScPtyq2kvjYm+IoCAtEV6hAtgYmnG8S433wKlGce7SHq6W8e4xPGOHQsBBBDoVYFCMTnRTvaCMLms3hiGw+QltZPBMP1jvaQHS9ckh06to5TcctCyjXeqtx6+Q6BXBGr7O7fD9cpPRj8RaEugLJ1YDWDqHu9i6SUuwImlP9ZLelCWDrU2dlvcRonjXVvyNEIAAQS6UCAoJe8rhOn1w8X0mHrdC8JkvTspDMJkS702hXDro6tB0CX15vMdAr0k4Pb3VtNeGhN9RQABKZbeF0vXj0t1j3extN4FQdHUhaOZalukR1fbcLybycM3CCCAQP8IBGFyhTsZHA6Tt9Qb2dCLozsPhdHjjj5164Przec7BHpJwO3vraa9NCb6igACrQVi6QovCKp7vIukO0fS4zZLHO9ak9ICAQQQ6E2BoVOifQql9HZ3Mri0tPUZvTkSeo1A+wJuf281bX+NtEQAgW4XiKR9Yul2FwSVJY533f6j0T8EEEBgvgSCUrzUPxEMVo3dc762xXoR6BYBf59vVu+W/tIPBBCYu8CYtNQFQDYdkzjezZ2VNSCAAAK9KRCU0tfVTgLD5Ce9OQp6jcDsBGr7PIkRZgdHawR6WCCWXucFQRzvevi3pOsIIIDAnAUKpfR8d0IYFJNPznmFrACBHhBw+3yraQ8MhS4igECbArF0vhcEcbxr041mCCCAQF8KFErpNbUTwWLlFX05SAaFQE6gts9zJSgnw0cE+lcglq7xgiCOd/37UzMyBBBAoLmAZXqbdjK4eushzZdgLgL9ITBtv28SCPXHaBkFAghYpjcvANqxReJ4x26BAAIIDKrAcDFZvutkMLl5aCi6w6BaMO7BEti136c7mtUHS4XRItC/ArG03AVBkXRzJHG869+fm5EhgAACzQWCMPlg7QQwTOLmrZmLQP8I1Pb7JleBrE3/jJiRIDDYArH0QS8ImtXxriwdGUvviqQPRdLHI+ncsvTIwRZl9AgggEAPCwRhcpk7GQzC5J09PBS6jsCsBNx+32o6q5XSGAEEulYgli7zgqBZHe+qqbXXx9L26jpuj6R9u3awdAwBBBBAoLHAgas37VUopX9zJ4FBsXJs49bMQaC/BNx+32raX6NmNAgMpsAmaa8sPfbfvCBot453sfRzW0ckfX8wJRk1Aggg0AcCQTE+3D8BHDolum8fDIshINCWgL/vN6u3tTIaIYBAVwuMSYe7AKgaxMz6eLdR2jOW/lJd/gNdPWA6hwACCCDQWKAQVkJ38heE6S8bt2QOAv0n4Pb9VtP+GzkjQmDwBGIpdEFQJO3W8S6SHuXWMS49d/AUGTECCCDQJwKFMPm8OwEMwuScdoc1VIwOCMLKJ4Iw/XUhTNKlaytPa7RsECZnBmH6xaCUvK9RG75HYDEE3L7faroYfWObCCDQWYFY+rwLYCKp7eOd34tYeml1HduzBAn3snll6XmxtNXePxRJlxIc+WLUEUAAgS4VKJTS37gTwCBMXtlONy3gCcLkxiBM/1pbtpReVW/Zwsotdw/CdLu1C0rpx+u14TsEFkvA7b+tpovVP7aLAAKdE8gCmN94QVBbx7v81i0rnK0jkiY2SneKpU9W1zl1i5wLkCyJQn5ZPiOAAAIIdInA0rXlf5t28hdW/l+rrg2V0idOJVIoVk7fmVQhWefWMXRq9PD88sHa9ClufhCmJ+Xn8xmBxRRw+2ar6WL2kW0jgMDcBcrSv7kAyKZlqeXxrt5WI+lHtnwknR1L51lyhHHpsdVnhV7hthFJF9Rbnu8QQAABBLpAoFBK3uqf/FnA0rJbyzbuORwmtfugh0tpsbaONckD88sHxfRNbn6wKnlYfj6fEVhMAbdvtpouZh/ZNgIIzF0geynqW12AYtMxqfXxLrfZi6R7uHVE0k2xVL5A2ttvFkk3Vttc7X9PHQEEEECgOwSWDBe3DhdKyU3+yV9QSj46dEq0z2y6WAiTj9k67PY4SUvyyxbC9MLqNq7Jz+MzAost4O//zeqL3U+2jwACuy2wZFwargYtO1wQE0sfjaRZHe/K0jPd8ra+SHpAvlfVZ4NsO3/Pz+MzAggggMAiC1hCg0YnfPb8zmyu2BRK6Q9tXUGYfL3esIIwva46/0v15vMdAosp0OjfQf77xewj20YAgd0XiKRPuMClznT7mNT2HQr+1aRIOrVer2LpW7ad3c0+V2+dfIcAAggg0GUCR62u3Lt2shgmr8137+g1Wx+6a34lzM/nMwKLLVDbP0vpjmb1xe4n20cAgcUXiKXxaoBzayTtW69HkXRtNdi6sN58vkMAAQQQ6AOBpcX0OHfiaAkT8kPKbpFb6+YHa+PD8vP5jMBiC7j9s9V0sfvJ9hFAYHEFLPFBJP25GuCcV683FhhV59uVoPfUa8N3CCCAAAJ9IBCEyQd2njwmNw8NRXfIDykI0x81m59vz2cEFlqgVfDj5i90v9geAgh0l0AkPcYLcE6u17uytNK1GZeeXa8N3yGAAAII9IFAUEq/ZSeJQSn5Tn44QTFZ6U4gC2ES5+fzGYFuEKjto9wO1w0/B31AoGsFsheh1tJfj0tH1OtoLH23GgRdVm8+3yGAAAII9IXAuj2m3he08yWo5/pDClZXDprKPBem10+dZIaVM9z8oZXR1Bu23WemCCymAEHQYuqzbQR6RyCSPu2u8myW9s/3PJKOdfMjaSg/n88IIIAAAn0iYC9KDUrJLXYSGYRJ7a9eQTE+PCgl1wal9GVBmP5y5/z03TbsYG3l4EIpvSYIKyf0CQPD6HEBgqAe/wHpPgILJBBJP3NBTlkK/M3ay1Ij6WabX5ZG/XnUEUAAAQT6UCAIky9Vg5ztQZiOB2ESFcLktuFS8hobbhAmm6bmW1AUJucEYfrXIEy+cNCyjXfqQw6G1IMCBEE9+KPRZQQWWGCztJ8LgKrTcXvZalk6tCy9O0uXfV01ADptgbvG5hBAAAEEFkNgabFyZCFMvulOJC0RwnCY1B4GtXqhekucvUx1uJi+qt4LVRej72wTARNw+26rKVoIIDC4AmXpORbkRNKXI+msWPqTC4qqGeMuLEvHDa4QI0cAAQQGVGCoGB0QhMm/1gtwDg833qWweushh668YO8B5WHYXSzQKvhx87t4CHQNAQTmWcDSY/svVd0k7RVJB26RDsleoDojM+o8d4fVI4AAAggggAACcxNwQU6r6dy2wtIIIIAAAggggAACCCCAQJcItAp+3Pwu6S7dQAABBBBAAAEEEEAAAQTmJuCCnFbTuW2FpRFAAAEEEEAAAQQQQACBLhFoFfy4+V3SXbqBAAIIIIAAAggggAACCMxNwAU5raZz2wpLI4AAAggggAACCCCAAAJdItAq+HHzu6S7dAMBBBBAAAEEEEAAAQQQmJuAC3JaTee2FZZGAAEEEEAAAQQQQAABBLpEoFXw4+Z3SXfpBgIIIIAAAggggAACCCAwNwEX5LSazm0rLI0AAggggAACCCCAAAIIdIlAq+DHze+S7tINBBBAAAEEEEAAAQQQQGBuAi7IaTWd21ZYGgEEEEAAAQQQQAABBBDoEoFWwY+b3yXdpRsIIIAAAggggAACCCCAwNwEXJDTajq3rbA0AggggAACCCCAAAIIINAlAq2CHze/S7pLNxBAoEMCm6S9ytIzy9J/RdLpkXR2WXp7JL0qko4fl/6lQ5tiNQgggAACCCCAQHcJuCCn1bS7ek1vEEBgdwUiaR8LemLpj7G0o1mJpJ/F0rLd3RbLIYAAAgh0scCBqzftVShWnhkUK/9VKFZOD4rJ2UExfftwMX1VsHbr8cPhOH8N6+Lfj67NTaBV8OPmz20rLI0AAt0gEEkPj6VfucCnLH0ukl40Lj0kuxJ033HpmEi61M23aSQd2w19pw8IIIAAAh0SGDol2seCnkKY/tGd6DWaBqX0Z8OlhL+Gdcie1XSPQKN9Pv999/SYniCAwO4IRNK9YukXLsCx2+DqrWdMumckXeXaXSTdr147vkMAAQQQ6EGBoVOjhxfC5Fe7TvSSzwVh+qLh1eMPGToluu9wMT2mECaX7pqf7giKFf4a1oO/NV1uhI489QAAIABJREFULuDv483qzdfCXAQQ6HaB7Da497rAJpbObNbfsvThattfNWvHPAQQQACBHhIYWhndq1BKfuFO+Ow2uHrdD1aN3TMopVe5dkcVK/w1rB4U3/W0gNu/W017epB0HoEBF4ikO0fSTS4Iym55e3ozkkg6udr2883aMQ8BBBoL2O2mZekJjVswB4EFFgjC5L3uhC8Ik6Z/DSuU0g9PtQ0T/hq2wL8Tm1sYAfdvodV0YXrDVhBAYD4ExqSDXAAUS9stOUKz7WyW7mrLbJb2a9aOeQgg0Fgglm6wf3eRdNG4dETjlsxBYAEEhl4c3blQSm5yJ3xBmDT9a9hwsXJyNQjir2EL8PuwiYUXcP8WWk0XvmdsEQEEOiVgV368IGjHFunRnVo360EAgfoCsXS9/+8uli6OpCfVb823CMyzQLC6cpA72QvCdLslR2i2yYNfsPmutswRL9/MX8OaQTGvZwXcv4dW054dIB1HAAFVs8LV0mGXpdfDggAC8ysQSdflgiD3b3B8XDp6frfO2hHICdiVn2kne+FW/hqWM+LjYAlM+/dQSnc0+jxYKowWgb4TWBJJN7oTMsv+Zimx+26UDAiBLhKIpGvdv7l600iKx6SlXdRlutLPAlNZ4bwTvSCs8NewLvnBl6+feNEJZ27bv0u6MzDdaBT05L8fGBAGikCfCkTSB/wTsUiasPcD9elwGRYCiy4QS3/w/801qkdSEkmFRe8wHeh7gSVBmNzoTvAs+5ulxO77UffAAEdGJy5aMTrx95HRyY+MnP39h/ZAl/uii+7fQqtpXwyWQSAwwALVDHHb/BMxyxjX7y9DLUvPKEvPjKRnjUvPLkvPKUv/z8Y9Lj23LB1Xlp6XBYXPj6VlZek/Iun4SDohlpaXpZFIWhFJ/xlLLyhLL7QXzGZX016cvXj2JWXpxEg6qZpR76VlaWUkvSySXh5LryhLp2RXBFZlt0admj0jsrosrcmuyq3N7IuxFJalUiS9MpJeFUuvtvc3RdJrIum1sfQ6u3Uxkt4QSW+MpTeVpdMi6b8jaV0s/U9ZenMkvSWS3hpLbytLb4+kd2S/9ztj6V1l6d2R9J5qivT3laX3R9Lp1aD4g2XpfyPpjOw9Uh+y1OmWHj2SzsquFJ4dS+vL0mgkbYikj8TSR8vSxyLp45H0iVj6ZFn6VCR9OpI+E0ufrb6A95zsFsxzY+nzsbQxkr4QSV+MpfNi6UuR9OVI+kosnR9LX42kCyLpa7F0YSxtiqSvWzKBWNpcfY5mS/YszVgsjcdSOZIiu4oSS1tjqVINItJYuiSWvhFJ36y+9PeyWPpWJH07+/2/E0vfjaXvRdL3s9//8li6IpaujKRt9keB7PefjKUfZL//D7Pf/0fZ7//jWPpJ9vv/NPv9f5b9/j+3d21lv/8vq+/SshcPX539/v+X/f6/jqXfxNJvs9//d9nv/3tLQuL/e2ujfsm49NQB/t8UQ59vgSBMPuCf8AVhMmHvB5rv7bL+5gIrRie/tmLD5I6pMjp5+8joxDnLP7zt4OZLMXeuAv6/hWb1uW6H5RFAYPEF7MqPneDlT8bshHi9dMfF72Fne7BO2iM/Vj7LPZfCVN1pYUHcuHRMZ/81sDYEJO3MEJdum37Cl9zEy1AXd/cYGZ38ci0IqgZDIxsmt49smPjq8RuueOLi9q5/tz793wHPBPXvL83IENgpcL50t+pf4aedBEeS/bW9abKgHjRcQtDTnSf6/C5t/S52FetZPfjvji53s4Bd+SmU0h/mTwDtKtGhK9f33V/Duvm3cH1bMTrxhXwQ5H8eGZ0YP+HsKwLXnmlnBPL/Bhp97szWWAsCCHSJgCVKeEN2e9XtuZPRz3ZJ/zrWjdz4pgV+zGvrRByzxbti9D27fbNj/xhYEQJO4MgTz79bEKZfyZ/0BWGypVXqbLcOpp0TWDE68Tk/6GlYH5289ITRSfufwpLObX1w15Tf/xt9HlwhRo5A/wqMSU/Jv8vEnpOpN+KydKQ9Y2LPjlSfCTm3LD2yXttu+o5Ah0Cn1/YBe16p35/V66b/RwxyX5YMF5M3FErp7dNO/sKk7/4aVv2RlyxbN3mnZ6//zt7L1n/n7s/90GX3XP6Bbfc5bsMVDzjhrO8fYAkJjj9z2yPsWZzj11/x2JGzJh+/4qyJI5ePXvnkkdErC8vPnnz68rMnnn3C6LbnLh/d9h8r1k+OjGyYeOHIhm0nLV8/+bKR9ZOnLt8wUVy+YdurV4xOvm5k/cSbRjZMvHn56La3j4xOvmfF+onTR9ZPfGjF6LazV4xOfnRkdOKTIxsmPjuyYXLjyIaJqxsGPu5ZIW86Mjp55fINE8uXLdu45yDvwHMd+7T93sucmP9+rttheQQQ6E4By0rlP8CdfU7r9dRS+dqD8l7b27Nnifat17abvvP6yxWNxbuigX179ldakg7+yNtN/wcZgL4Ea9OnFML0ev/EbzhM6v41bL44jvnfTXuNjE6eNbJhYsOKDROfGBnd9pmRDZPnjmyYOG/F6MT5I6OTm0Y2TF68YsNENDI6kawYnbx0ZMPEd1aMTly+YnRicmR08scrRid+sTOYmPjdyOjktSs2TNy4YsPEzSOjk7euGJ28fTZBRu+0nfjp8vUTJ1twN1+/TT+v19/nm9X72YCxITDoApYNzP213DLGNfOoZsjaYRm2mrXrlnku85hNLROZZSSzZ6IsQ5llKrOMZZa5zDKYWSYzy2hmmc0i6RzLdGYZzyzzmWVAs0xolhHNMqPZ1TDLlGYZ0yxzmmVQs0xqFihaZjUztUxrlnGtevXsDMvEFksftEQUlqHNMrXF0vssc5tlcLNMbtWrbe+0DG+W6c0yvlnmN8sAZ5ngLCOcZYazDHGWKc4yxlnmOLu90TLJWUY5yyxnGeYs05xlnLPMc5aBzjLRWUY6y0xnGeosU51lrLPMdZbBzjLZWUY7y2xnGe4s012W8eyllvnOMuBZJjzLiGeZ8SxDnmXKs4x5ljnPMuhZJj3LqGeZ9SzDnmXas4x7lnnPTu4tE59dabSrHJahz271sox99tyLZfCzTH6WECDL7Pb0svQ0y5RmVystUC9Lwbg0bMF4lhluqCw92V44OiYdlWWOe5JdqRyXjhiTDs8yyz2xLD1hXHr8mHRYlnnucWXp0HHpsVukQ7Lf/zFl6d/HpIO3SI/Ofv9H2VXNMemgLdIj7OXCZenfxqSHXSw9NPv9D7SkImPSv26WHpz9/geMSw/aIj1ws7R/9vs/YFz6l4ul+18k3c/ewTUm3aeaMa5lAFjNTLeM4Kdb/q8xgP0IwqQQhOn22olgmNT9a9h80Qyti+7cO4FHNYubd2Vm0fs+OvF/I6Pb1tpVrvn6jfpxvbX9vclVIGvTj2NnTAggsFPATlBdEGRTO5GrZ7NR2jM7qf6LtbET+Xpt+A4BBHYKZAGjpdBuFgRZOu4TLIshZggsukAhTM/adVKYNP1rWKc7O7QuusOiBxLdFNTMui8TN45s2Pb6p77nirt2+rfp5/Xt2t8bZ4YjCOrnPYCxISDZX8H9k7WN0l3qudhfzF27Rs8O1VuO7xAYRIHqu4RmBEH2DiK7akbwM4h7RRePuVCqPM8/KTyqWKn717D5GgJB0O5cYZq42Z45Ovb073f9venztd/MZb3+/t6sPpdtsCwCCCy8QPVlmZdY4NJq63YLkgtu7IWPjdrbrVHVdtuzW7zuZe2qV5HspZXX2AsqCY4a6fH9oAnYS1W9f1cWDP3Ebh+0K6qDZsF4e0BgaZg+0j8RPDzcWPevYfM1lJHRiX8QCLUXCNlzTiMbJj/43LOu2G++fo9BWK+/vzerD4IFY0SgnwTsTfZ2AmbPZrQaV/VZkqm/WNtzKo3a23Mw1XVObJTuZM/HVE/ypm6Rq9a323MbjdbB9wgMikAs/aL67+Vn9gwVwc+g/PJdNM4gTN4ZlJJLhtZELf8aNlxMj/FOBOv+NWw4TF4SlJLvFErpb4bD9P2WarvecJeGlScHYfpFK0vXJk+o1yb/3cjo5F/nMwiyl4+uGJ34+4rRib+sGJ3844oNk9eNbJj4/Yqp52kmfzkyOvmTFRsmfmCZ11aMTn53ZMPEZSMbJtKR0cl4ZHRyy4oNE18fGZ24YMXo5JeqGd0+O5XhbXTyI5bxbWR04oypDHCjk++Zygi3YeLNliFuKlPc6LZXWea4qQxylkluw7aTLLPcVIa59ZPLphJAtHELnAWKI6OTHznhzG375/34PHsBb3/f0aw++zWzBAIILJaAPaBdDUgsCPpIs37YQ9wuTXb2MP0t9uB3o/Z2G0/1pO7sakKB79vD5tVnhV7hbfOCRuvgewQGRSBL2DBmySSyxBZ3GJQxM84uEyiUkqvt5C5Yu7XlX8OCsPJ6dyJoAY4/FLsqFITJl6bWVUpu2dUueYnfztWDMHlvrc2q8Qe575tNd6aanjh5ZHTyxSOjkytWnL3t+JGztx1n78VZMXrlMcvP3vaUkfUTS5evn3zS8RuueOLIhisPPf7siX9fdvbkQcePXv6wZRuueLAFB8et/879lq//zr3sFjF7RsYyz2nduq5+8G5kdOItzQJAC+BGRifOsTTezQyZNzsBt4+2ms5urbRGAIHFFLAsXF5Acptl1qrXH8t6ZSmxvbYn1Gtn310k3cNrd1MslS+QpiWiyTKO3Vhtc3Wj9fA9AgMkwPsMB+jH7rqhHnnqxfd3J3dBmDT9a9jQKdF9XZrsoJTccvSpW6f9NSwIk69aQDUURo+zl6kWSsnNtu6glJ5bb+B29WnnthMOBvWAct8tH508rVEQNLJh4qv27qLcInzsgID799Fq2oFNsQoEEFgggWqqZf+BbHuGx9I+F6tpiy1tsqV5vrUatNxgKY6bdc9SGPtBkKUFzrePJXs2yLb79/w8PiOAAAIILKDA0mJ6XO3kLkxuW7qmUvevYUNhdGAhTFLXNggrM/4aNhX8FKMDXPcLpeSmqfZh8jH3nZseunL9HS2Q2rm+5HPue6aNBSyzWz4IGhmdGLcrXo2XYs5cBdw+32o61+2wPAIILJyAvWMlks6IpW+4lNYugMlNf27vo7Fb4lr1zt5V45a198rUax9L37I29kB4vfl8hwACCCCwQAJBmL7bP7mz9wDZlZvhUlpcGqb/UQgrrw7CyicKYXJrNWC5IShubfrXMOt6YU3ywNp6w0qYH06wNj7MzQ/C5JT8fD7PFFi+Ydura0HQ6OSlJ5x9Rd2AdeaSfDMXAbeftprOZRssiwACiydgaXg3S/vZSyDtxZLVF1I+vt6VnGa9jKXxaoBza/aOoLrZOLMXbl5bDZQubLYu5iGAAAIIzLPA0rWVpxXCyhlBmH6jEKZ/aXSiF4TJzwth8g67Ja6dLtnzRW5d9ZIeFIqV1W5+sLbCbVxtoI6snwgtIYM9/9RGc5p0SMDtp62mHdocq0EAgR4UsMQHkfTnaoBzXr0hWGBUnW9Xgt5Trw3fIYAAAggsisC6PY54+eb9ji5ufUQQxkctLW19xnBYefzQ6mjGfc2tuheUkg/ZSWMQJn8eGopmZP0ohMlnq/NvlLo7IUGrsS7U/Gqqax4iXCjw6nZaBT9u/gJ3i80hgEAXCUTSY7wA5+R6XStLK12bcenZ9drwHQIIIIBAjwsUwvTKnSeHyUX5oRy0bOOdCqX0mqn5YcotAXkgPneVgAtyWk27qtN0BgEEFlQgexFqLf31uHREvY3H0nerQdBl9ebzHQIIIIBAjwscHl50D3u2aGeQk7w2P5zhYrLcnVAGpfR1+fl8RqCbBNy+2mraTX2mLwggsLACkfRpd5VnszTjHW2RdKybH0lDC9s7toYAAgggsCACdhudO2EM1ibP8jd68As237UQJj9x8wvFhIOBD0S96wRq+2op5WWpXffr0CEEukMgkn7mgpz8O4fsZamRdLPNL0uj3dFjeoEAAggg0HGBQpi80Z04Dp0aPdzfQCFMPla7Fc6eGVo1ds/q/CVe3V+EOgKLKuD25VbTRe0kG0cAgUUTsMxyLgCqTsfHpKeUpUPtfURZuuzrqgHQaYvWSTaMAAIIIDD/AsPF5L/dCeNwMT3GtrjzvUDpxwth8gNLv+3mH7ryguxt2uv2CMLkzCBMJrRs457z30O2gED7Am5fbTVtf420RACBfhIoS8+xICeSvhxJZ8XSn1xQVM0Yd2FZOq6fxsxYEEAAAQTqCFjKa++E8ZpCKflcEKa/nwqAVo0/yDLOuflBmGwJSun3CmH6x6Vh5cl1VsdXCCyqgNtXW00XtZNsHAEEFk3A0mOPSQ9zHdgk7RVJB26RDsleoDojO6prxxQBBBBAoA8FdqbITm6wE8cgTP8ehMn6oWLkXh63xIKf2kllmMRHr9n60D5kYEh9IFDbT3kmqA9+TYaAAAIIIIAAAgjMs4Clwh4qRo858sTz71ZvUxb4DK8af1C9eXyHQLcIEAR1yy9BPxBAAAEEEEAAAQQQQGBBBAiCFoSZjSCAAAIIIIAAAggggEC3CBAEdcsvQT8QQAABBBBAAAEEEEBgQQQIghaEmY0ggAACCCCAAAIIIIBAtwgQBHXLL0E/EEAAAQQQQAABBBBAYEEECIIWhJmNIIAAAggggAACCCCAQLcIEAR1yy9BPxBAAAEEEEAAAQQQQGBBBAiCFoSZjSCAAAIIIIAAAggggEC3CBAEdcsvQT8QQAABBBBAAAEEEEBgQQQIghaEmY0ggAACCCCAAAIIIIBAtwgQBHXLL0E/EEAAAQQQQAABBBBAYEEECIIWhJmNIIAAAggggAACCCCAQLcIEAR1yy9BPxBAAAEEEEAAAQQQQGBBBAiCFoSZjSCAAAIIIIAAAggggEC3CBAEdcsvQT8QQAABBBBAAAEEEEBgQQQIghaEmY0ggAACCCCAAAIIIIBAtwgQBHXLL0E/EEAAAQQQQAABBBBAYEEECIIWhJmNIIAAAggggAACCCCAQLcIEAR1yy9BPxBAAAEEEEAAAQQQQGBBBAiCFoSZjSCAAAIIIIAAAggggEC3CBAEdcsvQT8QQAABBBBAAAEEEEBgQQQIghaEmY0ggAACCCCAAAIIIIBAtwgQBHXLL0E/EEAAAQQQQAABBBBAYEEECIIWhJmNIIAAAggggAACCCCAQLcIEAR1yy9BPxBAAAEEEEAAAQQQQGBBBAiCFoSZjSCAAAIIIIAAAggggEC3CBAEdcsvQT8QQAABBBBYGIEJSRQM2AfYBwZ6H5hFEDTQTm0eL/4oaQcFA/YB9gH2AfaBDu0DX56PsIgDFQdr9gH2gYHfB/bed/8d7ZQO/c984L1x5MSIfYB9gH2AfWAW+wBB0CywOMngxJ59gH2AfYB9gH2AfYB9gH2AfaD39wGCIIIg/mrAPsA+wD7APsA+wD7APsA+wD4wUPsAQRA7/EDt8Pzlpvf/csNvyG/IPsA+wD7APsA+wD4w132AIIggiCCIfYB9gH2AfYB9gH2AfYB9gH1goPaBeQmCHimJggH7APsA+wD7QKf2gX+ajyw+rBMBBBBAAAEEEEAAAQQQQAABBBBAAAEEEEAAAQQQQAABBBBAAAEEEEAAAQQQQAABBBBAAAEEEEAAAQQQQAABBBBAAAEEEEAAAQQQQAABBBBAAAEEEEAAAQQQQAABBBBAAAEEEEAAAQQQQAABBBBAAAEEEEAAAQQQQAABBBBAAAEEEEAAAQQQQAABBBBAAAEEEEAAAQQQQAABBBBAAAEEEEAAAQQQQAABBBBAAAEEEEAAAQQQQAABBBBAAAEEEEAAAQQQQAABBBBAAAEEEEAAAQQQQAABBBBAAAEEEEAAAQQ8gUMl3df7TBUBBBBAAAEEEEAAAQQQ6DsBC3peJWmbpL9KukvfjZABIYAAAggggAACCCCAwMAL7CXp+ZK+Juk2STuq5cKBlwEAAQQQQAABBBBAAAEE+krgMElnSrrBC3xcAGTTU/pqtAwGAQQQQAABBBBAAAEEBlLg/tltbv8l6QcNAh8/CHrQQAoxaAQQQAABBBBAAAEEEOgbgZW52938gCdft2eC+A8BBBBAAAEEEEAAAQQQ6GmBPbJsb2e3cQXIAqJ39vRI6TwCCCCAAAIIIIAAAggg4Am8o41A6CivPVUEEEAAAQQQQAABBBBAoOcFXt0kELJECXv2/AgZAAIIIIAAAggggAACCCDgCVha7IkGgdDnvHZUEUAAAQQQQAABBBBAAIGeF7CrPOdJ+ryk4yX9LRcMrej5ETIABBBAAAEEEEAAAQQQQKAqsETSxyRdJOmO1e+eKunmaiB0u6R7ooUAAggggAACCCCAAAII9IvA+yRdImnv3IAOr7401ebxHwIIIIAAAggggAACCCDQFwKnSbpc0r4NRvNoSSc1mMfXCCCAAAIIIIAAAggggEBPCZwi6aeS7tNTvaazCCCAAAIIIIAAAggggMBuCIxIulrSAbuxLIsggAACCCCAAAIIIIAAAj0l8ExJv5N0UE/1ms4igAACCCCAAAIIIIAAArshcJSkayQdthvLsggCCCCAAAIIIIAAAggg0FMCh1QDoOGe6jWdRQABBBBAAAEEEEAAAQR2Q+Bhkn6bZYI7djeWZREEEEAAAQQQQAABBBBAoKcE9pd0laQX9VSv6SwCCCCAAAIIIIAAAgggsBsC95b0I0nF3ViWRRBAAAEEEEAAAQQQQACBnhL4J0nfzXq8rqd6TWcRQAABBBBAAAEEEEAAgd0QuLOkWNIZu7EsiyCAAAIIIIAAAggggAACPSVwB0kXSPqMpCU91XM6iwACCCCAAAIIIIAAAgjMUsCCHgt+LAiyYIj/EEAAAQQQQAABBBBAAIG+FrDb3+w2OLsdjv8QQAABBBBAAAEEEEAAgb4WeEs1EYIlROA/BBBAAAEEEEAAAQQQQKCvBSwFtqXCtpTY/IcAAggggAACCCCAAAII9LWAvQTVXoZqL0XlPwQQQAABBBBAAAEEEECgrwWOlfRbSQ/r61EyOAQQQAABBBBAAAEEEEBA0rCkayQdggYCCCCAAAIIIIAAAggg0O8Ch1UDoKP6faCMDwEEEEAAAQQQQAABBBA4SNLvJD0TCgQQQAABBBBAAAEEEECg3wUOkHS1pJF+HyjjQwABBBBAAAEEEEAAAQTuI+mnkk6BAgEEEEAAAQQQQAABBBDod4F9JV0h6fX9PlDGhwACCCCAAAIIIIAAAgjsLekSSe+DAgEEEEAAAQQQQAABBBDod4E7SrpI0sckLen3wTI+BBBAAAEEEEAAAQQQGGyBPSR9XtJ5kvYcbApGjwACCCCAAAIIIIAAAoMgsF7SmKS9BmGwjBEBBBBAAAEEEEAAAQQGW+Cdki6VtM9gMzB6BBBAAAEEEEAAAQQQGASB10iakHSPQRgsY0QAAQQQQAABBBBAAIHBFnippJ9Luv9gMzB6BBBAAAEEEEAAAQQQGASBZZJ+LekhgzBYxogAAggggAACCCCAAAKDLfA0Sb/PMsE9erAZGD0CCCCAAAIIIIAAAggMgsARkv4g6fBBGCxjRAABBBBAAAEEEEAAgcEWOLh6Beipg83A6BFAAAEEEEAAAQQQQGAQBOzZH3sG6PmDMFjGiAACCCCAAAIIIIAAAoMtYNnffpEFQScPNgOjRwABBBBAAAEEEEAAgUEQsPf/2HuAXj0Ig2WMCCCAAAIIIIAAAgggMNgC+0i6TNLbB5uB0SOAAAIIIIAAAggggMAgCOwlaUzS2YMwWMaIAAIIIIAAAggggAACgy2wp6QvSTpX0h6DTcHoEUAAAQQQQAABBBBAoN8Flkj6uKSvS7pjvw+W8SGAAAIIIIAAAggggAAC75eUStobCgQQQAABBBBAAAEEEECg3wXeJOlySfv2+0AZHwIIIIAAAggggAACCCCwStJPJN0HCgQQQAABBBBAAAEEEECg3wVWSLo6exboQf0+UMaHAAIIIIAAAggggAACCDxL0u8kPQIKBBBAAAEEEEAAAQQQQKDfBY6WdI2kw/p9oIwPAQQQQAABBBBAAAEEEHhsNQBaCgUCCCCAAAIIIIAAAggg0O8C/7+9ew+1parjAP61MrkVt7dZdrMHZFQXpBtUREX0hsoef5T0tgdUUAaW9EYqoReVUqDVH2kG/RFFRQVGUJFQIpUGGWTdKOydZVZWpu4f7IHFYs7e+3bn3Dme+xnYzOyZNWuv9Tn/nC9rZq2Tk1yT5NTd3lH9I0CAAAECBAgQIECAwL4kB5O8FAUBAgQIECBAgAABAgR2u8A9k1yV5I27vaP6R4AAAQIECBAgQIAAgb1JLk9yNgoCBAgQIECAAAECBAjsdoE9Sb6d5Nzd3lH9I0CAAAECBAgQIECAQAlckOSixSjQMTgIECBAgAABAgQIECBwNAickOR2R0NH9ZEAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBCYWWB/kgMTfE7o+rGvqfPk7pqvBAgQIECAAAECBAgQmE3gV0lunuBzVteDjzV1fq+75isBAgQIECBAgAABAgRmExCCZqP3wwQIECBAgAABAgQIzCEgBM2h7jcJECBAgAABAgQIEJhNoA1B30hym//zc0zXA4/DdSC+EiBAgAABAgQIECCwMwTaEPT1CZskBE2IqSoCBAgQIECAAAECBKYTEIKms1QTAQIECBAgQIAAAQK3AoGdGoJqyu0Tk9xhQsM9SU5KUvtNtrsnOX6TghuUqccF75PkthuUVYQAAQIECBAgQIAAgW0U2AkhqMLGmUk+k+T7Sf7aTK9d03f/LsnnkzxtjcNpSb66/LxwWfZOSd6R5Oquzl8meVuAZGBiAAAH1klEQVSSO3Z1PjjJ+V0brk3ynSRP6Mqu+/rIJOct7/3b8vf/leSyRcD7ZJInrqvAdQIECBAgQIAAAQIEpheYOwSdkeTvXUBZtW7Rl0eCy6Dyrqaedya56zJUrarvB0nutqzgRYswdn1TR3/fTYtRpPcPP7ZiX6M99fv/XVFX1V31fTjJcSvqcokAAQIECBAgQIAAgYkF5gxB7x4JCT9O8pUkFy9HUH4/UuY9Wxi0IejjSa5o7q3AcWWStr9DyLkgybMXweV/TfnfJvnhYhTpxubcEFwevcXv1+kKXpd299yQ5PJln+pajQYNv1376vNUj92taJpLBAgQIECAAAECBAiUQBsKjuTscA/vRkpqRKbO9VuNqrw6yV+a4PDnLUaD2hA0hIzrkpyepN4xGrZHJDnY1FdBZxgB+maSBw0Fk9x5MWLT1/ut5np/eG5Tb7Xhc4tH4upxv3Y7Nsn7liNBQzvr8TgbAQIECBAgQIAAAQJHQKANQRUMamrrQ/k8dYs2rpsi+1NNWPhjknttUc9w+uVN+QoOzx0uNPs+rNToz3Oa6+3h87r6qs6vJenXOxruubApX+8sjW0P60aOzhkr1Jyr95aGEFSjUBXObAQIECBAgAABAgQIbLNAG4KGf8gPZf/2Ldq3KgRV0PhNEwA+uEUd7ema4KBt1+vai8vjPgR9YKTMcKoWhf1nU2e9v/OQ4eLIvsJe+/vDe0Rt0UuaMvWI2+3bi1sc10QOQ701+YKNAAECBAgQIECAAIFtFpgjBFWX6jG3+yd50mI2tntv2Mc/NYHhTSP39CHolJEy7amfN/XV+0Ortoc2ZSu09HXv7a6/flVlzbUaqRpCUI1cTTklePMzDgkQIECAAAECBAgQGATaEHRNks8e4ufUoaJuv2okqCu69mutr9PP3PbmkbvaEPTvJDXas2qr6biHAPKlVQWX6wsNZWtf01+324Gmrrq+6aNt+7r79reVOiZAgAABAgQIECBAYHqBNgQdyYkRxnpyvyRPTvLaxYQEH1m+o/OLLiQMQeQtIxW0IegPI9f7U20IqgkNVm19WOlDUPt+T7WxHm2rCRQ2+Qx9qn29q2QjQIAAAQIECBAgQGAbBeYOQRUuaq2cmhyhDQPrjteFoHrUbd3WhqBqw6ptXQiqdYHWtXmT62etaoRrBAgQIECAAAECBAgcvsCcIejMbprsPiTUjGk/W6yh84nFoqfPSNK+E7QuBF21Ac2UIeijE4WgD23QbkUIECBAgAABAgQIEDgMgblCUD/ldQWgWlD0vOW6QI8aWQuoXStop4WgNzQh6NoVU20fxp/KrQQIECBAgAABAgQITCEwRwi6SzcCVO/vPH5NZ2pa7RoZGkaLxh4ba98JOtIjQU9v2lZtfMCa/rhMgAABAgQIECBAgMBMAnOEoGd1geGZG/T9pO6et47cM2cIemDXvuePtG/s1HFJKkDVGkWmxx4Tco4AAQIECBAgQIDAxAJzhKBaxHQY0alFSvds0Kczmnvq3pqIoN/mDEG17lE9Bjf069INH4mr9YSGe2r/uL5TvhMgQIAAAQIECBAgMK3AHCGon0lt3WKpT0lyQxcW3jvCMGcIqua07wVVoHnVSBvbU/dI8uumX1e2Fx0TIECAAAECBAgQILA9AnOEoHr8rR39+PSKrtXIyD+68nVvLcbab3OHoBoNuqJpawW3mgFvbNHW45Nc1pStPp3ed8h3AgQIECBAgAABAgSmF5gjBNXjbz/pAsB3k7w4yWOWj4S9JMkXmwkU6rG5q5t7vjBCMXcIqibVBA//adpZ4aZmvaupr6tPr1lO+d0Hu/NH+uMUAQIECBAgQIAAAQLbIDBHCKpu7F+MklzfhYV2dKg9PrgMR69oyl838i7RTghB1bdTkvyoaWvbl7Hji7YYLdqGP7cqCRAgQIAAAQIECBCYKwSV/H2TXJjkppHAcGOSnyapCRGGiRNO7Mq9oPvz7ZQQVM06djExwtlJWt8+AF2S5LFdH3wlQIAAAQIECBAgQOAoEKgJAuoxuHoc7mVJDjTBZzd0f++yf69MclqSWgi2+mwjQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECOxWgVsAu811N9YF8TAAAAAASUVORK5CYII=)\n",
-        "\n",
-        "https://github.com/Cantera/cantera-jupyter/blob/main/flames/flame_speed_with_convergence_analysis.ipynb"
-      ],
-      "metadata": {
-        "id": "DYytzkhwehHN"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "%%capture\n",
-        "!pip install neqsim==2.5.35\n",
-        "!pip install cantera"
-      ],
-      "metadata": {
-        "id": "Eqi29awDevzv"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "from neqsim.process.unitop import unitop\n",
-        "from neqsim import jNeqSim\n",
-        "from jpype import JImplements, JOverride\n",
-        "import cantera as ct\n",
-        "import numpy as np\n",
-        "import pandas as pd\n",
-        "import matplotlib.pylab as plt"
-      ],
-      "metadata": {
-        "id": "VvtbXONOe3yb"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "class CanteraUnitOperation(unitop):\n",
-        "    def __init__(self):\n",
-        "        super().__init__()\n",
-        "        self.serialVersionUID = None\n",
-        "        self.name = \"\"\n",
-        "        self.inputstream = None\n",
-        "        self.oxidizerStream = None\n",
-        "        self.flameSpeed = None\n",
-        "        self.width = 0.015 #m\n",
-        "        self.flame_speed = None\n",
-        "        self.flame = None\n",
-        "\n",
-        "        # Import plotting modules and define plotting preference\n",
-        "        %config InlineBackend.figure_formats = [\"svg\"]\n",
-        "        %matplotlib inline\n",
-        "\n",
-        "        plt.rcParams[\"axes.labelsize\"] = 14\n",
-        "        plt.rcParams[\"xtick.labelsize\"] = 12\n",
-        "        plt.rcParams[\"ytick.labelsize\"] = 12\n",
-        "        plt.rcParams[\"legend.fontsize\"] = 10\n",
-        "        plt.rcParams[\"figure.figsize\"] = (8, 6)\n",
-        "        plt.rcParams[\"figure.dpi\"] = 120\n",
-        "\n",
-        "        # Get the best of both ggplot and seaborn\n",
-        "        plt.style.use(\"ggplot\")\n",
-        "        plt.style.use(\"seaborn-v0_8-deep\")\n",
-        "\n",
-        "        plt.rcParams[\"figure.autolayout\"] = True\n",
-        "\n",
-        "    def setInputStream(self, stream):\n",
-        "        self.inputstream = stream\n",
-        "\n",
-        "    def setFuelStream(self, stream):\n",
-        "        self.inputstream = stream\n",
-        "\n",
-        "    def setOxidizerStream(self, stream):\n",
-        "        self.oxidizerStream = stream\n",
-        "\n",
-        "    def setWidth(self, width):\n",
-        "        self.width = width\n",
-        "\n",
-        "    def getFlameSpeed(self):\n",
-        "      return self.flameSpeed\n",
-        "\n",
-        "    def plotFlame(self):\n",
-        "      plt.figure()\n",
-        "\n",
-        "      plt.plot(self.flame.grid * 100, self.flame.T, \"-o\")\n",
-        "      plt.xlabel(\"Distance (cm)\")\n",
-        "      plt.ylabel(\"Temperature (K)\");\n",
-        "      plt.show()\n",
-        "\n",
-        "    def calc_flame(self):\n",
-        "      # Inlet Temperature in Kelvin and Inlet Pressure in Pascals\n",
-        "      # In this case we are setting the inlet T and P to room temperature conditions\n",
-        "      To = self.inputstream.getTemperature()\n",
-        "      Po = self.inputstream.getPressure(\"Pa\")\n",
-        "      fuel_oxidizer_ratio = self.inputstream.getFlowRate(\"mole/sec\")/self.oxidizerStream.getFlowRate(\"mole/sec\")\n",
-        "\n",
-        "      # Define the gas-mixutre and kinetics\n",
-        "      # In this case, we are choosing a GRI3.0 gas kinetics\n",
-        "      gas = ct.Solution(\"gri30.yaml\")\n",
-        "\n",
-        "      fuel_composition = self.get_composition(self.inputstream)\n",
-        "      oxidizer_composition = self.get_composition(self.oxidizerStream)\n",
-        "\n",
-        "      # Create a stoichiometric CH4/Air premixed mixture\n",
-        "      gas.set_equivalence_ratio(fuel_oxidizer_ratio, fuel_composition, oxidizer_composition, basis='mole')\n",
-        "\n",
-        "\n",
-        "      gas.TP = To, Po\n",
-        "\n",
-        "      # Create the flame object\n",
-        "      self.flame = ct.FreeFlame(gas, width=self.width)\n",
-        "\n",
-        "      # Define tolerances for the solver\n",
-        "      self.flame.set_refine_criteria(ratio=3, slope=0.1, curve=0.1)\n",
-        "\n",
-        "      # Define logging level\n",
-        "      loglevel = 0\n",
-        "\n",
-        "      self.flame.solve(loglevel=loglevel, auto=True)\n",
-        "      self.flameSpeed = self.flame.velocity[0]\n",
-        "\n",
-        "      #return rkt.AqueousProps(state)\n",
-        "\n",
-        "    def get_composition(self, stream):\n",
-        "      composition = \"\"\n",
-        "      components_list = [stream.getFluid().getComponent(i).getName() for i in range(stream.getFluid().getNumberOfComponents())]\n",
-        "      for component in components_list:\n",
-        "        mole_fraction = stream.getFluid().getComponent(component).getz()\n",
-        "        if component == \"methane\":\n",
-        "          component = \"CH4\"\n",
-        "        elif component == \"ethane\":\n",
-        "          component = \"C2H6\"\n",
-        "        elif component == \"propane\":\n",
-        "          component = \"C3H8\"\n",
-        "        elif component == \"nitrogen\":\n",
-        "          component = \"N2\"\n",
-        "        elif component == \"oxygen\":\n",
-        "          component = \"O2\"\n",
-        "\n",
-        "        composition += str(component) + \":\"+ str(mole_fraction) + \",\"\n",
-        "      return composition[:-1]\n",
-        "\n",
-        "    @JOverride\n",
-        "    def run(self, uuid):\n",
-        "      self.serialVersionUID = uuid\n",
-        "      self.calc_flame()\n",
-        "\n",
-        "    @JOverride\n",
-        "    def toJson(self):\n",
-        "      data_dict = {\n",
-        "            \"name\": self.name,\n",
-        "            \"flame_speed\": self.flameSpeed\n",
-        "      }\n",
-        "      return json.dumps(data_dict)"
-      ],
-      "metadata": {
-        "id": "87Ta9i7ne4kH"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "temperature = 100 #C\n",
-        "pressure = 1.01325 #bara\n",
-        "\n",
-        "#Fuel\n",
-        "fuel_rate = 10 #kg/hr\n",
-        "methane = 0.5 #mol fraction\n",
-        "ethane = 0.25\n",
-        "propane = 0.24\n",
-        "nitrogen = 0.005\n",
-        "CO2 = 0.005\n",
-        "O2 = 0.0\n",
-        "#oxidizer\n",
-        "oxidizer_rate = 5 #kg/hr\n",
-        "o2_oxidizer = 0.21 #mole fraction\n",
-        "n2_oxidizer = 0.79\n",
-        "#burner\n",
-        "burner_width = 0.015 #m\n",
-        "\n",
-        "from neqsim.thermo import fluid\n",
-        "#Fuel\n",
-        "fluid1 = fluid(\"srk\")  # create a fluid using the SRK-EoS\n",
-        "fluid1.setTemperature(temperature, \"C\")\n",
-        "fluid1.setPressure(pressure, \"bara\")\n",
-        "fluid1.addComponent(\"methane\", methane)\n",
-        "fluid1.addComponent(\"ethane\", ethane)\n",
-        "fluid1.addComponent(\"propane\", propane)\n",
-        "fluid1.addComponent(\"nitrogen\", nitrogen)\n",
-        "fluid1.addComponent(\"CO2\", CO2)\n",
-        "fluid1.addComponent(\"O2\", O2)\n",
-        "fluid1.setMixingRule(2)\n",
-        "\n",
-        "stream1 = jNeqSim.processSimulation.processEquipment.stream.Stream(fluid1)\n",
-        "stream1.setFlowRate(fuel_rate, \"kg/hr\")\n",
-        "\n",
-        "components_list = [stream1.getFluid().getComponent(i).getName() for i in range(stream1.getFluid().getNumberOfComponents())]\n",
-        "\n",
-        "#Oxidizer\n",
-        "fluid2 = fluid1.clone()\n",
-        "fluid2.setMolarComposition(        [\n",
-        "            n2_oxidizer if component == \"nitrogen\" else o2_oxidizer if component == \"oxygen\" else 0\n",
-        "            for component in components_list\n",
-        "        ])\n",
-        "\n",
-        "stream2 = jNeqSim.processSimulation.processEquipment.stream.Stream(fluid2)\n",
-        "stream2.setFlowRate(oxidizer_rate, \"kg/hr\")\n",
-        "\n",
-        "burner = CanteraUnitOperation()\n",
-        "burner.setName(\"Adiabatic Burner\")\n",
-        "burner.setFuelStream(stream1)\n",
-        "burner.setOxidizerStream(stream2)\n",
-        "burner.setWidth(burner_width)\n",
-        "\n",
-        "example_process = jNeqSim.processSimulation.processSystem.ProcessSystem()\n",
-        "example_process.add(stream1)\n",
-        "example_process.add(stream2)\n",
-        "example_process.add(burner)\n",
-        "example_process.run()\n",
-        "\n",
-        "flame_speed = burner.getFlameSpeed()\n",
-        "print(f\"Flame Speed is: {flame_speed * 100:.2f} cm/s\")\n",
-        "burner.plotFlame()"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 605
-        },
-        "id": "av5i30mZe_h-",
-        "outputId": "e90d81bb-5223-4328-a5eb-f4de4829090f"
-      },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Flame Speed is: 7.35 cm/s\n"
-          ]
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "<Figure size 960x720 with 1 Axes>"
-            ],
-            "image/svg+xml": "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"no\"?>\n<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\n  \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n<svg xmlns:xlink=\"http://www.w3.org/1999/xlink\" width=\"568.8pt\" height=\"424.8pt\" viewBox=\"0 0 568.8 424.8\" xmlns=\"http://www.w3.org/2000/svg\" version=\"1.1\">\n <metadata>\n  <rdf:RDF xmlns:dc=\"http://purl.org/dc/elements/1.1/\" xmlns:cc=\"http://creativecommons.org/ns#\" xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\">\n   <cc:Work>\n    <dc:type rdf:resource=\"http://purl.org/dc/dcmitype/StillImage\"/>\n    <dc:date>2024-08-21T19:49:12.467947</dc:date>\n    <dc:format>image/svg+xml</dc:format>\n    <dc:creator>\n     <cc:Agent>\n      <dc:title>Matplotlib v3.7.1, https://matplotlib.org/</dc:title>\n     </cc:Agent>\n    </dc:creator>\n   </cc:Work>\n  </rdf:RDF>\n </metadata>\n <defs>\n  <style type=\"text/css\">*{stroke-linejoin: round; stroke-linecap: butt}</style>\n </defs>\n <g id=\"figure_1\">\n  <g id=\"patch_1\">\n   <path d=\"M 0 424.8 \nL 568.8 424.8 \nL 568.8 0 \nL 0 0 \nz\n\" style=\"fill: #ffffff\"/>\n  </g>\n  <g id=\"axes_1\">\n   <g id=\"patch_2\">\n    <path d=\"M 60.35375 383.3725 \nL 561.6 383.3725 \nL 561.6 7.2 \nL 60.35375 7.2 \nz\n\" style=\"fill: #e5e5e5\"/>\n   </g>\n   <g id=\"matplotlib.axis_1\">\n    <g id=\"xtick_1\">\n     <g id=\"line2d_1\">\n      <path d=\"M 83.13767 383.3725 \nL 83.13767 7.2 \n\" clip-path=\"url(#p10e7e609dc)\" style=\"fill: none; stroke: #ffffff; stroke-width: 0.8; stroke-linecap: square\"/>\n     </g>\n     <g id=\"line2d_2\">\n      <defs>\n       <path id=\"md8605d3880\" d=\"M 0 0 \nL 0 3.5 \n\" style=\"stroke: #555555; stroke-width: 0.8\"/>\n      </defs>\n      <g>\n       <use xlink:href=\"#md8605d3880\" x=\"83.13767\" y=\"383.3725\" style=\"fill: #555555; stroke: #555555; stroke-width: 0.8\"/>\n      </g>\n     </g>\n     <g id=\"text_1\">\n      <!-- 0.0 -->\n      <g style=\"fill: #555555\" transform=\"translate(73.595795 399.490625) scale(0.12 -0.12)\">\n       <defs>\n        <path id=\"DejaVuSans-30\" d=\"M 2034 4250 \nQ 1547 4250 1301 3770 \nQ 1056 3291 1056 2328 \nQ 1056 1369 1301 889 \nQ 1547 409 2034 409 \nQ 2525 409 2770 889 \nQ 3016 1369 3016 2328 \nQ 3016 3291 2770 3770 \nQ 2525 4250 2034 4250 \nz\nM 2034 4750 \nQ 2819 4750 3233 4129 \nQ 3647 3509 3647 2328 \nQ 3647 1150 3233 529 \nQ 2819 -91 2034 -91 \nQ 1250 -91 836 529 \nQ 422 1150 422 2328 \nQ 422 3509 836 4129 \nQ 1250 4750 2034 4750 \nz\n\" transform=\"scale(0.015625)\"/>\n        <path id=\"DejaVuSans-2e\" d=\"M 684 794 \nL 1344 794 \nL 1344 0 \nL 684 0 \nL 684 794 \nz\n\" transform=\"scale(0.015625)\"/>\n       </defs>\n       <use xlink:href=\"#DejaVuSans-30\"/>\n       <use xlink:href=\"#DejaVuSans-2e\" x=\"63.623047\"/>\n       <use xlink:href=\"#DejaVuSans-30\" x=\"95.410156\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"xtick_2\">\n     <g id=\"line2d_3\">\n      <path d=\"M 159.084072 383.3725 \nL 159.084072 7.2 \n\" clip-path=\"url(#p10e7e609dc)\" style=\"fill: none; stroke: #ffffff; stroke-width: 0.8; stroke-linecap: square\"/>\n     </g>\n     <g id=\"line2d_4\">\n      <g>\n       <use xlink:href=\"#md8605d3880\" x=\"159.084072\" y=\"383.3725\" style=\"fill: #555555; stroke: #555555; stroke-width: 0.8\"/>\n      </g>\n     </g>\n     <g id=\"text_2\">\n      <!-- 0.5 -->\n      <g style=\"fill: #555555\" transform=\"translate(149.542197 399.490625) scale(0.12 -0.12)\">\n       <defs>\n        <path id=\"DejaVuSans-35\" d=\"M 691 4666 \nL 3169 4666 \nL 3169 4134 \nL 1269 4134 \nL 1269 2991 \nQ 1406 3038 1543 3061 \nQ 1681 3084 1819 3084 \nQ 2600 3084 3056 2656 \nQ 3513 2228 3513 1497 \nQ 3513 744 3044 326 \nQ 2575 -91 1722 -91 \nQ 1428 -91 1123 -41 \nQ 819 9 494 109 \nL 494 744 \nQ 775 591 1075 516 \nQ 1375 441 1709 441 \nQ 2250 441 2565 725 \nQ 2881 1009 2881 1497 \nQ 2881 1984 2565 2268 \nQ 2250 2553 1709 2553 \nQ 1456 2553 1204 2497 \nQ 953 2441 691 2322 \nL 691 4666 \nz\n\" transform=\"scale(0.015625)\"/>\n       </defs>\n       <use xlink:href=\"#DejaVuSans-30\"/>\n       <use xlink:href=\"#DejaVuSans-2e\" x=\"63.623047\"/>\n       <use xlink:href=\"#DejaVuSans-35\" x=\"95.410156\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"xtick_3\">\n     <g id=\"line2d_5\">\n      <path d=\"M 235.030473 383.3725 \nL 235.030473 7.2 \n\" clip-path=\"url(#p10e7e609dc)\" style=\"fill: none; stroke: #ffffff; stroke-width: 0.8; stroke-linecap: square\"/>\n     </g>\n     <g id=\"line2d_6\">\n      <g>\n       <use xlink:href=\"#md8605d3880\" x=\"235.030473\" y=\"383.3725\" style=\"fill: #555555; stroke: #555555; stroke-width: 0.8\"/>\n      </g>\n     </g>\n     <g id=\"text_3\">\n      <!-- 1.0 -->\n      <g style=\"fill: #555555\" transform=\"translate(225.488598 399.490625) scale(0.12 -0.12)\">\n       <defs>\n        <path id=\"DejaVuSans-31\" d=\"M 794 531 \nL 1825 531 \nL 1825 4091 \nL 703 3866 \nL 703 4441 \nL 1819 4666 \nL 2450 4666 \nL 2450 531 \nL 3481 531 \nL 3481 0 \nL 794 0 \nL 794 531 \nz\n\" transform=\"scale(0.015625)\"/>\n       </defs>\n       <use xlink:href=\"#DejaVuSans-31\"/>\n       <use xlink:href=\"#DejaVuSans-2e\" x=\"63.623047\"/>\n       <use xlink:href=\"#DejaVuSans-30\" x=\"95.410156\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"xtick_4\">\n     <g id=\"line2d_7\">\n      <path d=\"M 310.976875 383.3725 \nL 310.976875 7.2 \n\" clip-path=\"url(#p10e7e609dc)\" style=\"fill: none; stroke: #ffffff; stroke-width: 0.8; stroke-linecap: square\"/>\n     </g>\n     <g id=\"line2d_8\">\n      <g>\n       <use xlink:href=\"#md8605d3880\" x=\"310.976875\" y=\"383.3725\" style=\"fill: #555555; stroke: #555555; stroke-width: 0.8\"/>\n      </g>\n     </g>\n     <g id=\"text_4\">\n      <!-- 1.5 -->\n      <g style=\"fill: #555555\" transform=\"translate(301.435 399.490625) scale(0.12 -0.12)\">\n       <use xlink:href=\"#DejaVuSans-31\"/>\n       <use xlink:href=\"#DejaVuSans-2e\" x=\"63.623047\"/>\n       <use xlink:href=\"#DejaVuSans-35\" x=\"95.410156\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"xtick_5\">\n     <g id=\"line2d_9\">\n      <path d=\"M 386.923277 383.3725 \nL 386.923277 7.2 \n\" clip-path=\"url(#p10e7e609dc)\" style=\"fill: none; stroke: #ffffff; stroke-width: 0.8; stroke-linecap: square\"/>\n     </g>\n     <g id=\"line2d_10\">\n      <g>\n       <use xlink:href=\"#md8605d3880\" x=\"386.923277\" y=\"383.3725\" style=\"fill: #555555; stroke: #555555; stroke-width: 0.8\"/>\n      </g>\n     </g>\n     <g id=\"text_5\">\n      <!-- 2.0 -->\n      <g style=\"fill: #555555\" transform=\"translate(377.381402 399.490625) scale(0.12 -0.12)\">\n       <defs>\n        <path id=\"DejaVuSans-32\" d=\"M 1228 531 \nL 3431 531 \nL 3431 0 \nL 469 0 \nL 469 531 \nQ 828 903 1448 1529 \nQ 2069 2156 2228 2338 \nQ 2531 2678 2651 2914 \nQ 2772 3150 2772 3378 \nQ 2772 3750 2511 3984 \nQ 2250 4219 1831 4219 \nQ 1534 4219 1204 4116 \nQ 875 4013 500 3803 \nL 500 4441 \nQ 881 4594 1212 4672 \nQ 1544 4750 1819 4750 \nQ 2544 4750 2975 4387 \nQ 3406 4025 3406 3419 \nQ 3406 3131 3298 2873 \nQ 3191 2616 2906 2266 \nQ 2828 2175 2409 1742 \nQ 1991 1309 1228 531 \nz\n\" transform=\"scale(0.015625)\"/>\n       </defs>\n       <use xlink:href=\"#DejaVuSans-32\"/>\n       <use xlink:href=\"#DejaVuSans-2e\" x=\"63.623047\"/>\n       <use xlink:href=\"#DejaVuSans-30\" x=\"95.410156\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"xtick_6\">\n     <g id=\"line2d_11\">\n      <path d=\"M 462.869678 383.3725 \nL 462.869678 7.2 \n\" clip-path=\"url(#p10e7e609dc)\" style=\"fill: none; stroke: #ffffff; stroke-width: 0.8; stroke-linecap: square\"/>\n     </g>\n     <g id=\"line2d_12\">\n      <g>\n       <use xlink:href=\"#md8605d3880\" x=\"462.869678\" y=\"383.3725\" style=\"fill: #555555; stroke: #555555; stroke-width: 0.8\"/>\n      </g>\n     </g>\n     <g id=\"text_6\">\n      <!-- 2.5 -->\n      <g style=\"fill: #555555\" transform=\"translate(453.327803 399.490625) scale(0.12 -0.12)\">\n       <use xlink:href=\"#DejaVuSans-32\"/>\n       <use xlink:href=\"#DejaVuSans-2e\" x=\"63.623047\"/>\n       <use xlink:href=\"#DejaVuSans-35\" x=\"95.410156\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"xtick_7\">\n     <g id=\"line2d_13\">\n      <path d=\"M 538.81608 383.3725 \nL 538.81608 7.2 \n\" clip-path=\"url(#p10e7e609dc)\" style=\"fill: none; stroke: #ffffff; stroke-width: 0.8; stroke-linecap: square\"/>\n     </g>\n     <g id=\"line2d_14\">\n      <g>\n       <use xlink:href=\"#md8605d3880\" x=\"538.81608\" y=\"383.3725\" style=\"fill: #555555; stroke: #555555; stroke-width: 0.8\"/>\n      </g>\n     </g>\n     <g id=\"text_7\">\n      <!-- 3.0 -->\n      <g style=\"fill: #555555\" transform=\"translate(529.274205 399.490625) scale(0.12 -0.12)\">\n       <defs>\n        <path id=\"DejaVuSans-33\" d=\"M 2597 2516 \nQ 3050 2419 3304 2112 \nQ 3559 1806 3559 1356 \nQ 3559 666 3084 287 \nQ 2609 -91 1734 -91 \nQ 1441 -91 1130 -33 \nQ 819 25 488 141 \nL 488 750 \nQ 750 597 1062 519 \nQ 1375 441 1716 441 \nQ 2309 441 2620 675 \nQ 2931 909 2931 1356 \nQ 2931 1769 2642 2001 \nQ 2353 2234 1838 2234 \nL 1294 2234 \nL 1294 2753 \nL 1863 2753 \nQ 2328 2753 2575 2939 \nQ 2822 3125 2822 3475 \nQ 2822 3834 2567 4026 \nQ 2313 4219 1838 4219 \nQ 1578 4219 1281 4162 \nQ 984 4106 628 3988 \nL 628 4550 \nQ 988 4650 1302 4700 \nQ 1616 4750 1894 4750 \nQ 2613 4750 3031 4423 \nQ 3450 4097 3450 3541 \nQ 3450 3153 3228 2886 \nQ 3006 2619 2597 2516 \nz\n\" transform=\"scale(0.015625)\"/>\n       </defs>\n       <use xlink:href=\"#DejaVuSans-33\"/>\n       <use xlink:href=\"#DejaVuSans-2e\" x=\"63.623047\"/>\n       <use xlink:href=\"#DejaVuSans-30\" x=\"95.410156\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"text_8\">\n     <!-- Distance (cm) -->\n     <g style=\"fill: #555555\" transform=\"translate(269.009687 415.104375) scale(0.12 -0.12)\">\n      <defs>\n       <path id=\"DejaVuSans-44\" d=\"M 1259 4147 \nL 1259 519 \nL 2022 519 \nQ 2988 519 3436 956 \nQ 3884 1394 3884 2338 \nQ 3884 3275 3436 3711 \nQ 2988 4147 2022 4147 \nL 1259 4147 \nz\nM 628 4666 \nL 1925 4666 \nQ 3281 4666 3915 4102 \nQ 4550 3538 4550 2338 \nQ 4550 1131 3912 565 \nQ 3275 0 1925 0 \nL 628 0 \nL 628 4666 \nz\n\" transform=\"scale(0.015625)\"/>\n       <path id=\"DejaVuSans-69\" d=\"M 603 3500 \nL 1178 3500 \nL 1178 0 \nL 603 0 \nL 603 3500 \nz\nM 603 4863 \nL 1178 4863 \nL 1178 4134 \nL 603 4134 \nL 603 4863 \nz\n\" transform=\"scale(0.015625)\"/>\n       <path id=\"DejaVuSans-73\" d=\"M 2834 3397 \nL 2834 2853 \nQ 2591 2978 2328 3040 \nQ 2066 3103 1784 3103 \nQ 1356 3103 1142 2972 \nQ 928 2841 928 2578 \nQ 928 2378 1081 2264 \nQ 1234 2150 1697 2047 \nL 1894 2003 \nQ 2506 1872 2764 1633 \nQ 3022 1394 3022 966 \nQ 3022 478 2636 193 \nQ 2250 -91 1575 -91 \nQ 1294 -91 989 -36 \nQ 684 19 347 128 \nL 347 722 \nQ 666 556 975 473 \nQ 1284 391 1588 391 \nQ 1994 391 2212 530 \nQ 2431 669 2431 922 \nQ 2431 1156 2273 1281 \nQ 2116 1406 1581 1522 \nL 1381 1569 \nQ 847 1681 609 1914 \nQ 372 2147 372 2553 \nQ 372 3047 722 3315 \nQ 1072 3584 1716 3584 \nQ 2034 3584 2315 3537 \nQ 2597 3491 2834 3397 \nz\n\" transform=\"scale(0.015625)\"/>\n       <path id=\"DejaVuSans-74\" d=\"M 1172 4494 \nL 1172 3500 \nL 2356 3500 \nL 2356 3053 \nL 1172 3053 \nL 1172 1153 \nQ 1172 725 1289 603 \nQ 1406 481 1766 481 \nL 2356 481 \nL 2356 0 \nL 1766 0 \nQ 1100 0 847 248 \nQ 594 497 594 1153 \nL 594 3053 \nL 172 3053 \nL 172 3500 \nL 594 3500 \nL 594 4494 \nL 1172 4494 \nz\n\" transform=\"scale(0.015625)\"/>\n       <path id=\"DejaVuSans-61\" d=\"M 2194 1759 \nQ 1497 1759 1228 1600 \nQ 959 1441 959 1056 \nQ 959 750 1161 570 \nQ 1363 391 1709 391 \nQ 2188 391 2477 730 \nQ 2766 1069 2766 1631 \nL 2766 1759 \nL 2194 1759 \nz\nM 3341 1997 \nL 3341 0 \nL 2766 0 \nL 2766 531 \nQ 2569 213 2275 61 \nQ 1981 -91 1556 -91 \nQ 1019 -91 701 211 \nQ 384 513 384 1019 \nQ 384 1609 779 1909 \nQ 1175 2209 1959 2209 \nL 2766 2209 \nL 2766 2266 \nQ 2766 2663 2505 2880 \nQ 2244 3097 1772 3097 \nQ 1472 3097 1187 3025 \nQ 903 2953 641 2809 \nL 641 3341 \nQ 956 3463 1253 3523 \nQ 1550 3584 1831 3584 \nQ 2591 3584 2966 3190 \nQ 3341 2797 3341 1997 \nz\n\" transform=\"scale(0.015625)\"/>\n       <path id=\"DejaVuSans-6e\" d=\"M 3513 2113 \nL 3513 0 \nL 2938 0 \nL 2938 2094 \nQ 2938 2591 2744 2837 \nQ 2550 3084 2163 3084 \nQ 1697 3084 1428 2787 \nQ 1159 2491 1159 1978 \nL 1159 0 \nL 581 0 \nL 581 3500 \nL 1159 3500 \nL 1159 2956 \nQ 1366 3272 1645 3428 \nQ 1925 3584 2291 3584 \nQ 2894 3584 3203 3211 \nQ 3513 2838 3513 2113 \nz\n\" transform=\"scale(0.015625)\"/>\n       <path id=\"DejaVuSans-63\" d=\"M 3122 3366 \nL 3122 2828 \nQ 2878 2963 2633 3030 \nQ 2388 3097 2138 3097 \nQ 1578 3097 1268 2742 \nQ 959 2388 959 1747 \nQ 959 1106 1268 751 \nQ 1578 397 2138 397 \nQ 2388 397 2633 464 \nQ 2878 531 3122 666 \nL 3122 134 \nQ 2881 22 2623 -34 \nQ 2366 -91 2075 -91 \nQ 1284 -91 818 406 \nQ 353 903 353 1747 \nQ 353 2603 823 3093 \nQ 1294 3584 2113 3584 \nQ 2378 3584 2631 3529 \nQ 2884 3475 3122 3366 \nz\n\" transform=\"scale(0.015625)\"/>\n       <path id=\"DejaVuSans-65\" d=\"M 3597 1894 \nL 3597 1613 \nL 953 1613 \nQ 991 1019 1311 708 \nQ 1631 397 2203 397 \nQ 2534 397 2845 478 \nQ 3156 559 3463 722 \nL 3463 178 \nQ 3153 47 2828 -22 \nQ 2503 -91 2169 -91 \nQ 1331 -91 842 396 \nQ 353 884 353 1716 \nQ 353 2575 817 3079 \nQ 1281 3584 2069 3584 \nQ 2775 3584 3186 3129 \nQ 3597 2675 3597 1894 \nz\nM 3022 2063 \nQ 3016 2534 2758 2815 \nQ 2500 3097 2075 3097 \nQ 1594 3097 1305 2825 \nQ 1016 2553 972 2059 \nL 3022 2063 \nz\n\" transform=\"scale(0.015625)\"/>\n       <path id=\"DejaVuSans-20\" transform=\"scale(0.015625)\"/>\n       <path id=\"DejaVuSans-28\" d=\"M 1984 4856 \nQ 1566 4138 1362 3434 \nQ 1159 2731 1159 2009 \nQ 1159 1288 1364 580 \nQ 1569 -128 1984 -844 \nL 1484 -844 \nQ 1016 -109 783 600 \nQ 550 1309 550 2009 \nQ 550 2706 781 3412 \nQ 1013 4119 1484 4856 \nL 1984 4856 \nz\n\" transform=\"scale(0.015625)\"/>\n       <path id=\"DejaVuSans-6d\" d=\"M 3328 2828 \nQ 3544 3216 3844 3400 \nQ 4144 3584 4550 3584 \nQ 5097 3584 5394 3201 \nQ 5691 2819 5691 2113 \nL 5691 0 \nL 5113 0 \nL 5113 2094 \nQ 5113 2597 4934 2840 \nQ 4756 3084 4391 3084 \nQ 3944 3084 3684 2787 \nQ 3425 2491 3425 1978 \nL 3425 0 \nL 2847 0 \nL 2847 2094 \nQ 2847 2600 2669 2842 \nQ 2491 3084 2119 3084 \nQ 1678 3084 1418 2786 \nQ 1159 2488 1159 1978 \nL 1159 0 \nL 581 0 \nL 581 3500 \nL 1159 3500 \nL 1159 2956 \nQ 1356 3278 1631 3431 \nQ 1906 3584 2284 3584 \nQ 2666 3584 2933 3390 \nQ 3200 3197 3328 2828 \nz\n\" transform=\"scale(0.015625)\"/>\n       <path id=\"DejaVuSans-29\" d=\"M 513 4856 \nL 1013 4856 \nQ 1481 4119 1714 3412 \nQ 1947 2706 1947 2009 \nQ 1947 1309 1714 600 \nQ 1481 -109 1013 -844 \nL 513 -844 \nQ 928 -128 1133 580 \nQ 1338 1288 1338 2009 \nQ 1338 2731 1133 3434 \nQ 928 4138 513 4856 \nz\n\" transform=\"scale(0.015625)\"/>\n      </defs>\n      <use xlink:href=\"#DejaVuSans-44\"/>\n      <use xlink:href=\"#DejaVuSans-69\" x=\"77.001953\"/>\n      <use xlink:href=\"#DejaVuSans-73\" x=\"104.785156\"/>\n      <use xlink:href=\"#DejaVuSans-74\" x=\"156.884766\"/>\n      <use xlink:href=\"#DejaVuSans-61\" x=\"196.09375\"/>\n      <use xlink:href=\"#DejaVuSans-6e\" x=\"257.373047\"/>\n      <use xlink:href=\"#DejaVuSans-63\" x=\"320.751953\"/>\n      <use xlink:href=\"#DejaVuSans-65\" x=\"375.732422\"/>\n      <use xlink:href=\"#DejaVuSans-20\" x=\"437.255859\"/>\n      <use xlink:href=\"#DejaVuSans-28\" x=\"469.042969\"/>\n      <use xlink:href=\"#DejaVuSans-63\" x=\"508.056641\"/>\n      <use xlink:href=\"#DejaVuSans-6d\" x=\"563.037109\"/>\n      <use xlink:href=\"#DejaVuSans-29\" x=\"660.449219\"/>\n     </g>\n    </g>\n   </g>\n   <g id=\"matplotlib.axis_2\">\n    <g id=\"ytick_1\">\n     <g id=\"line2d_15\">\n      <path d=\"M 60.35375 359.109317 \nL 561.6 359.109317 \n\" clip-path=\"url(#p10e7e609dc)\" style=\"fill: none; stroke: #ffffff; stroke-width: 0.8; stroke-linecap: square\"/>\n     </g>\n     <g id=\"line2d_16\">\n      <defs>\n       <path id=\"m232a5ef2f8\" d=\"M 0 0 \nL -3.5 0 \n\" style=\"stroke: #555555; stroke-width: 0.8\"/>\n      </defs>\n      <g>\n       <use xlink:href=\"#m232a5ef2f8\" x=\"60.35375\" y=\"359.109317\" style=\"fill: #555555; stroke: #555555; stroke-width: 0.8\"/>\n      </g>\n     </g>\n     <g id=\"text_9\">\n      <!-- 400 -->\n      <g style=\"fill: #555555\" transform=\"translate(30.44875 363.668379) scale(0.12 -0.12)\">\n       <defs>\n        <path id=\"DejaVuSans-34\" d=\"M 2419 4116 \nL 825 1625 \nL 2419 1625 \nL 2419 4116 \nz\nM 2253 4666 \nL 3047 4666 \nL 3047 1625 \nL 3713 1625 \nL 3713 1100 \nL 3047 1100 \nL 3047 0 \nL 2419 0 \nL 2419 1100 \nL 313 1100 \nL 313 1709 \nL 2253 4666 \nz\n\" transform=\"scale(0.015625)\"/>\n       </defs>\n       <use xlink:href=\"#DejaVuSans-34\"/>\n       <use xlink:href=\"#DejaVuSans-30\" x=\"63.623047\"/>\n       <use xlink:href=\"#DejaVuSans-30\" x=\"127.246094\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"ytick_2\">\n     <g id=\"line2d_17\">\n      <path d=\"M 60.35375 305.74296 \nL 561.6 305.74296 \n\" clip-path=\"url(#p10e7e609dc)\" style=\"fill: none; stroke: #ffffff; stroke-width: 0.8; stroke-linecap: square\"/>\n     </g>\n     <g id=\"line2d_18\">\n      <g>\n       <use xlink:href=\"#m232a5ef2f8\" x=\"60.35375\" y=\"305.74296\" style=\"fill: #555555; stroke: #555555; stroke-width: 0.8\"/>\n      </g>\n     </g>\n     <g id=\"text_10\">\n      <!-- 600 -->\n      <g style=\"fill: #555555\" transform=\"translate(30.44875 310.302022) scale(0.12 -0.12)\">\n       <defs>\n        <path id=\"DejaVuSans-36\" d=\"M 2113 2584 \nQ 1688 2584 1439 2293 \nQ 1191 2003 1191 1497 \nQ 1191 994 1439 701 \nQ 1688 409 2113 409 \nQ 2538 409 2786 701 \nQ 3034 994 3034 1497 \nQ 3034 2003 2786 2293 \nQ 2538 2584 2113 2584 \nz\nM 3366 4563 \nL 3366 3988 \nQ 3128 4100 2886 4159 \nQ 2644 4219 2406 4219 \nQ 1781 4219 1451 3797 \nQ 1122 3375 1075 2522 \nQ 1259 2794 1537 2939 \nQ 1816 3084 2150 3084 \nQ 2853 3084 3261 2657 \nQ 3669 2231 3669 1497 \nQ 3669 778 3244 343 \nQ 2819 -91 2113 -91 \nQ 1303 -91 875 529 \nQ 447 1150 447 2328 \nQ 447 3434 972 4092 \nQ 1497 4750 2381 4750 \nQ 2619 4750 2861 4703 \nQ 3103 4656 3366 4563 \nz\n\" transform=\"scale(0.015625)\"/>\n       </defs>\n       <use xlink:href=\"#DejaVuSans-36\"/>\n       <use xlink:href=\"#DejaVuSans-30\" x=\"63.623047\"/>\n       <use xlink:href=\"#DejaVuSans-30\" x=\"127.246094\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"ytick_3\">\n     <g id=\"line2d_19\">\n      <path d=\"M 60.35375 252.376603 \nL 561.6 252.376603 \n\" clip-path=\"url(#p10e7e609dc)\" style=\"fill: none; stroke: #ffffff; stroke-width: 0.8; stroke-linecap: square\"/>\n     </g>\n     <g id=\"line2d_20\">\n      <g>\n       <use xlink:href=\"#m232a5ef2f8\" x=\"60.35375\" y=\"252.376603\" style=\"fill: #555555; stroke: #555555; stroke-width: 0.8\"/>\n      </g>\n     </g>\n     <g id=\"text_11\">\n      <!-- 800 -->\n      <g style=\"fill: #555555\" transform=\"translate(30.44875 256.935666) scale(0.12 -0.12)\">\n       <defs>\n        <path id=\"DejaVuSans-38\" d=\"M 2034 2216 \nQ 1584 2216 1326 1975 \nQ 1069 1734 1069 1313 \nQ 1069 891 1326 650 \nQ 1584 409 2034 409 \nQ 2484 409 2743 651 \nQ 3003 894 3003 1313 \nQ 3003 1734 2745 1975 \nQ 2488 2216 2034 2216 \nz\nM 1403 2484 \nQ 997 2584 770 2862 \nQ 544 3141 544 3541 \nQ 544 4100 942 4425 \nQ 1341 4750 2034 4750 \nQ 2731 4750 3128 4425 \nQ 3525 4100 3525 3541 \nQ 3525 3141 3298 2862 \nQ 3072 2584 2669 2484 \nQ 3125 2378 3379 2068 \nQ 3634 1759 3634 1313 \nQ 3634 634 3220 271 \nQ 2806 -91 2034 -91 \nQ 1263 -91 848 271 \nQ 434 634 434 1313 \nQ 434 1759 690 2068 \nQ 947 2378 1403 2484 \nz\nM 1172 3481 \nQ 1172 3119 1398 2916 \nQ 1625 2713 2034 2713 \nQ 2441 2713 2670 2916 \nQ 2900 3119 2900 3481 \nQ 2900 3844 2670 4047 \nQ 2441 4250 2034 4250 \nQ 1625 4250 1398 4047 \nQ 1172 3844 1172 3481 \nz\n\" transform=\"scale(0.015625)\"/>\n       </defs>\n       <use xlink:href=\"#DejaVuSans-38\"/>\n       <use xlink:href=\"#DejaVuSans-30\" x=\"63.623047\"/>\n       <use xlink:href=\"#DejaVuSans-30\" x=\"127.246094\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"ytick_4\">\n     <g id=\"line2d_21\">\n      <path d=\"M 60.35375 199.010246 \nL 561.6 199.010246 \n\" clip-path=\"url(#p10e7e609dc)\" style=\"fill: none; stroke: #ffffff; stroke-width: 0.8; stroke-linecap: square\"/>\n     </g>\n     <g id=\"line2d_22\">\n      <g>\n       <use xlink:href=\"#m232a5ef2f8\" x=\"60.35375\" y=\"199.010246\" style=\"fill: #555555; stroke: #555555; stroke-width: 0.8\"/>\n      </g>\n     </g>\n     <g id=\"text_12\">\n      <!-- 1000 -->\n      <g style=\"fill: #555555\" transform=\"translate(22.81375 203.569309) scale(0.12 -0.12)\">\n       <use xlink:href=\"#DejaVuSans-31\"/>\n       <use xlink:href=\"#DejaVuSans-30\" x=\"63.623047\"/>\n       <use xlink:href=\"#DejaVuSans-30\" x=\"127.246094\"/>\n       <use xlink:href=\"#DejaVuSans-30\" x=\"190.869141\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"ytick_5\">\n     <g id=\"line2d_23\">\n      <path d=\"M 60.35375 145.64389 \nL 561.6 145.64389 \n\" clip-path=\"url(#p10e7e609dc)\" style=\"fill: none; stroke: #ffffff; stroke-width: 0.8; stroke-linecap: square\"/>\n     </g>\n     <g id=\"line2d_24\">\n      <g>\n       <use xlink:href=\"#m232a5ef2f8\" x=\"60.35375\" y=\"145.64389\" style=\"fill: #555555; stroke: #555555; stroke-width: 0.8\"/>\n      </g>\n     </g>\n     <g id=\"text_13\">\n      <!-- 1200 -->\n      <g style=\"fill: #555555\" transform=\"translate(22.81375 150.202952) scale(0.12 -0.12)\">\n       <use xlink:href=\"#DejaVuSans-31\"/>\n       <use xlink:href=\"#DejaVuSans-32\" x=\"63.623047\"/>\n       <use xlink:href=\"#DejaVuSans-30\" x=\"127.246094\"/>\n       <use xlink:href=\"#DejaVuSans-30\" x=\"190.869141\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"ytick_6\">\n     <g id=\"line2d_25\">\n      <path d=\"M 60.35375 92.277533 \nL 561.6 92.277533 \n\" clip-path=\"url(#p10e7e609dc)\" style=\"fill: none; stroke: #ffffff; stroke-width: 0.8; stroke-linecap: square\"/>\n     </g>\n     <g id=\"line2d_26\">\n      <g>\n       <use xlink:href=\"#m232a5ef2f8\" x=\"60.35375\" y=\"92.277533\" style=\"fill: #555555; stroke: #555555; stroke-width: 0.8\"/>\n      </g>\n     </g>\n     <g id=\"text_14\">\n      <!-- 1400 -->\n      <g style=\"fill: #555555\" transform=\"translate(22.81375 96.836596) scale(0.12 -0.12)\">\n       <use xlink:href=\"#DejaVuSans-31\"/>\n       <use xlink:href=\"#DejaVuSans-34\" x=\"63.623047\"/>\n       <use xlink:href=\"#DejaVuSans-30\" x=\"127.246094\"/>\n       <use xlink:href=\"#DejaVuSans-30\" x=\"190.869141\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"ytick_7\">\n     <g id=\"line2d_27\">\n      <path d=\"M 60.35375 38.911176 \nL 561.6 38.911176 \n\" clip-path=\"url(#p10e7e609dc)\" style=\"fill: none; stroke: #ffffff; stroke-width: 0.8; stroke-linecap: square\"/>\n     </g>\n     <g id=\"line2d_28\">\n      <g>\n       <use xlink:href=\"#m232a5ef2f8\" x=\"60.35375\" y=\"38.911176\" style=\"fill: #555555; stroke: #555555; stroke-width: 0.8\"/>\n      </g>\n     </g>\n     <g id=\"text_15\">\n      <!-- 1600 -->\n      <g style=\"fill: #555555\" transform=\"translate(22.81375 43.470239) scale(0.12 -0.12)\">\n       <use xlink:href=\"#DejaVuSans-31\"/>\n       <use xlink:href=\"#DejaVuSans-36\" x=\"63.623047\"/>\n       <use xlink:href=\"#DejaVuSans-30\" x=\"127.246094\"/>\n       <use xlink:href=\"#DejaVuSans-30\" x=\"190.869141\"/>\n      </g>\n     </g>\n    </g>\n    <g id=\"text_16\">\n     <!-- Temperature (K) -->\n     <g style=\"fill: #555555\" transform=\"translate(16.318125 243.813125) rotate(-90) scale(0.12 -0.12)\">\n      <defs>\n       <path id=\"DejaVuSans-54\" d=\"M -19 4666 \nL 3928 4666 \nL 3928 4134 \nL 2272 4134 \nL 2272 0 \nL 1638 0 \nL 1638 4134 \nL -19 4134 \nL -19 4666 \nz\n\" transform=\"scale(0.015625)\"/>\n       <path id=\"DejaVuSans-70\" d=\"M 1159 525 \nL 1159 -1331 \nL 581 -1331 \nL 581 3500 \nL 1159 3500 \nL 1159 2969 \nQ 1341 3281 1617 3432 \nQ 1894 3584 2278 3584 \nQ 2916 3584 3314 3078 \nQ 3713 2572 3713 1747 \nQ 3713 922 3314 415 \nQ 2916 -91 2278 -91 \nQ 1894 -91 1617 61 \nQ 1341 213 1159 525 \nz\nM 3116 1747 \nQ 3116 2381 2855 2742 \nQ 2594 3103 2138 3103 \nQ 1681 3103 1420 2742 \nQ 1159 2381 1159 1747 \nQ 1159 1113 1420 752 \nQ 1681 391 2138 391 \nQ 2594 391 2855 752 \nQ 3116 1113 3116 1747 \nz\n\" transform=\"scale(0.015625)\"/>\n       <path id=\"DejaVuSans-72\" d=\"M 2631 2963 \nQ 2534 3019 2420 3045 \nQ 2306 3072 2169 3072 \nQ 1681 3072 1420 2755 \nQ 1159 2438 1159 1844 \nL 1159 0 \nL 581 0 \nL 581 3500 \nL 1159 3500 \nL 1159 2956 \nQ 1341 3275 1631 3429 \nQ 1922 3584 2338 3584 \nQ 2397 3584 2469 3576 \nQ 2541 3569 2628 3553 \nL 2631 2963 \nz\n\" transform=\"scale(0.015625)\"/>\n       <path id=\"DejaVuSans-75\" d=\"M 544 1381 \nL 544 3500 \nL 1119 3500 \nL 1119 1403 \nQ 1119 906 1312 657 \nQ 1506 409 1894 409 \nQ 2359 409 2629 706 \nQ 2900 1003 2900 1516 \nL 2900 3500 \nL 3475 3500 \nL 3475 0 \nL 2900 0 \nL 2900 538 \nQ 2691 219 2414 64 \nQ 2138 -91 1772 -91 \nQ 1169 -91 856 284 \nQ 544 659 544 1381 \nz\nM 1991 3584 \nL 1991 3584 \nz\n\" transform=\"scale(0.015625)\"/>\n       <path id=\"DejaVuSans-4b\" d=\"M 628 4666 \nL 1259 4666 \nL 1259 2694 \nL 3353 4666 \nL 4166 4666 \nL 1850 2491 \nL 4331 0 \nL 3500 0 \nL 1259 2247 \nL 1259 0 \nL 628 0 \nL 628 4666 \nz\n\" transform=\"scale(0.015625)\"/>\n      </defs>\n      <use xlink:href=\"#DejaVuSans-54\"/>\n      <use xlink:href=\"#DejaVuSans-65\" x=\"44.083984\"/>\n      <use xlink:href=\"#DejaVuSans-6d\" x=\"105.607422\"/>\n      <use xlink:href=\"#DejaVuSans-70\" x=\"203.019531\"/>\n      <use xlink:href=\"#DejaVuSans-65\" x=\"266.496094\"/>\n      <use xlink:href=\"#DejaVuSans-72\" x=\"328.019531\"/>\n      <use xlink:href=\"#DejaVuSans-61\" x=\"369.132812\"/>\n      <use xlink:href=\"#DejaVuSans-74\" x=\"430.412109\"/>\n      <use xlink:href=\"#DejaVuSans-75\" x=\"469.621094\"/>\n      <use xlink:href=\"#DejaVuSans-72\" x=\"533\"/>\n      <use xlink:href=\"#DejaVuSans-65\" x=\"571.863281\"/>\n      <use xlink:href=\"#DejaVuSans-20\" x=\"633.386719\"/>\n      <use xlink:href=\"#DejaVuSans-28\" x=\"665.173828\"/>\n      <use xlink:href=\"#DejaVuSans-4b\" x=\"704.1875\"/>\n      <use xlink:href=\"#DejaVuSans-29\" x=\"769.763672\"/>\n     </g>\n    </g>\n   </g>\n   <g id=\"line2d_29\">\n    <path d=\"M 83.13767 366.27375 \nL 128.705511 366.26792 \nL 151.489432 366.248939 \nL 174.273352 366.160877 \nL 185.665312 365.998011 \nL 191.361293 365.807902 \nL 197.057273 365.450775 \nL 202.753253 364.784962 \nL 208.449233 363.557134 \nL 214.145213 361.328937 \nL 219.841193 357.379922 \nL 222.689183 354.319588 \nL 225.537173 350.205838 \nL 228.385163 344.767902 \nL 231.233153 337.715738 \nL 234.081143 328.760392 \nL 236.929134 317.63707 \nL 239.777124 304.125337 \nL 241.201119 296.371278 \nL 242.625114 287.918292 \nL 244.049109 278.755001 \nL 245.473104 268.874591 \nL 246.897099 258.274691 \nL 248.321094 246.957486 \nL 249.745089 234.930302 \nL 250.457086 228.649375 \nL 251.169084 222.192558 \nL 251.881081 215.563492 \nL 252.593079 208.766881 \nL 253.305076 201.808804 \nL 254.017074 194.697138 \nL 254.373073 191.086965 \nL 254.729071 187.442162 \nL 255.08507 183.76456 \nL 255.441069 180.056217 \nL 255.797068 176.319448 \nL 256.153066 172.556843 \nL 256.509065 168.771292 \nL 256.865064 164.966005 \nL 257.221063 161.144532 \nL 257.577061 157.310784 \nL 257.93306 153.469052 \nL 258.289059 149.624018 \nL 258.645058 145.780768 \nL 259.001056 141.944803 \nL 259.357055 138.122028 \nL 259.713054 134.31875 \nL 260.069053 130.541647 \nL 260.425051 126.797726 \nL 260.78105 123.094267 \nL 261.137049 119.438737 \nL 261.493048 115.838693 \nL 261.849047 112.301658 \nL 262.205045 108.834989 \nL 262.561044 105.445731 \nL 262.917043 102.140475 \nL 263.273042 98.925215 \nL 263.62904 95.805232 \nL 263.985039 92.784989 \nL 264.341038 89.868062 \nL 264.697037 87.057105 \nL 265.053035 84.353839 \nL 265.409034 81.75908 \nL 265.765033 79.272789 \nL 266.121032 76.894136 \nL 266.47703 74.621608 \nL 266.833029 72.453071 \nL 267.189028 70.385909 \nL 267.545027 68.417081 \nL 267.901025 66.54325 \nL 268.257024 64.760837 \nL 268.613023 63.066127 \nL 268.969022 61.455304 \nL 269.32502 59.924539 \nL 269.681019 58.470011 \nL 270.393017 55.777717 \nL 271.105014 53.34395 \nL 271.817012 51.141893 \nL 272.529009 49.147027 \nL 273.241007 47.33722 \nL 273.953004 45.69268 \nL 275.376999 42.845172 \nL 276.800994 40.462629 \nL 278.224989 38.454609 \nL 279.648984 36.750456 \nL 281.072979 35.294765 \nL 282.496974 34.043852 \nL 285.344964 32.051247 \nL 288.192955 30.524245 \nL 291.040945 29.334139 \nL 293.888935 28.393132 \nL 299.584915 27.073884 \nL 305.280895 26.184301 \nL 310.976875 25.568018 \nL 322.368835 24.877554 \nL 333.760795 24.523138 \nL 345.152756 24.35586 \nL 356.544716 24.29875 \nL 379.328636 24.383585 \nL 402.112557 24.565811 \nL 447.680398 25.020708 \nL 493.248239 25.388072 \nL 538.81608 25.388072 \n\" clip-path=\"url(#p10e7e609dc)\" style=\"fill: none; stroke: #4c72b0; stroke-width: 1.5; stroke-linecap: square\"/>\n    <defs>\n     <path id=\"maf77d62555\" d=\"M 0 3 \nC 0.795609 3 1.55874 2.683901 2.12132 2.12132 \nC 2.683901 1.55874 3 0.795609 3 0 \nC 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 \nC 1.55874 -2.683901 0.795609 -3 0 -3 \nC -0.795609 -3 -1.55874 -2.683901 -2.12132 -2.12132 \nC -2.683901 -1.55874 -3 -0.795609 -3 0 \nC -3 0.795609 -2.683901 1.55874 -2.12132 2.12132 \nC -1.55874 2.683901 -0.795609 3 0 3 \nz\n\" style=\"stroke: #4c72b0\"/>\n    </defs>\n    <g clip-path=\"url(#p10e7e609dc)\">\n     <use xlink:href=\"#maf77d62555\" x=\"83.13767\" y=\"366.27375\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"128.705511\" y=\"366.26792\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"151.489432\" y=\"366.248939\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"174.273352\" y=\"366.160877\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"185.665312\" y=\"365.998011\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"191.361293\" y=\"365.807902\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"197.057273\" y=\"365.450775\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"202.753253\" y=\"364.784962\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"208.449233\" y=\"363.557134\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"214.145213\" y=\"361.328937\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"219.841193\" y=\"357.379922\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"222.689183\" y=\"354.319588\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"225.537173\" y=\"350.205838\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"228.385163\" y=\"344.767902\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"231.233153\" y=\"337.715738\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"234.081143\" y=\"328.760392\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"236.929134\" y=\"317.63707\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"239.777124\" y=\"304.125337\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"241.201119\" y=\"296.371278\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"242.625114\" y=\"287.918292\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"244.049109\" y=\"278.755001\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"245.473104\" y=\"268.874591\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"246.897099\" y=\"258.274691\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"248.321094\" y=\"246.957486\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"249.745089\" y=\"234.930302\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"250.457086\" y=\"228.649375\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"251.169084\" y=\"222.192558\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"251.881081\" y=\"215.563492\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"252.593079\" y=\"208.766881\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"253.305076\" y=\"201.808804\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"254.017074\" y=\"194.697138\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"254.373073\" y=\"191.086965\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"254.729071\" y=\"187.442162\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"255.08507\" y=\"183.76456\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"255.441069\" y=\"180.056217\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"255.797068\" y=\"176.319448\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"256.153066\" y=\"172.556843\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"256.509065\" y=\"168.771292\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"256.865064\" y=\"164.966005\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"257.221063\" y=\"161.144532\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"257.577061\" y=\"157.310784\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"257.93306\" y=\"153.469052\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"258.289059\" y=\"149.624018\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"258.645058\" y=\"145.780768\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"259.001056\" y=\"141.944803\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"259.357055\" y=\"138.122028\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"259.713054\" y=\"134.31875\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"260.069053\" y=\"130.541647\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"260.425051\" y=\"126.797726\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"260.78105\" y=\"123.094267\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"261.137049\" y=\"119.438737\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"261.493048\" y=\"115.838693\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"261.849047\" y=\"112.301658\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"262.205045\" y=\"108.834989\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"262.561044\" y=\"105.445731\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"262.917043\" y=\"102.140475\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"263.273042\" y=\"98.925215\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"263.62904\" y=\"95.805232\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"263.985039\" y=\"92.784989\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"264.341038\" y=\"89.868062\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"264.697037\" y=\"87.057105\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"265.053035\" y=\"84.353839\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"265.409034\" y=\"81.75908\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"265.765033\" y=\"79.272789\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"266.121032\" y=\"76.894136\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"266.47703\" y=\"74.621608\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"266.833029\" y=\"72.453071\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"267.189028\" y=\"70.385909\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"267.545027\" y=\"68.417081\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"267.901025\" y=\"66.54325\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"268.257024\" y=\"64.760837\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"268.613023\" y=\"63.066127\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"268.969022\" y=\"61.455304\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"269.32502\" y=\"59.924539\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"269.681019\" y=\"58.470011\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"270.393017\" y=\"55.777717\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"271.105014\" y=\"53.34395\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"271.817012\" y=\"51.141893\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"272.529009\" y=\"49.147027\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"273.241007\" y=\"47.33722\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"273.953004\" y=\"45.69268\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"275.376999\" y=\"42.845172\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"276.800994\" y=\"40.462629\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"278.224989\" y=\"38.454609\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"279.648984\" y=\"36.750456\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"281.072979\" y=\"35.294765\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"282.496974\" y=\"34.043852\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"285.344964\" y=\"32.051247\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"288.192955\" y=\"30.524245\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"291.040945\" y=\"29.334139\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"293.888935\" y=\"28.393132\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"299.584915\" y=\"27.073884\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"305.280895\" y=\"26.184301\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"310.976875\" y=\"25.568018\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"322.368835\" y=\"24.877554\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"333.760795\" y=\"24.523138\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"345.152756\" y=\"24.35586\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"356.544716\" y=\"24.29875\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"379.328636\" y=\"24.383585\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"402.112557\" y=\"24.565811\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"447.680398\" y=\"25.020708\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"493.248239\" y=\"25.388072\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n     <use xlink:href=\"#maf77d62555\" x=\"538.81608\" y=\"25.388072\" style=\"fill: #4c72b0; stroke: #4c72b0\"/>\n    </g>\n   </g>\n   <g id=\"patch_3\">\n    <path d=\"M 60.35375 383.3725 \nL 60.35375 7.2 \n\" style=\"fill: none; stroke: #ffffff; stroke-linejoin: miter; stroke-linecap: square\"/>\n   </g>\n   <g id=\"patch_4\">\n    <path d=\"M 561.6 383.3725 \nL 561.6 7.2 \n\" style=\"fill: none; stroke: #ffffff; stroke-linejoin: miter; stroke-linecap: square\"/>\n   </g>\n   <g id=\"patch_5\">\n    <path d=\"M 60.35375 383.3725 \nL 561.6 383.3725 \n\" style=\"fill: none; stroke: #ffffff; stroke-linejoin: miter; stroke-linecap: square\"/>\n   </g>\n   <g id=\"patch_6\">\n    <path d=\"M 60.35375 7.2 \nL 561.6 7.2 \n\" style=\"fill: none; stroke: #ffffff; stroke-linejoin: miter; stroke-linecap: square\"/>\n   </g>\n  </g>\n </g>\n <defs>\n  <clipPath id=\"p10e7e609dc\">\n   <rect x=\"60.35375\" y=\"7.2\" width=\"501.24625\" height=\"376.1725\"/>\n  </clipPath>\n </defs>\n</svg>\n"
-          },
-          "metadata": {}
-        }
-      ]
-    },
-    {
-      "cell_type": "code",
-      "source": [],
-      "metadata": {
-        "id": "lO7jrTAkewDG"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "#Use of the Fluids package in a NeqSim process simulation\n"
-      ],
-      "metadata": {
-        "id": "cmHtZrXNVHXY"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "In t his section we will use calculations of an orifice pressure drop (see documentation):\n",
-        "\n",
-        "\n",
-        "https://fluids.readthedocs.io/fluids.flow_meter.html"
-      ],
-      "metadata": {
-        "id": "RNGqpmB3Wu_h"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "%%capture\n",
-        "!pip install fluids"
-      ],
-      "metadata": {
-        "id": "DtbjHggBVSHg"
-      },
-      "execution_count": 79,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "from neqsim.process.unitop import unitop\n",
-        "from neqsim import jNeqSim\n",
-        "from jpype import JImplements, JOverride\n",
-        "import fluids\n",
-        "import json\n",
-        "\n",
-        "class Orifice(unitop):\n",
-        "    def __init__(self, name):\n",
-        "        super().__init__()\n",
-        "        self.serialVersionUID = None\n",
-        "        self.name = name\n",
-        "        self.inputstream = None\n",
-        "        self.outputstream = None\n",
-        "        self.dp = None\n",
-        "        self.diameter = None\n",
-        "        self.diameter_outer = None\n",
-        "        self.C = None\n",
-        "\n",
-        "    def setInputStream(self, stream):\n",
-        "        self.outputstream = stream.clone()\n",
-        "        self.inputstream = stream\n",
-        "\n",
-        "    def getOutputStream(self):\n",
-        "        return self.outputstream\n",
-        "\n",
-        "    def setOrificeParameters(self, diameter, diameter_outer, C):\n",
-        "        self.diameter = diameter\n",
-        "        self.diameter_outer = diameter_outer\n",
-        "        self.C = C\n",
-        "\n",
-        "    def calc_dp(self):\n",
-        "        try:\n",
-        "            self.dp = fluids.flow_meter.dP_orifice(\n",
-        "                D=self.diameter,\n",
-        "                Do=self.diameter_outer,\n",
-        "                P1=self.inputstream.getPressure('Pa'),\n",
-        "                P2=self.inputstream.getPressure('Pa') * 0.95,\n",
-        "                C=self.C\n",
-        "            ) / 1e5\n",
-        "        except Exception as e:\n",
-        "            print(f\"An error occurred in calc_dp: {e}\")\n",
-        "        return self.dp\n",
-        "\n",
-        "    @JOverride\n",
-        "    def run(self, uuid):\n",
-        "        out_fluid = self.inputstream.getFluid().clone()\n",
-        "        out_fluid.setPressure(self.inputstream.getPressure('bara') - self.calc_dp(), 'bara')\n",
-        "        self.outputstream.setFluid(out_fluid)\n",
-        "        self.outputstream.run()\n",
-        "\n",
-        "    @JOverride\n",
-        "    def toJson(self):\n",
-        "        data_dict = {\n",
-        "            \"name\": self.name,\n",
-        "            \"diameter\": self.diameter,\n",
-        "            \"diameter_outer\": self.diameter_outer,\n",
-        "            \"C\": self.C,\n",
-        "            \"dP\": self.dp\n",
-        "        }\n",
-        "        return json.dumps(data_dict)"
-      ],
-      "metadata": {
-        "id": "q6mrVs8rVRGC"
-      },
-      "execution_count": 80,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "from neqsim import jNeqSim\n",
-        "from neqsim.thermo.thermoTools import fluid\n",
-        "\n",
-        "# Create a fluid with the SRK (Soave-Redlich-Kwong) equation of state\n",
-        "fluid1 = fluid(\"srk\")\n",
-        "fluid1.setTemperature(30.0, \"C\")\n",
-        "fluid1.setPressure(10.0, \"bara\")\n",
-        "fluid1.addComponent(\"methane\", 1.0, \"kg/sec\")\n",
-        "fluid1.setMixingRule(2)\n",
-        "\n",
-        "# Create a stream with the fluid\n",
-        "stream1 = jNeqSim.processSimulation.processEquipment.stream.Stream(\"stream 1\", fluid1)\n",
-        "stream1.setFlowRate(3000, \"kg/hr\")\n",
-        "\n",
-        "# Define and set up the orifice unit operation\n",
-        "orif1 = Orifice(name=\"orifice 1\")\n",
-        "orif1.setInputStream(stream1)\n",
-        "orif1.setOrificeParameters(diameter=0.07366, diameter_outer=0.05, C=0.61)  # Corrected parameter spelling\n",
-        "\n",
-        "# Define the output stream after the orifice\n",
-        "stream2 = jNeqSim.processSimulation.processEquipment.stream.Stream(\"stream2\", orif1.getOutputStream())\n",
-        "\n",
-        "# Set up and run the process system\n",
-        "oilprocess = jNeqSim.processSimulation.processSystem.ProcessSystem()\n",
-        "oilprocess.add(stream1)\n",
-        "oilprocess.add(orif1)\n",
-        "oilprocess.add(stream2)\n",
-        "\n",
-        "oilprocess.run()\n",
-        "\n",
-        "# Output the pressure after the orifice\n",
-        "print('Pressure out of orifice:', stream2.getPressure('bara'), 'bara')"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "qDg0C0p7afKQ",
-        "outputId": "a46f8f2b-dc2e-4773-cb32-f704b74baa8a"
-      },
-      "execution_count": 81,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Pressure out of orifice: 9.731895927508736 bara\n"
-          ]
-        }
-      ]
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "All required public-PyPI packages are already available.\n"
+     ]
     }
-  ]
+   ],
+   "source": [
+    "import importlib.util\n",
+    "import subprocess\n",
+    "import sys\n",
+    "\n",
+    "required_packages = {\n",
+    "    \"neqsim\": \"neqsim\",\n",
+    "    \"CoolProp\": \"CoolProp\",\n",
+    "    \"thermopack\": \"thermopack\",\n",
+    "    \"cantera\": \"cantera\",\n",
+    "    \"fluids\": \"fluids\",\n",
+    "    \"scipy\": \"scipy\",\n",
+    "    \"pandas\": \"pandas\",\n",
+    "    \"matplotlib\": \"matplotlib\",\n",
+    "}\n",
+    "\n",
+    "missing_packages = [\n",
+    "    distribution\n",
+    "    for module_name, distribution in required_packages.items()\n",
+    "    if importlib.util.find_spec(module_name) is None\n",
+    "]\n",
+    "\n",
+    "if missing_packages:\n",
+    "    subprocess.check_call(\n",
+    "        [\n",
+    "            sys.executable,\n",
+    "            \"-m\",\n",
+    "            \"pip\",\n",
+    "            \"install\",\n",
+    "            \"--upgrade\",\n",
+    "            \"--no-cache-dir\",\n",
+    "            *missing_packages,\n",
+    "        ]\n",
+    "    )\n",
+    "else:\n",
+    "    print(\"All required public-PyPI packages are already available.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "cfac0a0d",
+   "metadata": {
+    "id": "6R_27ps-b4le"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Out[0]: \n",
+      "           version\n",
+      "NeqSim      3.16.0\n",
+      "CoolProp     8.0.0\n",
+      "ThermoPack   2.2.3\n",
+      "Cantera      3.2.0\n",
+      "fluids       1.3.1\n",
+      "SciPy       1.18.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "import importlib.metadata\n",
+    "import json\n",
+    "import math\n",
+    "\n",
+    "import CoolProp\n",
+    "import cantera as ct\n",
+    "import fluids\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import scipy\n",
+    "import thermopack\n",
+    "from scipy.optimize import brentq\n",
+    "\n",
+    "from jpype import JOverride\n",
+    "from neqsim import jneqsim\n",
+    "from neqsim.process.unitop import unitop\n",
+    "from neqsim.thermo import fluid\n",
+    "\n",
+    "plt.style.use(\"seaborn-v0_8-whitegrid\")\n",
+    "plt.rcParams.update(\n",
+    "    {\n",
+    "        \"figure.dpi\": 120,\n",
+    "        \"figure.figsize\": (8.0, 5.0),\n",
+    "        \"axes.titlesize\": 13,\n",
+    "        \"axes.labelsize\": 11,\n",
+    "        \"legend.fontsize\": 9,\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "runtime_versions = {\n",
+    "    \"NeqSim\": importlib.metadata.version(\"neqsim\"),\n",
+    "    \"CoolProp\": CoolProp.__version__,\n",
+    "    \"ThermoPack\": importlib.metadata.version(\"thermopack\"),\n",
+    "    \"Cantera\": ct.__version__,\n",
+    "    \"fluids\": fluids.__version__,\n",
+    "    \"SciPy\": scipy.__version__,\n",
+    "}\n",
+    "\n",
+    "pd.Series(runtime_versions, name=\"version\").to_frame()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d52130d8",
+   "metadata": {
+    "id": "158kYPMGc1hy"
+   },
+   "source": [
+    "## 1.1 A reusable carbonate-equilibrium unit operation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "dbba0091",
+   "metadata": {
+    "id": "71qW9mH-dFEo"
+   },
+   "outputs": [],
+   "source": [
+    "class ReaktoroUnitOperation(unitop):\n",
+    "    \"\"\"Public-PyPI carbonate screening model with the original process contract.\"\"\"\n",
+    "\n",
+    "    def __init__(self, alkalinity_mol_per_litre=0.05, calcium_mol_per_litre=0.001):\n",
+    "        super().__init__()\n",
+    "        self.input_stream = None\n",
+    "        self.alkalinity_mol_per_litre = alkalinity_mol_per_litre\n",
+    "        self.calcium_mol_per_litre = calcium_mol_per_litre\n",
+    "        self.results = {}\n",
+    "\n",
+    "    def setInputStream(self, stream):\n",
+    "        self.input_stream = stream\n",
+    "\n",
+    "    def calculate_carbonate_equilibrium(self, co2_fugacity_bara):\n",
+    "        henry_constant_mol_per_litre_atm = 0.033\n",
+    "        first_dissociation_constant = 4.45e-7\n",
+    "        second_dissociation_constant = 4.69e-11\n",
+    "        water_ion_product = 1.0e-14\n",
+    "        calcite_solubility_product = 3.3e-9\n",
+    "\n",
+    "        co2_fugacity_atm = co2_fugacity_bara / 1.01325\n",
+    "        dissolved_co2 = henry_constant_mol_per_litre_atm * co2_fugacity_atm\n",
+    "\n",
+    "        def charge_balance(log_hydrogen_concentration):\n",
+    "            hydrogen = 10.0 ** log_hydrogen_concentration\n",
+    "            bicarbonate = first_dissociation_constant * dissolved_co2 / hydrogen\n",
+    "            carbonate = (\n",
+    "                first_dissociation_constant\n",
+    "                * second_dissociation_constant\n",
+    "                * dissolved_co2\n",
+    "                / hydrogen**2\n",
+    "            )\n",
+    "            hydroxide = water_ion_product / hydrogen\n",
+    "            calculated_alkalinity = bicarbonate + 2.0 * carbonate + hydroxide - hydrogen\n",
+    "            return calculated_alkalinity - self.alkalinity_mol_per_litre\n",
+    "\n",
+    "        log_hydrogen = brentq(charge_balance, -14.0, 0.0)\n",
+    "        hydrogen = 10.0**log_hydrogen\n",
+    "        bicarbonate = first_dissociation_constant * dissolved_co2 / hydrogen\n",
+    "        carbonate = (\n",
+    "            first_dissociation_constant\n",
+    "            * second_dissociation_constant\n",
+    "            * dissolved_co2\n",
+    "            / hydrogen**2\n",
+    "        )\n",
+    "        saturation_ratio = (\n",
+    "            self.calcium_mol_per_litre\n",
+    "            * carbonate\n",
+    "            / calcite_solubility_product\n",
+    "        )\n",
+    "\n",
+    "        return {\n",
+    "            \"pH\": -math.log10(hydrogen),\n",
+    "            \"dissolved CO2 [mol/L]\": dissolved_co2,\n",
+    "            \"bicarbonate [mol/L]\": bicarbonate,\n",
+    "            \"carbonate [mol/L]\": carbonate,\n",
+    "            \"calcite saturation index [-]\": math.log10(saturation_ratio),\n",
+    "        }\n",
+    "\n",
+    "    @JOverride\n",
+    "    def run(self, calculation_id):\n",
+    "        fluid_system = self.input_stream.getThermoSystem()\n",
+    "        gas_phase = fluid_system.getPhase(0)\n",
+    "        co2_component = gas_phase.getComponent(\"CO2\")\n",
+    "        co2_fugacity_bara = (\n",
+    "            co2_component.getFugacityCoefficient()\n",
+    "            * co2_component.getx()\n",
+    "            * self.input_stream.getPressure(\"bara\")\n",
+    "        )\n",
+    "        self.results = self.calculate_carbonate_equilibrium(co2_fugacity_bara)\n",
+    "        self.results[\"CO2 fugacity [bara]\"] = co2_fugacity_bara\n",
+    "        self.results[\"temperature [degC]\"] = self.input_stream.getTemperature(\"C\")\n",
+    "        self.results[\"pressure [bara]\"] = self.input_stream.getPressure(\"bara\")\n",
+    "\n",
+    "    @JOverride\n",
+    "    def toJson(self):\n",
+    "        return json.dumps({\"name\": self.getName(), **self.results})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e81cc93f",
+   "metadata": {
+    "id": "D5qdzKGdjxde"
+   },
+   "source": [
+    "The wrapper reads NeqSim's gas-phase CO2 fugacity coefficient and mole fraction, solves the\n",
+    "screening aqueous model, and exposes a JSON-compatible result. The class deliberately retains\n",
+    "the historical `ReaktoroUnitOperation` name so existing readers can recognize the integration\n",
+    "pattern. A positive calcite saturation index indicates supersaturation under the stated ideal\n",
+    "screening assumptions; it does not prove that precipitation kinetics are fast."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "f1767a5f",
+   "metadata": {
+    "id": "0_0qWw3EkAHe"
+   },
+   "outputs": [],
+   "source": [
+    "carbonate_feed_fluid = fluid(\"srk\")\n",
+    "carbonate_feed_fluid.setTemperature(30.0, \"C\")\n",
+    "carbonate_feed_fluid.setPressure(100.0, \"bara\")\n",
+    "carbonate_feed_fluid.addComponent(\"methane\", 0.9)\n",
+    "carbonate_feed_fluid.addComponent(\"CO2\", 0.1)\n",
+    "carbonate_feed_fluid.setMixingRule(\"classic\")\n",
+    "\n",
+    "carbonate_feed = jneqsim.process.equipment.stream.Stream(\n",
+    "    \"carbonate chemistry feed\",\n",
+    "    carbonate_feed_fluid,\n",
+    ")\n",
+    "carbonate_feed.setFlowRate(30_000.0, \"kg/hr\")\n",
+    "\n",
+    "carbonate_unit = ReaktoroUnitOperation()\n",
+    "carbonate_unit.setName(\"Carbonate chemistry screening\")\n",
+    "carbonate_unit.setInputStream(carbonate_feed)\n",
+    "\n",
+    "carbonate_process = jneqsim.process.processmodel.ProcessSystem()\n",
+    "carbonate_process.add(carbonate_feed)\n",
+    "carbonate_process.add(carbonate_unit)\n",
+    "carbonate_process.run()\n",
+    "\n",
+    "assert 3.0 < carbonate_unit.results[\"pH\"] < 9.0\n",
+    "assert math.isfinite(carbonate_unit.results[\"calcite saturation index [-]\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "cd6998e5",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "WcuaEZXlkrtc",
+    "outputId": "b5971961-a1ee-421b-fdc7-98b6680b60a6"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Out[0]: \n",
+      "                                    pH  ...  pressure [bara]\n",
+      "name                                    ...                 \n",
+      "Carbonate chemistry screening  5.69453  ...            100.0\n",
+      "\n",
+      "[1 rows x 8 columns]\n"
+     ]
+    }
+   ],
+   "source": [
+    "carbonate_results = pd.DataFrame([json.loads(carbonate_unit.toJson())]).set_index(\"name\")\n",
+    "carbonate_results.round(5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "70ca3f56",
+   "metadata": {
+    "id": "slLtdQV5IGZ8"
+   },
+   "source": [
+    "## 2. CoolProp as an independent pure-fluid property check\n",
+    "\n",
+    "[CoolProp](https://coolprop.org/) provides high-accuracy pure-fluid and mixture property\n",
+    "models. Here it is used as an independent density comparison for pure CO2. Different equations\n",
+    "of state and reference conventions can produce real differences, especially near saturation\n",
+    "and the critical region, so agreement is a diagnostic rather than an identity requirement."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "bba9f6f8",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "iyd2CbqYINU4",
+    "outputId": "21c1e26c-0d07-4053-8896-09c5c60d08e7"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CoolProp 8.0.0 is ready for the pure-CO2 cross-check.\n"
+     ]
+    }
+   ],
+   "source": [
+    "from CoolProp.CoolProp import PropsSI\n",
+    "\n",
+    "print(f\"CoolProp {CoolProp.__version__} is ready for the pure-CO2 cross-check.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "7ef1274b",
+   "metadata": {
+    "id": "7TXXC6ehL18r"
+   },
+   "outputs": [],
+   "source": [
+    "class CoolPropUnitOperation(unitop):\n",
+    "    \"\"\"Compare pure-CO2 density from CoolProp and the attached NeqSim stream.\"\"\"\n",
+    "\n",
+    "    def __init__(self):\n",
+    "        super().__init__()\n",
+    "        self.input_stream = None\n",
+    "        self.results = {}\n",
+    "\n",
+    "    def setInputStream(self, stream):\n",
+    "        self.input_stream = stream\n",
+    "\n",
+    "    @JOverride\n",
+    "    def run(self, calculation_id):\n",
+    "        temperature_kelvin = self.input_stream.getTemperature(\"K\")\n",
+    "        pressure_pascal = self.input_stream.getPressure(\"Pa\")\n",
+    "        coolprop_density = PropsSI(\n",
+    "            \"Dmass\",\n",
+    "            \"T\",\n",
+    "            temperature_kelvin,\n",
+    "            \"P\",\n",
+    "            pressure_pascal,\n",
+    "            \"CO2\",\n",
+    "        )\n",
+    "\n",
+    "        fluid_system = self.input_stream.getThermoSystem()\n",
+    "        fluid_system.initPhysicalProperties(\"density\")\n",
+    "        neqsim_density = fluid_system.getPhase(0).getDensity(\"kg/m3\")\n",
+    "        relative_difference = (neqsim_density - coolprop_density) / coolprop_density\n",
+    "\n",
+    "        self.results = {\n",
+    "            \"temperature [degC]\": self.input_stream.getTemperature(\"C\"),\n",
+    "            \"pressure [bara]\": self.input_stream.getPressure(\"bara\"),\n",
+    "            \"CoolProp density [kg/m3]\": coolprop_density,\n",
+    "            \"NeqSim density [kg/m3]\": neqsim_density,\n",
+    "            \"relative density difference [-]\": relative_difference,\n",
+    "        }\n",
+    "\n",
+    "    @JOverride\n",
+    "    def toJson(self):\n",
+    "        return json.dumps({\"name\": self.getName(), **self.results})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "e920b69f",
+   "metadata": {
+    "id": "LrO_jcP-Rqs9"
+   },
+   "outputs": [],
+   "source": [
+    "coolprop_feed_fluid = fluid(\"srk\")\n",
+    "coolprop_feed_fluid.setTemperature(14.3, \"C\")\n",
+    "coolprop_feed_fluid.setPressure(55.0, \"bara\")\n",
+    "coolprop_feed_fluid.addComponent(\"CO2\", 1.0)\n",
+    "coolprop_feed_fluid.setMixingRule(\"classic\")\n",
+    "\n",
+    "coolprop_feed = jneqsim.process.equipment.stream.Stream(\n",
+    "    \"pure CO2 feed\",\n",
+    "    coolprop_feed_fluid,\n",
+    ")\n",
+    "coolprop_feed.setFlowRate(30_000.0, \"kg/hr\")\n",
+    "\n",
+    "coolprop_unit = CoolPropUnitOperation()\n",
+    "coolprop_unit.setName(\"CoolProp density check\")\n",
+    "coolprop_unit.setInputStream(coolprop_feed)\n",
+    "\n",
+    "coolprop_process = jneqsim.process.processmodel.ProcessSystem()\n",
+    "coolprop_process.add(coolprop_feed)\n",
+    "coolprop_process.add(coolprop_unit)\n",
+    "coolprop_process.run()\n",
+    "\n",
+    "assert coolprop_unit.results[\"CoolProp density [kg/m3]\"] > 0.0\n",
+    "assert coolprop_unit.results[\"NeqSim density [kg/m3]\"] > 0.0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "c4d50af6",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "c3Pxx5CnR0_7",
+    "outputId": "d857fc32-529e-4ead-ab77-4212056986ab"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Out[0]: \n",
+      "                        temperature [degC]  ...  relative density difference [-]\n",
+      "name                                        ...                                 \n",
+      "CoolProp density check                14.3  ...                         -0.11262\n",
+      "\n",
+      "[1 rows x 5 columns]\n"
+     ]
+    }
+   ],
+   "source": [
+    "coolprop_results = pd.DataFrame([json.loads(coolprop_unit.toJson())]).set_index(\"name\")\n",
+    "coolprop_results.round(5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e559ecd4",
+   "metadata": {
+    "id": "I3Z_pMYGU178"
+   },
+   "source": [
+    "## 3. ThermoPack SAFT-VR Mie as a mixture-property check\n",
+    "\n",
+    "[ThermoPack](https://thermotools.github.io/thermopack/) exposes several independent equations\n",
+    "of state. The retained example evaluates the molar volume of a CO2-rich methane mixture with\n",
+    "SAFT-VR Mie, converts it to density, and compares it with NeqSim SRK at the same state and\n",
+    "overall composition."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "242bd9fc",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "uHa-E5j3U9rf",
+    "outputId": "f1cdb0cb-d1c9-48b1-e16c-80a23c290a81"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ThermoPack 2.2.3 is ready for the SAFT-VR Mie comparison.\n"
+     ]
+    }
+   ],
+   "source": [
+    "from thermopack.saftvrmie import saftvrmie\n",
+    "\n",
+    "print(\n",
+    "    \"ThermoPack \"\n",
+    "    f\"{importlib.metadata.version('thermopack')} is ready for the SAFT-VR Mie comparison.\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "620c74c2",
+   "metadata": {
+    "id": "E78B61YsYKGG"
+   },
+   "outputs": [],
+   "source": [
+    "class ThermoPackUnitOperation(unitop):\n",
+    "    \"\"\"Compare SAFT-VR Mie and NeqSim densities for a CO2-rich mixture.\"\"\"\n",
+    "\n",
+    "    def __init__(self):\n",
+    "        super().__init__()\n",
+    "        self.input_stream = None\n",
+    "        self.results = {}\n",
+    "\n",
+    "    def setInputStream(self, stream):\n",
+    "        self.input_stream = stream\n",
+    "\n",
+    "    @JOverride\n",
+    "    def run(self, calculation_id):\n",
+    "        fluid_system = self.input_stream.getThermoSystem()\n",
+    "        composition = [float(value) for value in fluid_system.getzvector()]\n",
+    "        thermopack_model = saftvrmie(\"C1,CO2\")\n",
+    "\n",
+    "        phase_type = str(fluid_system.getPhase(0).getType()).lower()\n",
+    "        phase_flag = thermopack_model.VAPPH\n",
+    "        if \"liquid\" in phase_type:\n",
+    "            phase_flag = thermopack_model.LIQPH\n",
+    "\n",
+    "        molar_volume, = thermopack_model.specific_volume(\n",
+    "            self.input_stream.getTemperature(\"K\"),\n",
+    "            self.input_stream.getPressure(\"Pa\"),\n",
+    "            composition,\n",
+    "            phase_flag,\n",
+    "        )\n",
+    "        molar_mass = fluid_system.getPhase(0).getMolarMass(\"kg/mol\")\n",
+    "        thermopack_density = molar_mass / molar_volume\n",
+    "\n",
+    "        fluid_system.initPhysicalProperties(\"density\")\n",
+    "        neqsim_density = fluid_system.getPhase(0).getDensity(\"kg/m3\")\n",
+    "\n",
+    "        self.results = {\n",
+    "            \"temperature [degC]\": self.input_stream.getTemperature(\"C\"),\n",
+    "            \"pressure [bara]\": self.input_stream.getPressure(\"bara\"),\n",
+    "            \"ThermoPack density [kg/m3]\": thermopack_density,\n",
+    "            \"NeqSim density [kg/m3]\": neqsim_density,\n",
+    "            \"relative density difference [-]\": (\n",
+    "                (neqsim_density - thermopack_density) / thermopack_density\n",
+    "            ),\n",
+    "        }\n",
+    "\n",
+    "    @JOverride\n",
+    "    def toJson(self):\n",
+    "        return json.dumps({\"name\": self.getName(), **self.results})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "0dda1495",
+   "metadata": {
+    "id": "rfniROMzZVT4"
+   },
+   "outputs": [],
+   "source": [
+    "thermopack_feed_fluid = fluid(\"srk\")\n",
+    "thermopack_feed_fluid.setTemperature(14.3, \"C\")\n",
+    "thermopack_feed_fluid.setPressure(65.0, \"bara\")\n",
+    "thermopack_feed_fluid.addComponent(\"methane\", 0.01)\n",
+    "thermopack_feed_fluid.addComponent(\"CO2\", 0.99)\n",
+    "thermopack_feed_fluid.setMixingRule(\"classic\")\n",
+    "\n",
+    "thermopack_feed = jneqsim.process.equipment.stream.Stream(\n",
+    "    \"CO2-rich mixture feed\",\n",
+    "    thermopack_feed_fluid,\n",
+    ")\n",
+    "thermopack_feed.setFlowRate(30_000.0, \"kg/hr\")\n",
+    "\n",
+    "thermopack_unit = ThermoPackUnitOperation()\n",
+    "thermopack_unit.setName(\"ThermoPack density check\")\n",
+    "thermopack_unit.setInputStream(thermopack_feed)\n",
+    "\n",
+    "thermopack_process = jneqsim.process.processmodel.ProcessSystem()\n",
+    "thermopack_process.add(thermopack_feed)\n",
+    "thermopack_process.add(thermopack_unit)\n",
+    "thermopack_process.run()\n",
+    "\n",
+    "assert thermopack_unit.results[\"ThermoPack density [kg/m3]\"] > 0.0\n",
+    "assert thermopack_unit.results[\"NeqSim density [kg/m3]\"] > 0.0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "97c404d6",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "YgUwiNFAZccX",
+    "outputId": "f05b9255-54da-4a6a-fa34-c37450655ef8"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Out[0]: \n",
+      "                          temperature [degC]  ...  relative density difference [-]\n",
+      "name                                          ...                                 \n",
+      "ThermoPack density check                14.3  ...                         -0.12293\n",
+      "\n",
+      "[1 rows x 5 columns]\n"
+     ]
+    }
+   ],
+   "source": [
+    "thermopack_results = pd.DataFrame([json.loads(thermopack_unit.toJson())]).set_index(\"name\")\n",
+    "thermopack_results.round(5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0d475a7b",
+   "metadata": {
+    "id": "DYytzkhwehHN"
+   },
+   "source": [
+    "**Preserved visual provenance (verified 2 August 2026).** The embedded reactant/product flame sketch is retained from the original notebook and attributed by its existing link to Cantera's `flame_speed_with_convergence_analysis.ipynb`. It is a conceptual historical illustration, not a refreshed NeqSim result. The executable profile below is newly calculated with the installed Cantera version.\n",
+    "\n",
+    "**Use of Cantera as a unit operation in NeqSim process simulation**\n",
+    "\n",
+    "Cantera is an open-source collection of object-oriented software tools for problems involving chemical kinetics, thermodynamics, and transport processes.\n",
+    "\n",
+    "*   Evaluate thermodynamic and transport properties of mixtures\n",
+    "*   Evaluate species chemical production rates\n",
+    "*   Compute chemical equilibrium\n",
+    "*   Evaluate species chemical production rates\n",
+    "*   Conduct kinetics simulations with large reaction mechanisms\n",
+    "*   Simulate one-dimensional flames\n",
+    "*   Conduct reaction path analysis\n",
+    "*   Create process simulations using networks of stirred reactors\n",
+    "*   Model non-ideal fluids\n",
+    "\n",
+    "![image.png](data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAA0EAAAGACAYAAABr1mnhAAAgAElEQVR4AezdCZwcZZ3/8W9ARRFX1gOPFcUVXUVlRUQFBCdT7YHXH9EsZLJegFEJSbpaXW82632jiwiZeF9gFBWRSMhMV6WrUPAEMuN9IOuFnCoKKiT/+k366TxT09dkemb6+PB6Pa96uuupqud5d4Wq31TVr6Sd/10jaZtXrpTklysk+eVySX75viS/fE+SX74ryS/fkeSXb0vyy7ck+eUySX65VJJfvinJL9+Q5JdLJPklleSXRJJfKpL8slWSX2JJfokk+aUsyS/jkvwyJskvWyT55WJJftksyS8XSfLL1yX5ZZMkv1woyS9fk+SXCyT55auS/HK+JL98RZJfvizJL1+S5JfzJPnli5L88gVJftkoyS+fl+SXcyX55RxJfvmcJL98VpJfPiPJL5+W5JdPSfLLJyX55ROS/PJxSX75mCS/fFSSXz4iyS8bJPllVJJf1kvyy9mS/HKWJL98WJJfzpTklw9J8ssZkvzyv5L88kFJfvmAJL+cLskv75fkl/dJ8st7JfnlPZL88m5JfnmXJL+8U5Jf3iHJL2+X5Je3SfLLWyX55S2S/PJmSX75H0l+WZf9b9Mv/y3JL6dJ8subJPnljZL88gZJfnm9JL+8TpJfXivJL6+R5Jf/kuSXV0vyy6sk+eWVkvxSkuSXUJJfipL8slaSX9ZI8stqSX45VZJfVknyyymS/PIKSX55uSS/vEySX1ZK8stLJfnlZEl+OUmSX06U5JeXSPLLiyX55UWS/PJCSX55gSS//Kckv6yQ5JcRSX5ZLskvJ0jyy/GS/PIfkvyyTJJfni/JL8/Ljv1+OS47/vvludnx3y/HZsd/v/y/7Pjvl+dkx3+/PDs7/vvlWdnx3y/PzI7/fnlGdvz3yzHZ8d8vT8+O/355Wnb898tTs+O/X56SHf/9UsiO/34JsuO/X4az479flmbHf78MZcd/vzw5O/775ejs+O+Xo7Ljv1+elB3//XJkdvz3yxHZ8d8vh2fHf788MTv+++UJ2fHfL4/Pjv9+OSw7/vvlcdnx3y+HZsd/vzw2O/775ZDs+O+Xx2THf7/8e3b898vB2fHfL4/Ojv9+eVR2/PfLI7Pjv18Oyo7/fnlEdvz3y8Oz479f/i07/vvlYdnx3y8PzY7/fjkwO/775SHZ8d8v/5od//3y4Oz475cDsuO/Xx6UHf/98sDs+O+X/bPjv18ekB3//fIv2fHfL/fPjv9+uV92/PfLfbPjv1/ukx3//bJfdvz3y72z479f7pUd//1yz+z475d7ZMd/v/xzdvz3y77Z8d8vd8+O/375p+z475e7Zcd/v+yTHf/9ctfs+O+XvbPjv1/ukh3//XLn7Hi/VzV26dhkR3YQp2DAPsA+wD7APsA+wD7APsA+wD7APtCt+4BdtOnof906UPrFP0L2AfYB9gH2AfYB9gH2AfYB9gH2AdsH7E61jv7HjsWOxT7APsA+wD7APsA+wD7APsA+wD7QzfsAQRC373H7IvsA+wD7APsA+wD7APsA+wD7wEDtAwRB7PADtcN3818k6Bt/MWMfYB9gH2AfYB9gH2AfWJh9oONBkJ+pw+p+Jg+r+5k+rO5nArG6nynE6n4mEav7mUas7mcisbqfqcTqfiYTq/uZTqzuZ0Kxup8pxep+JhWr+5lWrO5nYrG6n6nF6n4mF6v7mV6s7meCsbqfKcbqfiYZq/uZZqzuZ6Kxup+pxup+Jhur+5lurO5nwrG6nynH6n4mHav7mXas7mfisbqfqcfqfiYfq/uZfqzuZwKyup8pyOp+JiGr+5mGrO5nIrK6n6nI6n4mI6v7mY6s7mdCsrqfKcnqfiYlq/uZlqzuZ2Kyup+pyep+Jier+5merO5ngrK6nynK6n4mKav7maas7meisrqfqcrqfiYrq/uZrqzuZ8Kyup8py+p+Ji2r+5m2rO5n4rK6n6nL6n4mL6v7mb6s7mcCs7qfKczqfiYxq/uZxqzuZyKzup+pzOp+JjOr+5nOrO5nQrO6nynN6n4mNav7mdas7mdis7qfqc3qfiY3q/uZ3qzuZ4Kzup8pzup+Jjmr+5nmrO5norO6n6nO6n4mO6v7me6s7mfCs7qfKc/qfiY9q/uZ9qzuZ+Kzup+pz+p+Jj+r+5n+rO5nArS6nynQ6n4mQav7mQat7mcitLqfqdDqfiZDq/uZDq3uZ0K0up8p0ep+JkWr+5kWre5nYrS6n6nR6n4mR6v7mR6t7meCtLqfKdLqfiZJq/uZJq3uZ6K0up+p0up+Jkur+5kure5nwrS6nynT6n4mTav7mTat7mfitLqfqdPqfiZPq/uZPq3uZwK1up8p1Op+JlGr+5lGre5nIrW6n6nU6n4mU6v7mU6t7mdCtbqfKdXqfiZVq/uZVq3uZ2K1up+p1ep+Jler+5lere5ngrW6nynW6n4mWav7mWat7meitbqfqdbqfiZbq/uZbq3uZ8K1up8p1+p+Jl2r+5l2re5n4rW6n6nX6n4mX6v7mX6t7mcCtrqfKdjqfiZhq9sJq1/8TMRWn8iVyewcwC8/yM4B/PLD7BzALz/KzgH88uPsHMAvP8nOAfzy0+wcwC8/y84B/PLz7BzAL7/IzgH88svsHMAvV2XnAH75VXYO4Jers3MAv/xfdg7gl19n5wB++U12DuCX32bnAH75XXYO4JffZ+cAfrFsz375Q3YO4Jdrs3MAv1yXnQP45frsHMAvN2TnAH65MTsH8MtN2TmAX/6YnQP45U/ZOYBf/pydA/jl5uwcwC9/yc4B/PLX7BzAL7dU9+mOPhPEyhBAAAEEEEAAAQQQQAABBBBAAAEEBkmgUEp3tFMGyYSxIoAAAggggAACCCCAQB8LtBMAWZs+JmBoCCCAAAIIIIAAAgggMEgCBEGD9GszVgQQQAABBBBAAAEEEBBBEDsBAggggAACCCCAAAIIDJQAQdBA/dwMFgEEEEAAAQQQQAABBAiC2AcQQAABBBBAAAEEEEBgoAQIggbq52awCCCAAAIIIIAAAgggQBDEPoAAAggggAACCCCAAAIDJUAQNFA/N4NFAAEEEEAAAQQQQAABgiD2AQQQQAABBBBAAAEEEBgoAYKggfq5GSwCCCCAAAIIIIAAAggQBLEPIIAAAggggAACCCCAwEAJEAQN1M/NYBFAAAEEEEAAAQQQQIAgiH0AAQQQQAABBBBAAAEEBkqAIGigfu6BHexGac+ydGg7ZYt0yJh00GbpwRuluwwCWiQ9xtmMSfcchDEzRgQQQAABBBAYYAGCoAH+8Qdo6F+T/jmWduxOiaSfRdJ/R9IB/UoWSzc4m0g6qZfHuVnazwK6Xh4DfUcAAQQQQACBeRYgCJpnYFbfFQJzCYJccBBL2yPpgn68OtQPQdA6aY9IWhVJN0ZSsSt2PDqBAAIIIIAAAt0pQBDUnb8LveqsQIeCoKkrSZF0bmd7t/hr64cgKJbGXcBKELT4+xQ9QAABBBBAoKsFCIK6+uehcx0SyAdBkfROu3JQr9jzQ3a1x56NiaTHlaX3R9It7gS7On1Th7rWFavpkyDoV+43Igjqit2KTiDQ3QJL1ySHzqYMrYkeVViTPLCwcsvdJS3p7tHROwQQaCVAENRKiPn9IFAnCHrHbMYVSYVIutU7yf5HJN1rNuvo5rYEQd3869A3BBDovMCyjXu2ewJUr11QSv9UKCUXDRfTVx268oK9O9/B/lnjES/fvJ8Fm/0zIqkfx9RPv0+7Y6n3b7ved+2uj3YIdKPAXIMgG1MsfdAFQTYtSyu7cay70yeCoN1RYxkEEOhdgTkGQdNOlMLkV4U1yZN6F2O+er5uj6CYrArC5MbhUtonD2r245jm6/fv/vVO+3dcSnc0+tz9I6GHCDQW6EQQNC491g+CLChqvMXpc2z7s02oYLfljUv/YrfsTV/b7n1qtr5uC4LMaov0wPXSHdsdbSzN6Xa4TdK9I2nfdrdHOwQQ6GWBXBAUlJJrgzD5brNSKKU/LITpX+qfKCU3BKuSh/UySaf7HoTpuLPqlyCoH8fU6d+9l9bn9s9W014aE31FIC/QiSBoi3T3XBD0eX87kfTi7Bmir1mJpWU2z6aRlMTS7dXsctssBXUk3cFf1tXHpKNi6fORtC2W/lbd3l9i6VuR9JEx6SmubTvT86W7RdKrYukHsfR3W59lT4ulC2Pp1ZukvWw9rYIgu+rlxhZJ72ln25ZAwi0zLh3Tapmy9ORY+mwk/d45R9JtsfSLSDqnLD0yv46ydKTbRu65rUnv+9Pzy9ln2yfK0utj6Xux9Ee3zVj6bSSNlaX/jaShesvyHQII9LpALggqlNIPtzuko1ZX7l0Ik9cWwvT66SdPSdLuOgahXcGukFX/ut4vQVA/jmkQ9sVGY3T7Z6tpo+X5HoFeEOhEEBRJB3onyhZMvNcfuyVb8Oa/LpJOsMDH+869p+gGF3y45TdL+1vQUKetW8afrrfgxi3baFoNqK5vts7sWafUEkC0CoJytwJe0mib/ve5db7Mn+fXqwkotjTrZ3Xe7RYI+gFkJD2/1XKR9G1/e1a3oCyS/txq2er8r26W7ppfB58RQKCXBeYQBLlhH33K1v3zgVC/Pfvixro7034MGPpxTLvz2/bLMq2CHze/X8bLOAZToBNBUFk6zj9ptis/vmYuCPpg9YqLH7xM1cvStD84jkn3yd5vc21u3XYF5IpY2hhLV1aviNTWFUm/HJMa3nlRPcnPZ7SzF6JuslTSuQDgJ7H0V7f9ei9Lna8gaLP04MzxKrft6vTvkfT9LOj8TLWvN/vzI+ks516WnhlJv64WM5syyrLD3eS+tzG79ja1F6lmV8dq66zaXmLWZelTsbTVT4Jh64ykL/jroI4AAr0u0IEgyAiGi5UXuxMlmwZh+j+9TtOp/vdjwNCPY+rU792L6/H/7Tar9+LY6DMCTmCuQZA9mxJL33Un2Ta1k2m3fpvmgiD/VrbPl6UTI+kMu7WrLD3BXy6Wzs+t92PZVaZ9/DabpH+KpE/77eKp83m/1c569Ra433lt/1ZN4lDL6GrPB9ntcNXb9GrBlS2zkEFQJE27AlSWPmdj9Ud1kXQ/e0mtNx7r7wv8NlZv95mgWLKAx435G+PSg/Lryq44PSCWLnbtLFCyfuTb8RkBBHpVoFNB0KrxB/knT0GYfnqWJEuOPPXi+2vZxj1nuVzT5kOnRPcdDsf/pVOZ6w4PN97F0oMfunJ92w9qdipg6PRYDM7GYVfyDly9aeqe8KaY3sy5jslupRwqRjx86pkuZtX/t9usvph9ZNsIzFVgLkFQ9STcrkq4E2cLFKJ8n3JBkLXdbs+55Nv5n7MrOi/KrXetPz9fz557eU2u/Yo6bfzb8ixYC/Jt3OdIOtZfn9UXKgiKpeX+tiPpLa5f+Wlme+fqsztTv4Hdxpdv004QdIG0t3s2qjrWA/LrcZ8tmLTng7w+vtrNY4oAAr0u0KEgKFg1ds9pJ09hcl4rmqEwelwhrJwRhGmlEKZ/tOWDUnJLIUy/HZTSDUEpXtpqHf5864Ol6g6KySeDMLmsUEpu8vsUhOnvC2Hy+aVrK0/zl2tVXxpWnlwIk89OLe8yZ4XJbYVS8osgTM5ZGqYzHtRcWqwcWQjTr1mZGlN1uaCUTLrvC8VK3Qc1rT+dGstwMVnutheUKv9p67ZAbsopTK4IwnT7lHuY/j0Ik8sLYfIx+13qmcxlTE96RfLPQVh5fVBKv+d+66nfJkx+WyglY8Ol9H8LxYSHT+vBL8B3/r+TZvUF6AqbQGDeBOoEQfbQvr37Z0YpS08rSy+0h+Yj6RO5B+7tJPxv2fM7D893Nh8E2YP1+Tb+Z3u2xW7b8k6yv9fq/XuWKc5uj3PLWBKBXNa5JbF0jZufvxXM376rWxIAr/2CBUGRdJHbbiT9LjcO173aNBewbc9+m2kBTDtB0Jh0mNumBal2K2JtA3UqkfQGu1JXfWHusXWa8BUCCPSkQKeCoOLWFf7JU1CqvLmhx7KNewbF9E1BKfmHv0y+bifoQSl5XztXKSzhQBAmf86vo9HnIEy+evALNjd9yNECkSBMtjRah/f97UGYfGRoKKpl+gmKled78+unHA7TGQ9qmlknxxKEldNcP+w3CVZXDiqEyQ/cdw2mfysUK6vzv9/ujmm4mB7T7m/Tzu+S7xef5y7QYD+Ysd/OfUusAYHFE8gHQd6JcO3qTpvf2dWdUr2R1AmCGl6BseXL0r/52yxLz6i33vx349Kz/eWyLGi1P17lTvJ3jEtH55fPfx6TlubWd1K+TaefCapeZXG3DNrVqrqmfj/slsSy9Ga7FW5cenw+aGonCLJlckHtZ0l64CtTR2BQBDoTBC2ZutrgrpLYFZ1i5fn1CHdeEUi/Me2kK0xutZTc1ast3/CvnFi7IEyusJdy1luffTdcTP572vqqywSl5ILqOiuFUnpNvs1wmDS87H70qVsfHJTSq/xlgjD9eyFMvx+U0s/sTBGd3OzPL4Rp7UHNQrHyzCBMf22lMHXVyL17JbnJfR+EybQHNedjLNODoHRDoZRcXevzzn79sBAmP6l9N+03TFb55rszJkuQUSh5TmFyW1BKLimUko2FMPlUUEq3ZhkGb/W3H4QJD5/68AtQ9/2b1RegK2wCgXkT6EQQFEk/G5ee26iT+SDI3nPTqK19n7+ykc8Y12jZ6i1dteAtkmq3xFXTYbt529tcp109qgUkC3E7nF2B8wOvMenwRuNt9/t2giBbl/+sT7UPvypL77ZgcKN0p3a3RzsEEOhlgTkGQYeHF90jCJOv+ydOQZj+qNHVm6nbnrwT7UIp+ZxdcfEJ7TmVIEzf5m7VsnXb7XF+G1cfWhM9yr+iFJTSb9l3bn5tumzjnsOlyksLpeSGWl/D9PpGV4NmXgFKPveE1ZumPah5VLFyv6lAyxvPcDGZ8aBmu8/PzMdYpgVB1Vvf7Ha07MWta/3faGh19IAgTN5Zs5kyT37c6LaMdse0M+DZGQAGYfqN4VXjMx4+ndp2Kbm4tu0wuc1sa78dlXkXqNl7+3K97+a9I2wAgXkUyAdBlv2rmkHMsojli71H5+os/fJE9Zatt41LT230/0TXbT8IsqsNrV5ymgUer/MCgd+69bQzzb1Lp/ZHPbtty1vnH9pZl7WxbHNuuYUIguxqjtueTe2lsO32tVG7doMgC7hiqW7qcMuaF0lfyW7Pe5mlLW+0Lb5HAIFeF5gRBCUbh4uVxzYqwdr4sKVrKkGwduvxQZi8d9qVhakrMOn24bVb6156t2dn/KsiQTF9ezO+IKyc4J2I3W59yre329Bcm6kXva4da3pvbz6L3XCYzPiL3tRzNN7JYLMrRkMvju489ZyLax8mMx7UbDtgmIex+EGQOU0FjOHWR+cd3WcLNp3n1LTBczrtjMmSUUxdPavaDBWjafduu23a9MgTz79bYer5oOoVs7DCw6c+0DzXp/3mbl+uM53nbrB6BOZVoE4Q9I5ObzAXBP2w1fqr6ZjdVZtvtGrvz4+kb3pBxEY3r5pW2q3TnjFq679Yqrj1LUQQlAUbr3Tbs0QFrQLGdgbRbhBk67L04lkg9nOvD87Mn9pzR2m9THTt9Ic2CCDQzQIzgiB329ZuTMP0eguOGg3Xv7pit7gdtGxjy0vO/m12lkAht+4lU7eb1U7WKi3fYD10SrSPf8IXhMkpuXWqUEoucm2CUvI7SySQb+N/DoqVY2vtw3R7/mS/nYDB/ro4H2OZEQSFyQf8vufrdtuhG4tNh8P01Hwb+9zOmCxgduuaer6rZYCavKFQSs8fDtP3m2m97fLd/Ai436nVdH62zloRWBiBhQ6CLJNZq5HF0pe8k/DxVu39+dWT86kTdv8dNtX3CrkT+bYDq0j6sutLp4Ig/z1JdmUl1//Xuu1lqbr/4s/b3fpsgiDbhqUht3c9Vd9F9A+vP87Pn34yC3LvvLt9YzkEEOg2gY4EQcnNQSk9t9ktTHYrmX+CFRSnP2/SiCUfYMxIdb1s454WdNjVqWbb99cfhOl1tb6EldCfN3VFopT+zc0PiknLBzWnbt8rVd5st8INh5XH54OmdgKGqT50eCy2znwQVGhyFcg55LLgvdF970/bGZM5THu+K0w+2+j2Q3/d1BdewO3vraYL3zO2iEDnBLoxCLLnUNyJtz1vNJvRZoHK/7ll/ZevVt9F5IKjX7e7zki61K2vjSCoreAq95zRy/2+xNIytz2b2u/jz9+d+myDIH8b1fcwHWsvYvVvDfT7GElf95ehjgACvSyQC4LspHXqtrJScu3UNEyvm3YiW7vqYleKks9Z+uh2rujsfEB+19Wlere21WO0d9hMOzFr4yS+3nrsO3sPUTCVxc5/UH/6bVdBmBT87QXFeM4ParYTMDTqc6Pv2xmLLZsPgvLPNdVbf1BKfuwMGmX5a3dMgf+sj+07YfKrIEzfbenP29lv6vWP7zov4H7vVtPOb5k1IrBwAt0YBMXSS72T7LZvCau+uPV2t2z2wqJ1TtLServv7UWo1tbNazb134dTLwiKpA+49UbSd5qty+bZVRPX3qb5K0FbpEP8+WPSwa3WafMt2USjgGkuQVB+25YCPZbeFkt/cv20F6Y22nZ+eT4jgEC3C+SCoEIp/XC9Lttf8IMwfZElPXAnShYcDReTN7RzMpt7vmeH3doWhGm5neK2Z9OlxfS4ev3zv7OXmU4FM8XKK+xdPJaFzd7p46/H1YNi5b/8Ze1qjptnU3vRqj9/d+rtBgz11j2Xsdj6/CAoS4ZwY71t5L8rhOmVuwySt+bn2+d2x2RBZCFMr9+1vl2BsKXNDsL0K0EpfZkFu/W2w3cLI1Dv96n33cL0hq0gMD8C3RgERdKQO8G2aVma8d65ehrj0mNzy424dmPSU3Lz/t3NazStpqve7parFwT5V61i6QeN1uW+3yI92q3Pplkih2lXguzKiz+/LD3PLdtsml1Bmqyuz5JZFP227QZB9m4ge4mtOfrL16vns9jZFax67fgOAQR6TaDNIMgNy1Jc28tMp58gJfZA5hLXpt7U3gs0fZldJ8Oz+X64lLym3vrtJNreKWRXr2azvnwQlJ2Yv9Itbw/1S+v2qLe92XzXbsDg1tmpsdj6pgVBpalsb24zDaedDIKm+rAqeVgQJj93rvWmU5kAwyStl12vYUeZ0TGBer9Jve86tkFWhMAiCHRjELRZ2s+SArhgIJLOaYfGf5bIstxZQOGWsxew+pnP2llntg7/+Zy6L0stS6e5ftrVkY3Snm6b9abZcz6v9trPCIJsmex5nKu8Nlvrrcf/zjLIee13jElH+fNj6Rfe/Gm3u7t22RWec702Zfd9s6k9s+SWsZenNmvLPAQQ6BWBWQZBNqyhYrRvECaX+ydJ9q6eZkMOwuQDfvvdrVtGuvx2hovpq/w02XXWfXv1Fq8P73xx565ngvJBUPbOmtfWlg/TjjyoOZsgqJNjMadpQVCY/ihvV+9zp4Mg24YlpLDMfPZ+pRa/1Y6gmHzSsu7V6xvfzY9AbZ+fdrvrzD9UzM/WWSsCCyPQjUGQjTx3hcVexHpoM5EsZfcT3Ql5dXp+vr09I+S1ub3ZrWbVZ2Gu89rXDYLsXUR+Gwty8tt1n8elI2Lpr377/JUga1tNSlBLPmBXZ9w66k0jaYO3zmvyGeUspbmbb0FbvXWUpRe6NllA848x6aB67dx349JDXPvqlCtBDocpAj0tsBtBkI032PnX/T+7k6ed7/SpNLyUHZSSNbvaTt2W1fTKUbum+ZTXto2dL16tnGHvBVq6NnlC/mF8/11B+SBouJQsc/20qV35arcvjdq1GwR1eixTv1NYOc2Nx25lbNRH//v5CIL89dtzSVMJL8L0rOwWy1+6/vlTe/eUvwz1+RXw7ZvV57cXrB2B+RXo1iCoeivab92JtmVUs5eo1tOwW8Zi6Y+urV2hsGdX8m3HpHtG0rVeuz/UCzAi6QDLYue1cwkVTsqvs9rP2vMxFuSUpRm32o1Jh0XStKDK1l8vCLK7SCLp2972ry9Lz8hv29plV7dWe+1sfa/Nt8sld7h8i3T3fBv7zq6eeev68Wbpwfl29tnaxtIlrq2Na7N013pt+Q4BBHpNYDeDIBvmcLFy8rQTpjD9S6PsY0GYPN1ve/SpW+v+D2c2fFNXpErJP2rrDZM/NHpHkbfeJYVSertbJn97XWH11kPcPJsGayttPahpz+40CpjaCYLmYyw25m65EuT5z6gOnRo9fOrluKX0TzX7MLmtkeeMFfDFnAVq7lwJmrMlK+hegW4Ngkwskk6IpdozOdWT7s2x9D9laaQsvTmWLnYn4970JY3Eq9nX/OQJ/7BU2vYcTSSdHEkf8W6b+1urxAi2nVg609u2C5i2xdK7quu72ptvLyOt9blBEGRXwo60KzLecubw1SwJwRvNxW4/84Obaju7+jXjj6mx9FFvPRYo3VbNojftGaaydKLfrnpLoqXALpqb9TWSTvdTfFv7srSykTffI4BArwnMIQiyoRbCdPO0E6gw/baWbZxxn3AQJv86rV2p8VUjn/DA1Zv2sgDKTpTz6bGHw+TZ/jqDtcmz/GXr1YdXjT9o2jKl9HV+u3wq70Kb/QxKyeTO9SY3DZfSaQ9qthMEzcdYbFyLHQQFa8fuYxkE28kGmM/MZ1fl/N+G+vwJ+P8mmtXnrwesGYH5F+jmIMhGPy4N556Rqd0mljtht+9vKEvPaaU2Lj03km6ps7y/7r+OS8fE0oWuXb3ECLat6hWmr7t2TaY32PM6kfQh1yafHc7veyQ9Lgt4fuTaNptGUlTvCo+tr7qeP9dZfnv+Co4FbnXa+S5+/XYLyvw+U0cAgV4XmGsQtDMTW+22uKkTqNy7d6aIlm3c07KTuROsIEztHQMz/oqT57T3CbllbBqEce0hSEu17ObZcyb59/Pk12WfLUBxy0ytr5i+Kd8uKKVXuTZBKW35oKZlkHPtp9bp9SH9HOEAACAASURBVNHWPS0zXT2bqWBlnsYyX7fD+dn2Go2plJ7rXCwLYN653ueCXU2sXo2wzIP12vBd5wWceatp57fMGhFYOIFuD4JMwm45s/fUxNI1DU7Q7ba2d2+W2s6oac+8RNJncldb7ATfrhJd6W6TaycIqv5adgubJVKo3cLn9fXvkfTF7KrQA6xtu0GQtd0o3SWWPtho7BYglqX/qPah4aQsBX6WONe3epng7PmqSLrAtclP7ba5LLD6Wr1lG3aAGQgg0CMCcwyCbJSFYmX19JOn5GZ7gWlewH8uyNrb7XT5Nv7noZXRvYIw+T9v3dv8+fmMc61elhqsTZ+SJT641VufvetoRgro/LM5diXD326+HpTSDd46r8lnlAvCZMLNtysz+eXt83yNZb6uBLUzpiz4e2Ft3KXkH8HqStOHT4dXjz/EtbcpV4Lq7Snz853v3qw+P1tnrQggUE/A0jhbema7NassHWcJEzZKd6rXtp3vbH12tcneTVSWntboako763JtLpbub1ek7CpPWXrmJunebt5cptW+PtVuPxuXnloN+lr+4dTb5pKLpYdWb7V7lJ89z2tTq9oVLgt07FmssnRK9uLa/zR7C0prjagggECfCXQgCLKT/kKYXDr95Cm5aIaUbct/B02Y3GrZ0PJBgy13xMs37zcjFXcxOdFfp93+5m8zKCUf9ef7dbuC5F9lcMsFYfJBv121vmTatsP0+qWlrXUf1JwRAIbJjAc1fZuprHort8x4UHO+xjJfQVA7Yyqs3HJ3P+i0DH2NngWztkEpuWTX75Jel09oUed34qsOCTj3VtMObY7VIIAAAggggAACiyzQkSDIng3a+mh7r45/EhWUKv+ZH50lLpjRLky+a6mv7R0xQTFZaS9szQcsQZisz6/Lbn/zr0js3HaS2HbtJZ0W+Eyts5R82aVltum0d9aEyXn59drnpcXKkW4ZW69lvwvC5KuFMHmjvfjVbtXyA4HquOs+qGnBme+SreO2qStcYVJ7UHO+xjJfQVA7YzLHQjE50R+7/faWAttuS7QrPcNh5eXVF9rWbpWc8i4mPHxab8ecp+/836hZfZ42z2oRQAABBBBAAIEFFuhQEGS9tgxf/gmUvbjUbmnLj2ioGD0m/54hf7l8PQjTT9e7WmTrteCrUEpuzi9T77M962PB0XCYvMTND0rpnxo9SzQURo+ztNKubbNpECaRXc3Ij9U+71xPMv25qWpg5V/tmI+xzFcQ1O6YbPxBKXlXM7vcvNst0KznyHfzJ5D7DXY0+jx/PWDNCCCAAAIIIIDAQgp0MAiyF1wWwuQn/gnUzgBm5oAOXbn+jkGY/o+fOc1fzupBmGyxKzIzl57+zdDq6AGFMPnUzncV5V7wGCa3FUrpD+3Kgwt2ZiQyWLv1+Olr3PWpeoXmg4VSek2+f1N9LKVXLQ3Tlg9qLl1TCeqNNZ81rdNjma8gyITaHZO1HSqlTwxKyQX1DKe+s2e1wvRreY9dvwS1+RRo+LvkUmbPZx9YNwIIIIAAAgggMFACO1+eabevpScNF5Pl9oLTeleQWqFMJVKw2+DsdrgwfdHSNcmhLvBptWw78y3d83C49al2y55Njz5lq2XnmdWDmkev2fpQC+yG1kSPsnE32u58j6XRdnfj+yXtjsnWHawau6cFOvay1CBMTtn5WyWFI088n4dPdwO/U4sQBHVKkvUggAACCCCAAAIIIIBATwgQBPXEz0QnEUAAAQQQQAABBBBAoFMCBEGdkmQ9CCCAAAIIIIAAAggg0BMCBEE98TPRSQQQQAABBBBAAAEEEOiUAEFQpyRZDwIIIIAAAggggAACCPSEAEFQT/xMdBIBBBBAAAEEEEAAAQQ6JUAQ1ClJ1oMAAggggAACCCCAAAI9IUAQ1BM/E51EAAEEEEAAAQQQQACBTgkQBHVKkvUggAACCCCAAAIIIIBATwgQBPXEz0QnEUAAAQQQQAABBBBAoFMCBEGdkmQ9CCCAAAIIIIAAAggg0BMCBEE98TPRSQQQQAABBBBAAAEEEOiUAEFQpyRZDwIIIIAAAggggAACCPSEAEFQT/xMdBIBBBBAAAEEEEAAAQQ6JUAQ1ClJ1oMAAggggAACCCCAAAI9IUAQ1BM/E51EAAEEEEAAAQQQQACBTgkQBHVKkvUggAACCCCAAAIIIIBATwgQBPXEz0QnEUAAAQQQQAABBBBAoFMCBEGdkmQ9CCCAAAIIIIAAAggg0BMCBEE98TPRSQQQQAABBBBAAAEEEOiUAEFQpyRZDwIIIIAAAggggAACCPSEAEFQT/xMdBIBBBBAAAEEEFgwgSULtiU2hMAiCRAELRI8m0WguwQ43nXX70FvEEAAgYUTOGp15d6FMHltIUwuDcL094UwuS0Ik8uDMDlzaTE9buF6wpYQWDgBgqCFs2ZLCHSLwCbp3pH02ki6NJJ+H0m3RdLlsXRmWeJ41y0/FP1AAAEE5lsgKCarsgDo1qkTwjC9Migl7yoUK6cXwvSnu04Sk3Xz3Q/Wj8BCC+zav9MdzeoL3S+2hwAC8yMQSauyAOjWWNoRS1fG0rsi6fRI+mn1ux2RxPFufvhZKwIIINA9AkEp3bDr5C9Zp2Ub9/R7F5TSc9384VLyGn8edQR6XcDt262mvT5O+o8AAlIkbfADnY3StONdJJ3rzed4x06DAAII9KtAECavrJ38helZ9cZ5xMs371copbfvbJfcIIl7p+tB8V1PCtT2/xJXgnryB6TTCLQpEEmv9AKcuse7zdJ+sXR7tR3HuzZtaYYAAgj0lMDSMH2kPfdjJ4FBKb3q0JXr79hoAIVS+ht3sjgURgc2asf3CPSagNuvW017bVz0FwEEdgmUpUfacz8W3ETSVeulhse7WPqNFyxxvNvFSA0BBBDoD4EgTM5xJ37DYXpqs1EFpfRbtbbFZHmztsxDoJcE3H7datpLY6KvCCAwXSCSzvECm6bHu1j6lmsbSxzvplPyCQEEEOhtgaNP3fpg/xa3w8ONd2k2oqCUTLqTRJ4LaibFvF4TcPt1q2mvjYv+IoDAToHN0oP9W9w2Sk2Pd7E06YKgSOK5IHYkBBBAoJ8ECmEl3HXSl2xsNbaplNnVZyaCMH1Rq/bMR6BXBHb9O+CZoF75zegnArMRiKXQBTWx1PJ4ZymzXftImna8K0tHVrPJfSiSPm6JFOxWu9n0h7YIIIAAAosoEITpuDv5Gy5WTm7WFbtK5J4dsmWGw61PbdaeeQj0koD7d9Bq2ktjoq8IILBLIJbGvaCm6fHOrhK5Z4dsmXFp2vFuTFoaS+tjaXt1nbdH0r67tkYNAQQQQKBrBSyoCcL07+6kb3jV+IOadTYI46NcW5u2at9sXcxDoNsE/H27Wb3b+k1/EECgtYAFNbH0dxcEjUtNj3dj0lGubTUIqts+ln5u8yPp+617QQsEEEAAga4QGF679ehdJ3vJL1p1yp4Bcu2DMLm8VXvmI9BLAm7fbjXtpTHRVwQQ2CkwLh3tBTUtj3f2DJBrH0l1j3f2bqFY+ks1CPoA1ggggAACPSKQC2rOadXtQph8050gBmHltFbtmY9ALwm4fbvVtJfGRF8RQGCnQC6oaXm8i6RvuiCoLNU93kXSo1ybcem5WCOAAAII9IhAEKZfcSd8QZisbdbtYG3lYNe2ECa3DhWjA/z29jkIK58IwvTXhTBJl66tPM2f79eDMDkzCNMvBqXkff731BFYTIHa/s3LUhfzZ2DbCMyLQCR9xQUskdT0eDcmHey1vTWSph3vXAez9wi9tNpueyTdy74vS8+Lpa2xdE0kXUpw5LSYIoAAAl0kUCil19RO/IrJULOuFcLkU65tEKZv89tawJMFUTcGYfrXWptSepXfxtULK7fcPQjT7dYuKKUfd98zRWCxBdy+22q62P1k+wggMHsBC0q8wKbp8a4sfcq1jaVpxzt/y5YVztpF0sRG6U6x9MnqclO3yFXr2y2Jgr8cdQQQQACBRRQYXj3+EP9kb3jN1iMadWc4TJ7r2gal9KqDX7D5rq7tUCl9YqGU/q1QrJx+4OpNexVKyTrXdujU6OGunZsGa9OnuPlBmJ7kvmeKwGILuP2y1XSx+8n2EUBgdgLj0kO8oMYyvTU83tmVG9c2kq7aLNWOd/mtRtKPrG0knR1L51lyhHHpsdVnhV7hreeC/LJ8RgABBBBYJIHhYvIC/2QvCJO6D3UGYVIolJIbdrZNrh4KowOndXnZxj0tSHLfDZfSYm29a5IHuu/dNCimb3Lzg1XJw9z3TBFYbAG3X7aaLnY/2T4CCMxOIMvg9gIXkFSDlrrHu0gqxNIN1bZXR9L045232Yuke7h1RtJNsVS+QNrba6Lstrsb3br876kjgAACCCyiQKGUfjh/sheEyZaglL7OssYFxcrzgzBZXyilt1u7IEwmjj5164NbdbkQJh+rtr9R0pJ8+0KYXljd7jX5eXxGYDEF8v8eGn1ezD6ybQQQmL1AWfqwC1jcNJK2xNLrLGtcdjvb86vv/Lnd5tvtbZulpse7svRMb103RdID8j2rPhu0w1Jz5+fxGQEEEEBgkQQKYfp9d5IXFNO3WwDkvwi1Ni9Mf1QoJS/Uso17ttPVQin9oS0bhMnX67UPwvS66vwv1ZvPdwgsloDb51tNF6t/bBcBBHZPwG5TcwFLWXq7BUD+i1DdPLu9rSy90G5na7WlSHqrt9yp9drH0resTST9st58vkMAAQQQWGCBoVOifVzAE5SSWw5duf6O1oUnrN70T8HqykFBKV46FEaPO/LE8+82m64dtbpy79oJZJi8Nr/s0Wu2PnTX/EqYn89nBBZToLZvkh1uMX8Gto1ARwUiaR8X8GRpsm9ZL00d7zZJ/zQmHWRJCyLpcedLszrexdJ4NcCx7HH71ut0JF1bDZQurDef7xBAAAEEFlhguLh1uHbCFyZppza/tJge59ZrCRPy67U03G5+sDY+LD+fzwgspoDbN1tNF7OPbBsBBGYnMC4Ne1dsOnK8sytFkfTn6nrPq9cjC4y87b6nXhu+QwABBBBYYIHhYvKGXSd6lY79z9mSK+xcb3Lz0FB0h/ywgqlb69IdhVL9+fn2fEZgIQV2/ZuwfbRxWcg+sS0EEJibQCS9odPBSPbOocd46zy5Xg/L0krXZlx6dr02fIcAAgggsMACXnKCHXb1plObD0rpt+zkMSgl38mvMygmK2snlmES5+fzGYHFFqjtn00CIGuz2P1k+wgg0L5ALF3ogpGy1JHjXfbOoVr660bptmPpu9XtXtZ+b2mJAAIIIDCfAksKYXq9O+E7qli5X2c2tm6PqfcF7XwJ6rn+Ou05o0Ipuam23bByhps/tDKaesu2+8wUgcUScP8mWk0Xq39sFwEEZi2wJJaud0HQRVJHjneR9Gm3zs3S/vleRdKxbn4kNX0xa35ZPiOAAAIIzJOAvcC0dpIXJr/q1GbsRamWZMHWHYRJ7S9fQTE+PCgl1wal9GVBmP5y5/z03bbdYG3l4EIpvSYIKyd0qh+sB4HdFaj9u+BK0O4SshwCXSUQSQ93wUgsdex4F0k/c+stS4E/aHtZaiTdbPPL0qg/jzoCCCCAwCIKDIfJS9zJXlBKp12xmWu3gjD5UjXI2R6E6XgQJpFloRsuJa+xdQdhsmlqvgVFYXJOEKZ/DcLkCwct23inuW6b5RGYq4D7d9FqOtftsDwCCCyMQBb4vMQFK1lA1JHj3WZpP7fO6nR8THpKWTq0LL07kq6rBkCnLcwo2QoCCCCAQFsChTAZdSd5lq2trYXabLS0WDmyECbf3LX+9EfDYVJ7INTq7pa4bNs3DhfTV9V7oWqbm6MZAh0VcPttq2lHN8rKEEBg3gTsSowLWCKpI8e7svQcW2ckfTmSzoqlP3nbsIxxF3bq2aN5g2HFCCCAwGAKrNtj6sWnO19+umQ+DIaK0QFBmPxrvQDn8HDjXQqrtx5y6MoL9p6PbbNOBHZXoFXw4+bv7vpZDgEEFlZgnbSHpbOuvvy0I8c7W9eY9DA3kk3SXpF04BbpkOwFqjOyorp2TBFAAAEEEEAAga4UcEFOq2lXdp5OIYAAAggggAACCCCAAAKzFWgV/Lj5s10v7RFAAAEEEEAAAQQQQACBrhRwQU6raVd2nk4hgAACCCCAAAIIIIAAArMVaBX8uPmzXS/tEUAAAQQQQAABBBBAAIGuFHBBTqtpV3aeTiGAAAIIIIAAAggggAACsxVoFfy4+bNdL+0RQAABBBBAAAEEEEAAga4UcEFOq2lXdp5OIYAAAggggAACCCCAAAKzFWgV/Lj5s10v7RFAAAEEEEAAAQQQQACBrhRwQU6raVd2nk4hgAACCCCAAAIIIIAAArMVaBX8uPmzXS/tEUAAAQQQQAABBLpI4OhTtu5fKFWe16kirduji4ZHVxCYlYALclpNZ7VSGiOAQFcIbJb2L0vP61RZJ3G864pflk4ggAACuyEQhJXTWp3wtTs/KKVX7UYXWASBrhFod1/vmg7TEQQQaFugLJ0WSzs6USKJ413b8jREAAEEulAgCJOvuxO/oJTcUggrZwRhetLStVufYyUoJZNufiFML6x9X6w8Pwgrr59appTusDZBKT23C4dIlxBoW6C2r1f36Uaf214hDRFAoGsEIunrLgCKpFsi6YxIOqksPcdKLE26+bF0ofs+kp5fll5vy7j5kcTxrmt+WTqCAAIIzF5gSaGU3LDzRC+5qbAmeVJuFTb/JnciOFysnJybr6CYvt3ND8JkbX4+nxHoJQG3L7ea9tKY6CsCCEwJLImlGyyIiaSbImnG8c6+94KcGce7svR2bz7HO3YsBBBAoFcFji5ufYQ72RsuJi/Ij8Ofb+2G1kSPyrcJwuTptXWElcfn5/MZgV4ScPtyq2kvjYm+IoCAtEV6hAtgYmnG8S433wKlGce7SHq6W8e4xPGOHQsBBBDoVYFCMTnRTvaCMLms3hiGw+QltZPBMP1jvaQHS9ckh06to5TcctCyjXeqtx6+Q6BXBGr7O7fD9cpPRj8RaEugLJ1YDWDqHu9i6SUuwImlP9ZLelCWDrU2dlvcRonjXVvyNEIAAQS6UCAoJe8rhOn1w8X0mHrdC8JkvTspDMJkS702hXDro6tB0CX15vMdAr0k4Pb3VtNeGhN9RQABKZbeF0vXj0t1j3extN4FQdHUhaOZalukR1fbcLybycM3CCCAQP8IBGFyhTsZHA6Tt9Qb2dCLozsPhdHjjj5164Przec7BHpJwO3vraa9NCb6igACrQVi6QovCKp7vIukO0fS4zZLHO9ak9ICAQQQ6E2BoVOifQql9HZ3Mri0tPUZvTkSeo1A+wJuf281bX+NtEQAgW4XiKR9Yul2FwSVJY533f6j0T8EEEBgvgSCUrzUPxEMVo3dc762xXoR6BYBf59vVu+W/tIPBBCYu8CYtNQFQDYdkzjezZ2VNSCAAAK9KRCU0tfVTgLD5Ce9OQp6jcDsBGr7PIkRZgdHawR6WCCWXucFQRzvevi3pOsIIIDAnAUKpfR8d0IYFJNPznmFrACBHhBw+3yraQ8MhS4igECbArF0vhcEcbxr041mCCCAQF8KFErpNbUTwWLlFX05SAaFQE6gts9zJSgnw0cE+lcglq7xgiCOd/37UzMyBBBAoLmAZXqbdjK4eushzZdgLgL9ITBtv28SCPXHaBkFAghYpjcvANqxReJ4x26BAAIIDKrAcDFZvutkMLl5aCi6w6BaMO7BEti136c7mtUHS4XRItC/ArG03AVBkXRzJHG869+fm5EhgAACzQWCMPlg7QQwTOLmrZmLQP8I1Pb7JleBrE3/jJiRIDDYArH0QS8ImtXxriwdGUvviqQPRdLHI+ncsvTIwRZl9AgggEAPCwRhcpk7GQzC5J09PBS6jsCsBNx+32o6q5XSGAEEulYgli7zgqBZHe+qqbXXx9L26jpuj6R9u3awdAwBBBBAoLHAgas37VUopX9zJ4FBsXJs49bMQaC/BNx+32raX6NmNAgMpsAmaa8sPfbfvCBot453sfRzW0ckfX8wJRk1Aggg0AcCQTE+3D8BHDolum8fDIshINCWgL/vN6u3tTIaIYBAVwuMSYe7AKgaxMz6eLdR2jOW/lJd/gNdPWA6hwACCCDQWKAQVkJ38heE6S8bt2QOAv0n4Pb9VtP+GzkjQmDwBGIpdEFQJO3W8S6SHuXWMS49d/AUGTECCCDQJwKFMPm8OwEMwuScdoc1VIwOCMLKJ4Iw/XUhTNKlaytPa7RsECZnBmH6xaCUvK9RG75HYDEE3L7faroYfWObCCDQWYFY+rwLYCKp7eOd34tYeml1HduzBAn3snll6XmxtNXePxRJlxIc+WLUEUAAgS4VKJTS37gTwCBMXtlONy3gCcLkxiBM/1pbtpReVW/Zwsotdw/CdLu1C0rpx+u14TsEFkvA7b+tpovVP7aLAAKdE8gCmN94QVBbx7v81i0rnK0jkiY2SneKpU9W1zl1i5wLkCyJQn5ZPiOAAAIIdInA0rXlf5t28hdW/l+rrg2V0idOJVIoVk7fmVQhWefWMXRq9PD88sHa9ClufhCmJ+Xn8xmBxRRw+2ar6WL2kW0jgMDcBcrSv7kAyKZlqeXxrt5WI+lHtnwknR1L51lyhHHpsdVnhV7hthFJF9Rbnu8QQAABBLpAoFBK3uqf/FnA0rJbyzbuORwmtfugh0tpsbaONckD88sHxfRNbn6wKnlYfj6fEVhMAbdvtpouZh/ZNgIIzF0geynqW12AYtMxqfXxLrfZi6R7uHVE0k2xVL5A2ttvFkk3Vttc7X9PHQEEEECgOwSWDBe3DhdKyU3+yV9QSj46dEq0z2y6WAiTj9k67PY4SUvyyxbC9MLqNq7Jz+MzAost4O//zeqL3U+2jwACuy2wZFwargYtO1wQE0sfjaRZHe/K0jPd8ra+SHpAvlfVZ4NsO3/Pz+MzAggggMAiC1hCg0YnfPb8zmyu2BRK6Q9tXUGYfL3esIIwva46/0v15vMdAosp0OjfQf77xewj20YAgd0XiKRPuMClznT7mNT2HQr+1aRIOrVer2LpW7ad3c0+V2+dfIcAAggg0GUCR62u3Lt2shgmr8137+g1Wx+6a34lzM/nMwKLLVDbP0vpjmb1xe4n20cAgcUXiKXxaoBzayTtW69HkXRtNdi6sN58vkMAAQQQ6AOBpcX0OHfiaAkT8kPKbpFb6+YHa+PD8vP5jMBiC7j9s9V0sfvJ9hFAYHEFLPFBJP25GuCcV683FhhV59uVoPfUa8N3CCCAAAJ9IBCEyQd2njwmNw8NRXfIDykI0x81m59vz2cEFlqgVfDj5i90v9geAgh0l0AkPcYLcE6u17uytNK1GZeeXa8N3yGAAAII9IFAUEq/ZSeJQSn5Tn44QTFZ6U4gC2ES5+fzGYFuEKjto9wO1w0/B31AoGsFsheh1tJfj0tH1OtoLH23GgRdVm8+3yGAAAII9IXAuj2m3he08yWo5/pDClZXDprKPBem10+dZIaVM9z8oZXR1Bu23WemCCymAEHQYuqzbQR6RyCSPu2u8myW9s/3PJKOdfMjaSg/n88IIIAAAn0iYC9KDUrJLXYSGYRJ7a9eQTE+PCgl1wal9GVBmP5y5/z03TbsYG3l4EIpvSYIKyf0CQPD6HEBgqAe/wHpPgILJBBJP3NBTlkK/M3ay1Ij6WabX5ZG/XnUEUAAAQT6UCAIky9Vg5ztQZiOB2ESFcLktuFS8hobbhAmm6bmW1AUJucEYfrXIEy+cNCyjXfqQw6G1IMCBEE9+KPRZQQWWGCztJ8LgKrTcXvZalk6tCy9O0uXfV01ADptgbvG5hBAAAEEFkNgabFyZCFMvulOJC0RwnCY1B4GtXqhekucvUx1uJi+qt4LVRej72wTARNw+26rKVoIIDC4AmXpORbkRNKXI+msWPqTC4qqGeMuLEvHDa4QI0cAAQQGVGCoGB0QhMm/1gtwDg833qWweushh668YO8B5WHYXSzQKvhx87t4CHQNAQTmWcDSY/svVd0k7RVJB26RDsleoDojM+o8d4fVI4AAAggggAACcxNwQU6r6dy2wtIIIIAAAggggAACCCCAQJcItAp+3Pwu6S7dQAABBBBAAAEEEEAAAQTmJuCCnFbTuW2FpRFAAAEEEEAAAQQQQACBLhFoFfy4+V3SXbqBAAIIIIAAAggggAACCMxNwAU5raZz2wpLI4AAAggggAACCCCAAAJdItAq+HHzu6S7dAMBBBBAAAEEEEAAAQQQmJuAC3JaTee2FZZGAAEEEEAAAQQQQAABBLpEoFXw4+Z3SXfpBgIIIIAAAggggAACCCAwNwEX5LSazm0rLI0AAggggAACCCCAAAIIdIlAq+DHze+S7tINBBBAAAEEEEAAAQQQQGBuAi7IaTWd21ZYGgEEEEAAAQQQQAABBBDoEoFWwY+b3yXdpRsIIIAAAggggAACCCCAwNwEXJDTajq3rbA0AggggAACCCCAAAIIINAlAq2CHze/S7pLNxBAoEMCm6S9ytIzy9J/RdLpkXR2WXp7JL0qko4fl/6lQ5tiNQgggAACCCCAQHcJuCCn1bS7ek1vEEBgdwUiaR8LemLpj7G0o1mJpJ/F0rLd3RbLIYAAAgh0scCBqzftVShWnhkUK/9VKFZOD4rJ2UExfftwMX1VsHbr8cPhOH8N6+Lfj67NTaBV8OPmz20rLI0AAt0gEEkPj6VfucCnLH0ukl40Lj0kuxJ033HpmEi61M23aSQd2w19pw8IIIAAAh0SGDol2seCnkKY/tGd6DWaBqX0Z8OlhL+Gdcie1XSPQKN9Pv999/SYniCAwO4IRNK9YukXLsCx2+DqrWdMumckXeXaXSTdr147vkMAAQQQ6EGBoVOjhxfC5Fe7TvSSzwVh+qLh1eMPGToluu9wMT2mECaX7pqf7giKFf4a1oO/NV1uhI489QAAIABJREFULuDv483qzdfCXAQQ6HaB7Da497rAJpbObNbfsvThattfNWvHPAQQQACBHhIYWhndq1BKfuFO+Ow2uHrdD1aN3TMopVe5dkcVK/w1rB4U3/W0gNu/W017epB0HoEBF4ikO0fSTS4Iym55e3ozkkg6udr2883aMQ8BBBoL2O2mZekJjVswB4EFFgjC5L3uhC8Ik6Z/DSuU0g9PtQ0T/hq2wL8Tm1sYAfdvodV0YXrDVhBAYD4ExqSDXAAUS9stOUKz7WyW7mrLbJb2a9aOeQgg0Fgglm6wf3eRdNG4dETjlsxBYAEEhl4c3blQSm5yJ3xBmDT9a9hwsXJyNQjir2EL8PuwiYUXcP8WWk0XvmdsEQEEOiVgV368IGjHFunRnVo360EAgfoCsXS9/+8uli6OpCfVb823CMyzQLC6cpA72QvCdLslR2i2yYNfsPmutswRL9/MX8OaQTGvZwXcv4dW054dIB1HAAFVs8LV0mGXpdfDggAC8ysQSdflgiD3b3B8XDp6frfO2hHICdiVn2kne+FW/hqWM+LjYAlM+/dQSnc0+jxYKowWgb4TWBJJN7oTMsv+Zimx+26UDAiBLhKIpGvdv7l600iKx6SlXdRlutLPAlNZ4bwTvSCs8NewLvnBl6+feNEJZ27bv0u6MzDdaBT05L8fGBAGikCfCkTSB/wTsUiasPcD9elwGRYCiy4QS3/w/801qkdSEkmFRe8wHeh7gSVBmNzoTvAs+5ulxO77UffAAEdGJy5aMTrx95HRyY+MnP39h/ZAl/uii+7fQqtpXwyWQSAwwALVDHHb/BMxyxjX7y9DLUvPKEvPjKRnjUvPLkvPKUv/z8Y9Lj23LB1Xlp6XBYXPj6VlZek/Iun4SDohlpaXpZFIWhFJ/xlLLyhLL7QXzGZX016cvXj2JWXpxEg6qZpR76VlaWUkvSySXh5LryhLp2RXBFZlt0admj0jsrosrcmuyq3N7IuxFJalUiS9MpJeFUuvtvc3RdJrIum1sfQ6u3Uxkt4QSW+MpTeVpdMi6b8jaV0s/U9ZenMkvSWS3hpLbytLb4+kd2S/9ztj6V1l6d2R9J5qivT3laX3R9Lp1aD4g2XpfyPpjOw9Uh+y1OmWHj2SzsquFJ4dS+vL0mgkbYikj8TSR8vSxyLp45H0iVj6ZFn6VCR9OpI+E0ufrb6A95zsFsxzY+nzsbQxkr4QSV+MpfNi6UuR9OVI+kosnR9LX42kCyLpa7F0YSxtiqSvWzKBWNpcfY5mS/YszVgsjcdSOZIiu4oSS1tjqVINItJYuiSWvhFJ36y+9PeyWPpWJH07+/2/E0vfjaXvRdL3s9//8li6IpaujKRt9keB7PefjKUfZL//D7Pf/0fZ7//jWPpJ9vv/NPv9f5b9/j+3d21lv/8vq+/SshcPX539/v+X/f6/jqXfxNJvs9//d9nv/3tLQuL/e2ujfsm49NQB/t8UQ59vgSBMPuCf8AVhMmHvB5rv7bL+5gIrRie/tmLD5I6pMjp5+8joxDnLP7zt4OZLMXeuAv6/hWb1uW6H5RFAYPEF7MqPneDlT8bshHi9dMfF72Fne7BO2iM/Vj7LPZfCVN1pYUHcuHRMZ/81sDYEJO3MEJdum37Cl9zEy1AXd/cYGZ38ci0IqgZDIxsmt49smPjq8RuueOLi9q5/tz793wHPBPXvL83IENgpcL50t+pf4aedBEeS/bW9abKgHjRcQtDTnSf6/C5t/S52FetZPfjvji53s4Bd+SmU0h/mTwDtKtGhK9f33V/Duvm3cH1bMTrxhXwQ5H8eGZ0YP+HsKwLXnmlnBPL/Bhp97szWWAsCCHSJgCVKeEN2e9XtuZPRz3ZJ/zrWjdz4pgV+zGvrRByzxbti9D27fbNj/xhYEQJO4MgTz79bEKZfyZ/0BWGypVXqbLcOpp0TWDE68Tk/6GlYH5289ITRSfufwpLObX1w15Tf/xt9HlwhRo5A/wqMSU/Jv8vEnpOpN+KydKQ9Y2LPjlSfCTm3LD2yXttu+o5Ah0Cn1/YBe16p35/V66b/RwxyX5YMF5M3FErp7dNO/sKk7/4aVv2RlyxbN3mnZ6//zt7L1n/n7s/90GX3XP6Bbfc5bsMVDzjhrO8fYAkJjj9z2yPsWZzj11/x2JGzJh+/4qyJI5ePXvnkkdErC8vPnnz68rMnnn3C6LbnLh/d9h8r1k+OjGyYeOHIhm0nLV8/+bKR9ZOnLt8wUVy+YdurV4xOvm5k/cSbRjZMvHn56La3j4xOvmfF+onTR9ZPfGjF6LazV4xOfnRkdOKTIxsmPjuyYXLjyIaJqxsGPu5ZIW86Mjp55fINE8uXLdu45yDvwHMd+7T93sucmP9+rttheQQQ6E4By0rlP8CdfU7r9dRS+dqD8l7b27Nnifat17abvvP6yxWNxbuigX179ldakg7+yNtN/wcZgL4Ea9OnFML0ev/EbzhM6v41bL44jvnfTXuNjE6eNbJhYsOKDROfGBnd9pmRDZPnjmyYOG/F6MT5I6OTm0Y2TF68YsNENDI6kawYnbx0ZMPEd1aMTly+YnRicmR08scrRid+sTOYmPjdyOjktSs2TNy4YsPEzSOjk7euGJ28fTZBRu+0nfjp8vUTJ1twN1+/TT+v19/nm9X72YCxITDoApYNzP213DLGNfOoZsjaYRm2mrXrlnku85hNLROZZSSzZ6IsQ5llKrOMZZa5zDKYWSYzy2hmmc0i6RzLdGYZzyzzmWVAs0xolhHNMqPZ1TDLlGYZ0yxzmmVQs0xqFihaZjUztUxrlnGtevXsDMvEFksftEQUlqHNMrXF0vssc5tlcLNMbtWrbe+0DG+W6c0yvlnmN8sAZ5ngLCOcZYazDHGWKc4yxlnmOLu90TLJWUY5yyxnGeYs05xlnLPMc5aBzjLRWUY6y0xnGeosU51lrLPMdZbBzjLZWUY7y2xnGe4s012W8eyllvnOMuBZJjzLiGeZ8SxDnmXKs4x5ljnPMuhZJj3LqGeZ9SzDnmXas4x7lnnPTu4tE59dabSrHJahz271sox99tyLZfCzTH6WECDL7Pb0svQ0y5RmVystUC9Lwbg0bMF4lhluqCw92V44OiYdlWWOe5JdqRyXjhiTDs8yyz2xLD1hXHr8mHRYlnnucWXp0HHpsVukQ7Lf/zFl6d/HpIO3SI/Ofv9H2VXNMemgLdIj7OXCZenfxqSHXSw9NPv9D7SkImPSv26WHpz9/geMSw/aIj1ws7R/9vs/YFz6l4ul+18k3c/ewTUm3aeaMa5lAFjNTLeM4Kdb/q8xgP0IwqQQhOn22olgmNT9a9h80Qyti+7cO4FHNYubd2Vm0fs+OvF/I6Pb1tpVrvn6jfpxvbX9vclVIGvTj2NnTAggsFPATlBdEGRTO5GrZ7NR2jM7qf6LtbET+Xpt+A4BBHYKZAGjpdBuFgRZOu4TLIshZggsukAhTM/adVKYNP1rWKc7O7QuusOiBxLdFNTMui8TN45s2Pb6p77nirt2+rfp5/Xt2t8bZ4YjCOrnPYCxISDZX8H9k7WN0l3qudhfzF27Rs8O1VuO7xAYRIHqu4RmBEH2DiK7akbwM4h7RRePuVCqPM8/KTyqWKn717D5GgJB0O5cYZq42Z45Ovb073f9venztd/MZb3+/t6sPpdtsCwCCCy8QPVlmZdY4NJq63YLkgtu7IWPjdrbrVHVdtuzW7zuZe2qV5HspZXX2AsqCY4a6fH9oAnYS1W9f1cWDP3Ebh+0K6qDZsF4e0BgaZg+0j8RPDzcWPevYfM1lJHRiX8QCLUXCNlzTiMbJj/43LOu2G++fo9BWK+/vzerD4IFY0SgnwTsTfZ2AmbPZrQaV/VZkqm/WNtzKo3a23Mw1XVObJTuZM/HVE/ypm6Rq9a323MbjdbB9wgMikAs/aL67+Vn9gwVwc+g/PJdNM4gTN4ZlJJLhtZELf8aNlxMj/FOBOv+NWw4TF4SlJLvFErpb4bD9P2WarvecJeGlScHYfpFK0vXJk+o1yb/3cjo5F/nMwiyl4+uGJ34+4rRib+sGJ3844oNk9eNbJj4/Yqp52kmfzkyOvmTFRsmfmCZ11aMTn53ZMPEZSMbJtKR0cl4ZHRyy4oNE18fGZ24YMXo5JeqGd0+O5XhbXTyI5bxbWR04oypDHCjk++Zygi3YeLNliFuKlPc6LZXWea4qQxylkluw7aTLLPcVIa59ZPLphJAtHELnAWKI6OTHznhzG375/34PHsBb3/f0aw++zWzBAIILJaAPaBdDUgsCPpIs37YQ9wuTXb2MP0t9uB3o/Z2G0/1pO7sakKB79vD5tVnhV7hbfOCRuvgewQGRSBL2DBmySSyxBZ3GJQxM84uEyiUkqvt5C5Yu7XlX8OCsPJ6dyJoAY4/FLsqFITJl6bWVUpu2dUueYnfztWDMHlvrc2q8Qe575tNd6aanjh5ZHTyxSOjkytWnL3t+JGztx1n78VZMXrlMcvP3vaUkfUTS5evn3zS8RuueOLIhisPPf7siX9fdvbkQcePXv6wZRuueLAFB8et/879lq//zr3sFjF7RsYyz2nduq5+8G5kdOItzQJAC+BGRifOsTTezQyZNzsBt4+2ms5urbRGAIHFFLAsXF5Acptl1qrXH8t6ZSmxvbYn1Gtn310k3cNrd1MslS+QpiWiyTKO3Vhtc3Wj9fA9AgMkwPsMB+jH7rqhHnnqxfd3J3dBmDT9a9jQKdF9XZrsoJTccvSpW6f9NSwIk69aQDUURo+zl6kWSsnNtu6glJ5bb+B29WnnthMOBvWAct8tH508rVEQNLJh4qv27qLcInzsgID799Fq2oFNsQoEEFgggWqqZf+BbHuGx9I+F6tpiy1tsqV5vrUatNxgKY6bdc9SGPtBkKUFzrePJXs2yLb79/w8PiOAAAIILKDA0mJ6XO3kLkxuW7qmUvevYUNhdGAhTFLXNggrM/4aNhX8FKMDXPcLpeSmqfZh8jH3nZseunL9HS2Q2rm+5HPue6aNBSyzWz4IGhmdGLcrXo2XYs5cBdw+32o61+2wPAIILJyAvWMlks6IpW+4lNYugMlNf27vo7Fb4lr1zt5V45a198rUax9L37I29kB4vfl8hwACCCCwQAJBmL7bP7mz9wDZlZvhUlpcGqb/UQgrrw7CyicKYXJrNWC5IShubfrXMOt6YU3ywNp6w0qYH06wNj7MzQ/C5JT8fD7PFFi+Ydura0HQ6OSlJ5x9Rd2AdeaSfDMXAbeftprOZRssiwACiydgaXg3S/vZSyDtxZLVF1I+vt6VnGa9jKXxaoBza/aOoLrZOLMXbl5bDZQubLYu5iGAAAIIzLPA0rWVpxXCyhlBmH6jEKZ/aXSiF4TJzwth8g67Ja6dLtnzRW5d9ZIeFIqV1W5+sLbCbVxtoI6snwgtIYM9/9RGc5p0SMDtp62mHdocq0EAgR4UsMQHkfTnaoBzXr0hWGBUnW9Xgt5Trw3fIYAAAggsisC6PY54+eb9ji5ufUQQxkctLW19xnBYefzQ6mjGfc2tuheUkg/ZSWMQJn8eGopmZP0ohMlnq/NvlLo7IUGrsS7U/Gqqax4iXCjw6nZaBT9u/gJ3i80hgEAXCUTSY7wA5+R6XStLK12bcenZ9drwHQIIIIBAjwsUwvTKnSeHyUX5oRy0bOOdCqX0mqn5YcotAXkgPneVgAtyWk27qtN0BgEEFlQgexFqLf31uHREvY3H0nerQdBl9ebzHQIIIIBAjwscHl50D3u2aGeQk7w2P5zhYrLcnVAGpfR1+fl8RqCbBNy+2mraTX2mLwggsLACkfRpd5VnszTjHW2RdKybH0lDC9s7toYAAgggsCACdhudO2EM1ibP8jd68As237UQJj9x8wvFhIOBD0S96wRq+2op5WWpXffr0CEEukMgkn7mgpz8O4fsZamRdLPNL0uj3dFjeoEAAggg0HGBQpi80Z04Dp0aPdzfQCFMPla7Fc6eGVo1ds/q/CVe3V+EOgKLKuD25VbTRe0kG0cAgUUTsMxyLgCqTsfHpKeUpUPtfURZuuzrqgHQaYvWSTaMAAIIIDD/AsPF5L/dCeNwMT3GtrjzvUDpxwth8gNLv+3mH7ryguxt2uv2CMLkzCBMJrRs457z30O2gED7Am5fbTVtf420RACBfhIoS8+xICeSvhxJZ8XSn1xQVM0Yd2FZOq6fxsxYEEAAAQTqCFjKa++E8ZpCKflcEKa/nwqAVo0/yDLOuflBmGwJSun3CmH6x6Vh5cl1VsdXCCyqgNtXW00XtZNsHAEEFk3A0mOPSQ9zHdgk7RVJB26RDsleoDojO6prxxQBBBBAoA8FdqbITm6wE8cgTP8ehMn6oWLkXh63xIKf2kllmMRHr9n60D5kYEh9IFDbT3kmqA9+TYaAAAIIIIAAAgjMs4Clwh4qRo858sTz71ZvUxb4DK8af1C9eXyHQLcIEAR1yy9BPxBAAAEEEEAAAQQQQGBBBAiCFoSZjSCAAAIIIIAAAggggEC3CBAEdcsvQT8QQAABBBBAAAEEEEBgQQQIghaEmY0ggAACCCCAAAIIIIBAtwgQBHXLL0E/EEAAAQQQQAABBBBAYEEECIIWhJmNIIAAAggggAACCCCAQLcIEAR1yy9BPxBAAAEEEEAAAQQQQGBBBAiCFoSZjSCAAAIIIIAAAggggEC3CBAEdcsvQT8QQAABBBBAAAEEEEBgQQQIghaEmY0ggAACCCCAAAIIIIBAtwgQBHXLL0E/EEAAAQQQQAABBBBAYEEECIIWhJmNIIAAAggggAACCCCAQLcIEAR1yy9BPxBAAAEEEEAAAQQQQGBBBAiCFoSZjSCAAAIIIIAAAggggEC3CBAEdcsvQT8QQAABBBBAAAEEEEBgQQQIghaEmY0ggAACCCCAAAIIIIBAtwgQBHXLL0E/EEAAAQQQQAABBBBAYEEECIIWhJmNIIAAAggggAACCCCAQLcIEAR1yy9BPxBAAAEEEEAAAQQQQGBBBAiCFoSZjSCAAAIIIIAAAggggEC3CBAEdcsvQT8QQAABBBBAAAEEEEBgQQQIghaEmY0ggAACCCCAAAIIIIBAtwgQBHXLL0E/EEAAAQQQQAABBBBAYEEECIIWhJmNIIAAAggggAACCCCAQLcIEAR1yy9BPxBAAAEEEEAAAQQQQGBBBAiCFoSZjSCAAAIIIIAAAggggEC3CBAEdcsvQT8QQAABBBBYGIEJSRQM2AfYBwZ6H5hFEDTQTm0eL/4oaQcFA/YB9gH2AfaBDu0DX56PsIgDFQdr9gH2gYHfB/bed/8d7ZQO/c984L1x5MSIfYB9gH2AfWAW+wBB0CywOMngxJ59gH2AfYB9gH2AfYB9gH2AfaD39wGCIIIg/mrAPsA+wD7APsA+wD7APsA+wD4wUPsAQRA7/EDt8Pzlpvf/csNvyG/IPsA+wD7APsA+wD4w132AIIggiCCIfYB9gH2AfYB9gH2AfYB9gH1goPaBeQmCHimJggH7APsA+wD7QKf2gX+ajyw+rBMBBBBAAAEEEEAAAQQQQAABBBBAAAEEEEAAAQQQQAABBBBAAAEEEEAAAQQQQAABBBBAAAEEEEAAAQQQQAABBBBAAAEEEEAAAQQQQAABBBBAAAEEEEAAAQQQQAABBBBAAAEEEEAAAQQQQAABBBBAAAEEEEAAAQQQQAABBBBAAAEEEEAAAQQQQAABBBBAAAEEEEAAAQQQQAABBBBAAAEEEEAAAQQQQAABBBBAAAEEEEAAAQQQQAABBBBAAAEEEEAAAQQQQAABBBBAAAEEEEAAAQQQQAABBBBAAAEEEEAAAQQ8gUMl3df7TBUBBBBAAAEEEEAAAQQQ6DsBC3peJWmbpL9KukvfjZABIYAAAggggAACCCCAwMAL7CXp+ZK+Juk2STuq5cKBlwEAAQQQQAABBBBAAAEE+krgMElnSrrBC3xcAGTTU/pqtAwGAQQQQAABBBBAAAEEBlLg/tltbv8l6QcNAh8/CHrQQAoxaAQQQAABBBBAAAEEEOgbgZW52938gCdft2eC+A8BBBBAAAEEEEAAAQQQ6GmBPbJsb2e3cQXIAqJ39vRI6TwCCCCAAAIIIIAAAggg4Am8o41A6CivPVUEEEAAAQQQQAABBBBAoOcFXt0kELJECXv2/AgZAAIIIIAAAggggAACCCDgCVha7IkGgdDnvHZUEUAAAQQQQAABBBBAAIGeF7CrPOdJ+ryk4yX9LRcMrej5ETIABBBAAAEEEEAAAQQQQKAqsETSxyRdJOmO1e+eKunmaiB0u6R7ooUAAggggAACCCCAAAII9IvA+yRdImnv3IAOr7401ebxHwIIIIAAAggggAACCCDQFwKnSbpc0r4NRvNoSSc1mMfXCCCAAAIIIIAAAggggEBPCZwi6aeS7tNTvaazCCCAAAIIIIAAAggggMBuCIxIulrSAbuxLIsggAACCCCAAAIIIIAAAj0l8ExJv5N0UE/1ms4igAACCCCAAAIIIIAAArshcJSkayQdthvLsggCCCCAAAIIIIAAAggg0FMCh1QDoOGe6jWdRQABBBBAAAEEEEAAAQR2Q+Bhkn6bZYI7djeWZREEEEAAAQQQQAABBBBAoKcE9pd0laQX9VSv6SwCCCCAAAIIIIAAAgggsBsC95b0I0nF3ViWRRBAAAEEEEAAAQQQQACBnhL4J0nfzXq8rqd6TWcRQAABBBBAAAEEEEAAgd0QuLOkWNIZu7EsiyCAAAIIIIAAAggggAACPSVwB0kXSPqMpCU91XM6iwACCCCAAAIIIIAAAgjMUsCCHgt+LAiyYIj/EEAAAQQQQAABBBBAAIG+FrDb3+w2OLsdjv8QQAABBBBAAAEEEEAAgb4WeEs1EYIlROA/BBBAAAEEEEAAAQQQQKCvBSwFtqXCtpTY/IcAAggggAACCCCAAAII9LWAvQTVXoZqL0XlPwQQQAABBBBAAAEEEECgrwWOlfRbSQ/r61EyOAQQQAABBBBAAAEEEEBA0rCkayQdggYCCCCAAAIIIIAAAggg0O8Ch1UDoKP6faCMDwEEEEAAAQQQQAABBBA4SNLvJD0TCgQQQAABBBBAAAEEEECg3wUOkHS1pJF+HyjjQwABBBBAAAEEEEAAAQTuI+mnkk6BAgEEEEAAAQQQQAABBBDod4F9JV0h6fX9PlDGhwACCCCAAAIIIIAAAgjsLekSSe+DAgEEEEAAAQQQQAABBBDod4E7SrpI0sckLen3wTI+BBBAAAEEEEAAAQQQGGyBPSR9XtJ5kvYcbApGjwACCCCAAAIIIIAAAoMgsF7SmKS9BmGwjBEBBBBAAAEEEEAAAQQGW+Cdki6VtM9gMzB6BBBAAAEEEEAAAQQQGASB10iakHSPQRgsY0QAAQQQQAABBBBAAIHBFnippJ9Luv9gMzB6BBBAAAEEEEAAAQQQGASBZZJ+LekhgzBYxogAAggggAACCCCAAAKDLfA0Sb/PMsE9erAZGD0CCCCAAAIIIIAAAggMgsARkv4g6fBBGCxjRAABBBBAAAEEEEAAgcEWOLh6Beipg83A6BFAAAEEEEAAAQQQQGAQBOzZH3sG6PmDMFjGiAACCCCAAAIIIIAAAoMtYNnffpEFQScPNgOjRwABBBBAAAEEEEAAgUEQsPf/2HuAXj0Ig2WMCCCAAAIIIIAAAgggMNgC+0i6TNLbB5uB0SOAAAIIIIAAAggggMAgCOwlaUzS2YMwWMaIAAIIIIAAAggggAACgy2wp6QvSTpX0h6DTcHoEUAAAQQQQAABBBBAoN8Flkj6uKSvS7pjvw+W8SGAAAIIIIAAAggggAAC75eUStobCgQQQAABBBBAAAEEEECg3wXeJOlySfv2+0AZHwIIIIAAAggggAACCCCwStJPJN0HCgQQQAABBBBAAAEEEECg3wVWSLo6exboQf0+UMaHAAIIIIAAAggggAACCDxL0u8kPQIKBBBAAAEEEEAAAQQQQKDfBY6WdI2kw/p9oIwPAQQQQAABBBBAAAEEEHhsNQBaCgUCCCCAAAIIIIAAAggg0O8C/7+9ew+1parjAP61MrkVt7dZdrMHZFQXpBtUREX0hsoef5T0tgdUUAaW9EYqoReVUqDVH2kG/RFFRQVGUJFQIpUGGWTdKOydZVZWpu4f7IHFYs7e+3bn3Dme+xnYzOyZNWuv9Tn/nC9rZq2Tk1yT5NTd3lH9I0CAAAECBAgQIECAwL4kB5O8FAUBAgQIECBAgAABAgR2u8A9k1yV5I27vaP6R4AAAQIECBAgQIAAgb1JLk9yNgoCBAgQIECAAAECBAjsdoE9Sb6d5Nzd3lH9I0CAAAECBAgQIECAQAlckOSixSjQMTgIECBAgAABAgQIECBwNAickOR2R0NH9ZEAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBCYWWB/kgMTfE7o+rGvqfPk7pqvBAgQIECAAAECBAgQmE3gV0lunuBzVteDjzV1fq+75isBAgQIECBAgAABAgRmExCCZqP3wwQIECBAgAABAgQIzCEgBM2h7jcJECBAgAABAgQIEJhNoA1B30hym//zc0zXA4/DdSC+EiBAgAABAgQIECCwMwTaEPT1CZskBE2IqSoCBAgQIECAAAECBKYTEIKms1QTAQIECBAgQIAAAQK3AoGdGoJqyu0Tk9xhQsM9SU5KUvtNtrsnOX6TghuUqccF75PkthuUVYQAAQIECBAgQIAAgW0U2AkhqMLGmUk+k+T7Sf7aTK9d03f/LsnnkzxtjcNpSb66/LxwWfZOSd6R5Oquzl8meVuAZGBiAAAH1klEQVSSO3Z1PjjJ+V0brk3ynSRP6Mqu+/rIJOct7/3b8vf/leSyRcD7ZJInrqvAdQIECBAgQIAAAQIEpheYOwSdkeTvXUBZtW7Rl0eCy6Dyrqaedya56zJUrarvB0nutqzgRYswdn1TR3/fTYtRpPcPP7ZiX6M99fv/XVFX1V31fTjJcSvqcokAAQIECBAgQIAAgYkF5gxB7x4JCT9O8pUkFy9HUH4/UuY9Wxi0IejjSa5o7q3AcWWStr9DyLkgybMXweV/TfnfJvnhYhTpxubcEFwevcXv1+kKXpd299yQ5PJln+pajQYNv1376vNUj92taJpLBAgQIECAAAECBAiUQBsKjuTscA/vRkpqRKbO9VuNqrw6yV+a4PDnLUaD2hA0hIzrkpyepN4xGrZHJDnY1FdBZxgB+maSBw0Fk9x5MWLT1/ut5np/eG5Tb7Xhc4tH4upxv3Y7Nsn7liNBQzvr8TgbAQIECBAgQIAAAQJHQKANQRUMamrrQ/k8dYs2rpsi+1NNWPhjknttUc9w+uVN+QoOzx0uNPs+rNToz3Oa6+3h87r6qs6vJenXOxruubApX+8sjW0P60aOzhkr1Jyr95aGEFSjUBXObAQIECBAgAABAgQIbLNAG4KGf8gPZf/2Ldq3KgRV0PhNEwA+uEUd7ema4KBt1+vai8vjPgR9YKTMcKoWhf1nU2e9v/OQ4eLIvsJe+/vDe0Rt0UuaMvWI2+3bi1sc10QOQ701+YKNAAECBAgQIECAAIFtFpgjBFWX6jG3+yd50mI2tntv2Mc/NYHhTSP39CHolJEy7amfN/XV+0Ortoc2ZSu09HXv7a6/flVlzbUaqRpCUI1cTTklePMzDgkQIECAAAECBAgQGATaEHRNks8e4ufUoaJuv2okqCu69mutr9PP3PbmkbvaEPTvJDXas2qr6biHAPKlVQWX6wsNZWtf01+324Gmrrq+6aNt+7r79reVOiZAgAABAgQIECBAYHqBNgQdyYkRxnpyvyRPTvLaxYQEH1m+o/OLLiQMQeQtIxW0IegPI9f7U20IqgkNVm19WOlDUPt+T7WxHm2rCRQ2+Qx9qn29q2QjQIAAAQIECBAgQGAbBeYOQRUuaq2cmhyhDQPrjteFoHrUbd3WhqBqw6ptXQiqdYHWtXmT62etaoRrBAgQIECAAAECBAgcvsCcIejMbprsPiTUjGk/W6yh84nFoqfPSNK+E7QuBF21Ac2UIeijE4WgD23QbkUIECBAgAABAgQIEDgMgblCUD/ldQWgWlD0vOW6QI8aWQuoXStop4WgNzQh6NoVU20fxp/KrQQIECBAgAABAgQITCEwRwi6SzcCVO/vPH5NZ2pa7RoZGkaLxh4ba98JOtIjQU9v2lZtfMCa/rhMgAABAgQIECBAgMBMAnOEoGd1geGZG/T9pO6et47cM2cIemDXvuePtG/s1HFJKkDVGkWmxx4Tco4AAQIECBAgQIDAxAJzhKBaxHQY0alFSvds0Kczmnvq3pqIoN/mDEG17lE9Bjf069INH4mr9YSGe2r/uL5TvhMgQIAAAQIECBAgMK3AHCGon0lt3WKpT0lyQxcW3jvCMGcIqua07wVVoHnVSBvbU/dI8uumX1e2Fx0TIECAAAECBAgQILA9AnOEoHr8rR39+PSKrtXIyD+68nVvLcbab3OHoBoNuqJpawW3mgFvbNHW45Nc1pStPp3ed8h3AgQIECBAgAABAgSmF5gjBNXjbz/pAsB3k7w4yWOWj4S9JMkXmwkU6rG5q5t7vjBCMXcIqibVBA//adpZ4aZmvaupr6tPr1lO+d0Hu/NH+uMUAQIECBAgQIAAAQLbIDBHCKpu7F+MklzfhYV2dKg9PrgMR69oyl838i7RTghB1bdTkvyoaWvbl7Hji7YYLdqGP7cqCRAgQIAAAQIECBCYKwSV/H2TXJjkppHAcGOSnyapCRGGiRNO7Mq9oPvz7ZQQVM06djExwtlJWt8+AF2S5LFdH3wlQIAAAQIECBAgQOAoEKgJAuoxuHoc7mVJDjTBZzd0f++yf69MclqSWgi2+mwjQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECOxWgVsAu811N9YF8TAAAAAASUVORK5CYII=)\n",
+    "\n",
+    "https://github.com/Cantera/cantera-jupyter/blob/main/flames/flame_speed_with_convergence_analysis.ipynb"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "5129b515",
+   "metadata": {
+    "id": "Eqi29awDevzv"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cantera 3.2.0 is ready with the bundled GRI-Mech 3.0 mechanism.\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"Cantera {ct.__version__} is ready with the bundled GRI-Mech 3.0 mechanism.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "b42b1080",
+   "metadata": {
+    "id": "VvtbXONOe3yb"
+   },
+   "outputs": [],
+   "source": [
+    "from collections.abc import Mapping\n",
+    "\n",
+    "from matplotlib.ticker import MaxNLocator\n",
+    "\n",
+    "species_name_map = {\n",
+    "    \"methane\": \"CH4\",\n",
+    "    \"ethane\": \"C2H6\",\n",
+    "    \"propane\": \"C3H8\",\n",
+    "    \"nitrogen\": \"N2\",\n",
+    "    \"oxygen\": \"O2\",\n",
+    "    \"CO2\": \"CO2\",\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "db44cf61",
+   "metadata": {
+    "id": "87Ta9i7ne4kH"
+   },
+   "outputs": [],
+   "source": [
+    "class CanteraUnitOperation(unitop):\n",
+    "    \"\"\"Calculate a freely propagating premixed flame from two NeqSim streams.\"\"\"\n",
+    "\n",
+    "    def __init__(self, equivalence_ratio=1.0):\n",
+    "        super().__init__()\n",
+    "        self.fuel_stream = None\n",
+    "        self.oxidizer_stream = None\n",
+    "        self.equivalence_ratio = equivalence_ratio\n",
+    "        self.width_metre = 0.015\n",
+    "        self.flame = None\n",
+    "        self.flame_speed_metre_per_second = None\n",
+    "\n",
+    "    def setInputStream(self, stream):\n",
+    "        self.fuel_stream = stream\n",
+    "\n",
+    "    def setFuelStream(self, stream):\n",
+    "        self.fuel_stream = stream\n",
+    "\n",
+    "    def setOxidizerStream(self, stream):\n",
+    "        self.oxidizer_stream = stream\n",
+    "\n",
+    "    def setWidth(self, width_metre):\n",
+    "        self.width_metre = width_metre\n",
+    "\n",
+    "    def getFlameSpeed(self):\n",
+    "        return self.flame_speed_metre_per_second\n",
+    "\n",
+    "    def get_composition(self, stream):\n",
+    "        fluid_system = stream.getThermoSystem()\n",
+    "        composition = {}\n",
+    "        for component_index in range(fluid_system.getNumberOfComponents()):\n",
+    "            component = fluid_system.getComponent(component_index)\n",
+    "            neqsim_name = str(component.getName())\n",
+    "            cantera_name = species_name_map.get(neqsim_name)\n",
+    "            mole_fraction = float(component.getz())\n",
+    "            if cantera_name is not None and mole_fraction > 0.0:\n",
+    "                composition[cantera_name] = mole_fraction\n",
+    "        return composition\n",
+    "\n",
+    "    def calculate_flame(self):\n",
+    "        gas = ct.Solution(\"gri30.yaml\")\n",
+    "        gas.TP = (\n",
+    "            self.fuel_stream.getTemperature(\"K\"),\n",
+    "            self.fuel_stream.getPressure(\"Pa\"),\n",
+    "        )\n",
+    "        gas.set_equivalence_ratio(\n",
+    "            self.equivalence_ratio,\n",
+    "            self.get_composition(self.fuel_stream),\n",
+    "            self.get_composition(self.oxidizer_stream),\n",
+    "            basis=\"mole\",\n",
+    "        )\n",
+    "\n",
+    "        self.flame = ct.FreeFlame(gas, width=self.width_metre)\n",
+    "        self.flame.set_refine_criteria(ratio=4.0, slope=0.15, curve=0.15)\n",
+    "        self.flame.solve(loglevel=0, auto=True)\n",
+    "        self.flame_speed_metre_per_second = float(self.flame.velocity[0])\n",
+    "\n",
+    "    def plotFlame(self):\n",
+    "        figure, axis = plt.subplots()\n",
+    "        axis.plot(\n",
+    "            self.flame.grid * 100.0,\n",
+    "            self.flame.T,\n",
+    "            color=\"#0072B2\",\n",
+    "            linewidth=2.0,\n",
+    "            label=\"Cantera temperature profile\",\n",
+    "        )\n",
+    "        axis.set_title(\"Premixed fuel-gas flame temperature profile\")\n",
+    "        axis.set_xlabel(\"Distance through flame [cm]\")\n",
+    "        axis.set_ylabel(\"Temperature [K]\")\n",
+    "        axis.legend()\n",
+    "        figure.tight_layout()\n",
+    "        return figure\n",
+    "\n",
+    "    @JOverride\n",
+    "    def run(self, calculation_id):\n",
+    "        self.calculate_flame()\n",
+    "\n",
+    "    @JOverride\n",
+    "    def toJson(self):\n",
+    "        results = {\n",
+    "            \"name\": self.getName(),\n",
+    "            \"equivalence ratio [-]\": self.equivalence_ratio,\n",
+    "            \"flame speed [m/s]\": self.flame_speed_metre_per_second,\n",
+    "            \"maximum temperature [K]\": float(np.max(self.flame.T)),\n",
+    "        }\n",
+    "        return json.dumps(results)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "1723235f",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 605
+    },
+    "id": "av5i30mZe_h-",
+    "outputId": "e90d81bb-5223-4328-a5eb-f4de4829090f"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>equivalence ratio [-]</th>\n",
+       "      <th>flame speed [m/s]</th>\n",
+       "      <th>maximum temperature [K]</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>name</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>Cantera premixed flame</th>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.6217</td>\n",
+       "      <td>2292.7353</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                        equivalence ratio [-]  ...  maximum temperature [K]\n",
+       "name                                           ...                         \n",
+       "Cantera premixed flame                    1.0  ...                2292.7353\n",
+       "\n",
+       "[1 rows x 3 columns]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Figure size 960x600 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA7QAAAJMCAYAAADKcepuAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjExLjEsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvctoD+AAAAAlwSFlzAAASdAAAEnQB3mYfeAAAkPRJREFUeJzs3Xd4FNXbxvF7N70Reu+B0EGKFKWjgqAoAiKCoCBFBUHELsir8gMLqFjAQhFQLCgiUsWGgAQpgvTeIZCEkl7n/QOzZMkmJNkkO0m+n+viyu6ZMzvP7B428+SUsRiGYQgAAAAAgALG6uoAAAAAAADICRJaAAAAAECBREILAAAAACiQSGgBAAAAAAUSCS0AAAAAoEAioQUAAAAAFEgktAAAAACAAomEFgAAAABQIJHQAgAAAAAKJBJaAAAAAECBREILAAAAACiQSGgB4D8XLlxQnTp11LlzZ1eHkqHbb79dderU0alTp7K1X2hoqJ5++mm1adNGdevWVZ06dbRq1ao8ijJz/fv3V506dfTvv/+65Pj57ezZsxo3bpzde5/2X9OmTV0dIoBccPnyZb3yyiu67bbbVL9+fdWpU0fffvutJKlRo0aqU6eOkpKS7PYZMWKE6tSpo40bN7oiZKBQcHd1AAAKjgMHDujuu+9OV+7n56dq1aqpc+fOevjhhxUQEOCC6JCR5ORkDRkyRIcOHXJ1KEVO6nt/5MgRV4cCII8NGTJEu3btcnUYQJFDQgvAadHR0dqzZ4/27NmjpUuX6ssvv1TZsmVdHRb+s2XLFh06dEgVKlTQJ598oqCgILm5ubk6rCJh8+bNOnLkiMP3Pj4+Xo0bN3ZxhPnvvvvu0+7du/XDDz+oXr16rg6nyOB9z1u7du3Srl27VLx4cc2dO1d16tThexbIJyS0AHJk//79kiTDMHTu3DmtXr1a06dP18mTJzVlyhS98847Lo4w+8qUKWM7r8Lk8OHDkqT27dsrODjYxdEULak9s7z3QOGW+n/9lltuUf369dNtLypTLABXYA4tAKdYLBZVqFBBDz/8sEaNGiVJWrt2reLj410cGVLFxcVJujo0HPkr9f8B7z1QuKX+X/f19XVxJEDRQw8tgFzToUMHTZs2TQkJCTpz5oxq1KihESNG6Pfff9enn34qPz8/ffrpp/rnn3906dIlvfvuu+rWrZsk6fz585o7d65+//13nTlzRlarVbVr11afPn3Up08fWa32f39Lnc9bt25dffPNN5o1a5ZWrFihM2fOqESJErrzzjs1duxY+fj4KCwsTB988IF+//13hYWFqWLFinrggQc0ZMgQu9e8cOGC2rZtq0qVKunXX3+VdHUO5ODBg/X333/r4Ycf1gsvvGC3T1JSkgYMGKB//vlHw4YN0/jx423bEhMTtXjxYi1btkwHDx5UXFycKlSooM6dO2v48OEqWbKkw/fx9OnTeu+997R+/XpFRkaqUqVK6tmzpx599NFsfR7Lly/XuHHjbM/nzJmjOXPmSJIaNGig77//XtLVxUoSEhIy7J3u3LmzTp8+rT/++EPly5e325bTc8ypkydP6r333tOGDRsUFRWlihUr6u6779bw4cPVo0cPnThxQr/88osqV65s2+fSpUtauXKl1qxZo2PHjunChQvy8/NT/fr1df/99+vOO+9Md5yIiAh98skn+u2333T27Fl5eHioYsWKat68uQYMGKDatWtnGmdW3/uM5CTmbt266ejRo1qzZo327dunuXPn6sCBA3Jzc1OzZs309NNPKzg4WCkpKVqwYIG+++47nThxQl5eXurUqZOeffZZh59Xbn3GISEhGjRokO35vffea7d9/vz5atWqlVPHzYv3IO1r7t27V/PmzdP+/ftlsVjUqFEjjRw5Um3atHF4zs6ew8GDB/X5559r3759unLlim24cHbaR3be95x+F2QlZkk6evSo5syZo40bN+r8+fPy8vJS/fr19dBDD+n22293eMyMrF27Vk888YS6du2qV199VTNmzNCvv/6qsLAwlS1bVnfccYeeeOKJdGs6pN3v9ddf10cffaS1a9fq3LlzatWqlWbPni1JioyM1Jw5c/Tzzz/r1KlTslgsqlGjhu6880499NBD8vb2liStW7dOw4YNs73+4sWLtXjx4gzj3r17t9zds3b5nZycrKVLl2rJkiXav3+/YmJiVLZsWXXq1EkjRoxgag/wHxJaAHnCYrHYPV+7dq2+/fZbpaSk2MpSH2/fvl0jR47UpUuX7PbZsWOHduzYoY0bN+qdd95J95rS1YTy0Ucf1ebNm21loaGhmjdvng4dOqTJkyfr/vvvV2hoqG378ePH9cYbbygmJsbWq5wRNzc3TZs2Tffee6/mzZunli1bqkuXLrbt06ZN0z///KOmTZtq7NixtvKoqCgNHz5cW7dutXu948ePa+7cuVqzZo0WLFigSpUq2W0/dOiQBg4cqIsXL9rKjh49qvfee09bt25VcnJypvHmp5yeY07t27dPgwYN0uXLl21lx44d0/vvv6/t27dn+N68/vrrWrZsmV3ZpUuXtHHjRm3cuFE7d+7Uc889Z9t25coV9enTR6dPn7aVxcfH68CBAzpw4IB+/vlnbdiwIVfOKSPZjTmtefPm6csvv7Qr+/3337V9+3Z9//33evPNN7V69WrbttjYWC1ZskQHDhzQN998Y3exnd+fcW4dNzffg1SzZ8/W119/bVe2adMmhYSEaMqUKerVq1eunsPcuXO1aNEiu7LU70xn2kdeyizmNWvWaPz48XajdxISEhQSEqKQkBANHz5cTz/9dLaPefnyZd1///06fvy4rez06dOaO3eu1q9fry+++EKBgYHp9rty5Yr69u2rY8eO2coMw5AknTt3ToMGDbJ7TelqMrp7926tWrVK8+bNy9MFEOPi4vTEE09o/fr1duWnT5/WwoULtXr1an3++ecKCgrKsxiAAsMAgCzav3+/ERwcbAQHBzvc/vHHHxvBwcFGw4YNjdjYWMMwDGP48OG2fQYOHGhs27bNiI6Otu0TERFhtGnTxggODjaGDBli/P3338bly5eN8PBwY9myZcatt95qBAcHG1988UWGsbRo0cL4+uuvjXPnzhmXL182vvnmG6NBgwZGcHCw0alTJ+O2224zfvnlF+PixYtGaGio8dZbbxnBwcFGkyZNjMjISNtrnj9/3rbP9datW2fUqVPHaNmypXH69GnDMAzj119/tZWdOXPGrv6YMWNsr7VkyRLj7NmzRnR0tLF9+3Zj4MCBRnBwsDFo0KB0x+nVq5cRHBxs9OzZ09i8ebMRHx9vXLhwwfj444+NevXq2c755MmTWfzUDOOzzz4zgoODjalTpzrc3rBhwww/U8MwjE6dOhnBwcHG2bNnc+UcH3jgASM4ONjYuXNnls8hJSXFuPvuu43g4GCjV69expYtW4z4+HgjLCzM+Oyzz4z69etn+N5MnjzZmDp1qrFt2zbj/PnzRnx8vHHq1Cnj888/N2666SYjODjY2Lt3r63+559/bgQHBxu33367sX79euPy5ctGbGyscfDgQeOrr74yHn744SzHndl7HxcXZwQHBxs33XRTum3ZjdkwDKNr166292DixInG4cOHjZiYGGPbtm3GHXfcYfusGjVqZHz88cfGqVOnjMjISGPNmjVG8+bNjeDgYGP58uV2r5nTzzgzqW18z549GdbJ6XHz4j1I+5pjx441Dh8+bMTHxxuHDx82nnzySSM4ONho3LhxunaXG+cwduxYY+/evUZ8fLxdnZy0j6y87zn9LrhRzIcOHTIaNWpkBAcHG+PHjzf+/fdfIyoqyjh37pyxcOFCo2nTpkZwcLDx559/Znjs6/388892vwN++OEHIzIy0oiKijJWrFhhtG7d2ggODjaef/75DPdr2bKl8d133xnnzp2zq/PII48YwcHBRrt27Yw1a9YY0dHRxpUrV4wlS5bY2sn1r/vNN98YwcHBxosvvugw3tT3NjEx0a489Xfkhg0b7MonTJhgBAcHG7feeqvxzTffGKdPnzZiYmKMf//91xg2bJjtuxCAYZDQAsgyRwltSkqKcfbsWWPu3Lm2C5Ynn3zStj31l/Udd9xhJCQkpHvN999/33Zhl5SUlG779u3bjeDgYKNr164ZxvLzzz+n2++ZZ54xgoODjUaNGhlHjx6125aSkmJ079493UVEZgmtYRjGtGnTjODgYKNfv37GiRMnjJYtWxp16tQxfv31V7t6Bw4cMIKDg41mzZoZJ06cSPc6sbGxtovr/fv328r//vtv28Xx9RdYhmHYEnEzJLQ5PUfDyFlCu2nTJlvyd+HChXTb33333Ry9N5988okRHBxsfPjhh7ay6dOnG8HBwcaXX36Z5dfJSE4T2uzGbBjXkoqnn3463T5r1661vT9z585Ntz31/ZswYYKtzJnPODM3SqycOW5uvwdpX/O+++4zUlJS7LalpKQY9957rxEcHGy8/fbbuXoO2fnDSVoZtY/8SGgzijn1+zijZG/p0qVGcHCwMXz48AyPfb20ienKlSvTbf/jjz+M4OBgo0GDBkZ4eLjD/TZu3Jhuv3379hnBwcFGnTp1jB07dqTbvmbNGiM4ONioX7++3XdRbia0Z86cMerVq2c0atTI4f+thIQEW7v7+++/HR4PKEpYFApAjtSpU0d16tRR3bp11aFDB02ZMkXx8fGqVKmSXnzxxXT1+/btKw8Pj3Tl69atkyQNHDjQ4S0ObrrpJlWqVElHjx5VREREuu0BAQG67bbb0pWnrjLZtGlTVa9e3W6bxWKxzek6f/78jU/2P2PGjFGLFi20fft29erVS5cuXdIjjzyiTp06OTynjh07qkqVKulex9vbW507d5Ykbdu2zVaeOmz6zjvvVLly5dLtd/2cX1fK6Tnm1JYtWyRdnatXunTpdNvTzhF0ZPXq1RoxYoTatm2rhg0b2trv22+/LUl2w4tT285PP/2kU6dOOR17TmUn5rSuH/oqXZ23m5XtFy5csJXl92ecm8fNrfcgrUGDBqWb9mCxWDR48GBJspv2kBvn8OCDDzosT5XT9pGXMoo59f3I6P9p165d5e7unqN2VL58eXXt2jVdefv27VWrVi0lJiY6fN3q1as7nPv8999/S5Juvvlmh7fVuv3221WtWjUlJSWlG06eW9avX6/k5GS1bt3a4eroHh4etjnHufl/DyiomEMLwGm+vr6qWrWqOnfurEceeUTFihVLV6dq1aoO901NGMaMGSPp2hym639KVxfquX4RlYoVKzp83dRVZTOan5a6EmViYqLjk3LAzc1N06dPV5cuXRQZGakGDRrYLfxz/TktX75cK1euTHc+ac8pLCzM9vjcuXOSpBo1ajg8fsmSJVW8ePF0c41dIafnmJH+/fs7vDBLXUAldQ50Ru9NiRIlMnxvJk2alG5e3/XSzuu744471LNnT/3444/q0qWLatasqUaNGqlZs2bq0qWLypQpc8PzcVZ2Y07LUZtPbe/+/v4O5xOmbk9ISLCV5fZnnFW5cdzceg/Syqjt1axZU9K1/7+5dQ6OEuFUzrSPvOQo5qioKNuaAKl/SMjoe/7KlStKSEiQp6dnlo9ZvXp1h+srSFc/m0OHDtmtoZAqo99JqXVr1aqV4TFr1qyp48ePO3zd3JDaftatW2f7A1tG7Sc8PDxPYgAKEhJaADmS3fu1pq4Ieb3UBUOystiRo+QzowuZrG7PrpUrV9riOH36tMLDw9Ot/Jt6ToZh3PC8sntOaS9k8oujYzp7jvll586dWrRokdzd3TV27Fh17txZ5cuXl4+Pj6xWq5YsWaLnn3/ebh+LxaK33npLDz/8sNauXat//vlHv//+u5YuXarXX39dI0aM0OjRo00V8/Xx52Tb9Vz1GefGcXPrPcjOfmm358Y5+Pj4OCx3tn0440bfP45iTrtPVr/ns5PQ5vT7MqP3N3Wf3P7dkR0F5fsVMAsSWgAuVaFCBV28eFELFixQy5YtXR1Opnbu3Km3335b3t7e6tKli+3WLAsWLLAbLl2hQgVJV4dRT5gwIcuvn5oYHzlyxOH2iIgIuxV+c4uHh4cSEhIUFRUlf39/u20JCQkOh2Xn9BwzcqPeptQh2EePHnW4/eLFiw57Z1OHgfbp08fu1hqpDh8+nOExGzRoYBuGahiGtm3bpmeeeUYffPCBmjVrpltvvTXTmHPKmZhzU25/xqlulCjk1XGddeTIETVq1MhhuSS7aQJ5eQ45bR9ZSdBy8l1wIwEBAfL391dUVJTDW3856+jRozIMw+H5pX5fOJrCkZHU+DL7f5aT182O1Bh69uypt956K0+OARQmzKEF4FLt27eXdPVeiK7ofcyqyMhIPfXUU0pMTNTLL7+sN954QzfddJO2bt2qGTNm2NVNPadVq1Zla0haakK/cuVKh/ul3sc0t6UOof3333/Tbfvhhx+UlJSUrjyn55hTLVq0sB3P0RDN+fPnO9wvdfioo96YiIgIfffdd1k6vsViUfPmzXXHHXdIunqrqbySWzE7K68+49Tet+jo6Hw9rrMcfUcZhqHPP/9ckuz+IJeX55DT9nGj913K2XdBVrRr106SbO9Vbjp37pzdLZhSrVu3TocOHZKHh4eaNWuW5de7+eabJV29f++ePXvSbV+7dq2OHTsmd3d3NW/ePOeBZ6Jdu3ayWq367bff0t06CEB6JLQAXGrw4MEqUaKEfv75Zz366KNav369zp8/r4SEBJ0+fVqbNm3S5MmT9cwzz7g0zpdeekmnTp3SXXfdZVvgavr06SpWrJg++eQTu/uS1q9fX127dlVYWJgefPBBffPNNzp58qTi4+MVERGhXbt2ae7cubrvvvsUGRlp269FixZq0KCB4uLiNHz4cG3ZskUJCQkKDw/XJ598kmcJbatWrSRJr776qrZs2aLY2FidOnVKn376qf73v/853Cen55hTLVu2VJ06dRQTE6Phw4dr27ZtSkhIUEREhObMmaNPPvnE4X6pi3999dVXWrZsmSIjI3Xx4kX9/vvvGjBggMOFxl599VVNnDhRf/75p06ePKmEhARdunRJP//8s3788UdJytN5tDmJOS/k1WecOu996dKlDnvV87ttZdWuXbv09NNP6+jRo0pMTNSRI0c0duxY7dmzR97e3urXr1++nENO28eN3ncpZ98FWfHYY4/J09NTc+bM0fjx47V161ZFREQoPj5eJ06c0B9//KGXXnrJtqBVdk2YMEFLly5VVFSUoqOjtXLlStt9eO++++50ay9kpk6dOrrllltkGIaeeOIJ/fLLL4qJiVFUVJSWLl1qW/SwZ8+eDheoyw1Vq1a1tY2HHnpICxcu1PHjxxUXF6eLFy9q7969WrBggfr16+eSxb8As2HIMQCXKlmypD7++GPbDeSvv4l8KkerUeaXL774QqtXr1a1atX0f//3f7bySpUq6X//+59GjRqlZ555RkuXLrUlOv/73/90+fJlbdq0KdMhh9f3+Lz55psaMGCA9u3bpwEDBthta9u2rY4ePZrrFzDDhg3T8uXLdeTIkXTH7Nq1q3bu3KmzZ8+m2y+n55gTFotFb775pgYNGqTdu3erf//+dttvvfVWHTt2TKdPn7ZbTbtDhw666aab9M8//2j8+PF2+3h4eKhfv376+uuv7covXryoFStWpCtPVb9+ffXs2dPpc8pITmLOK3nxGXft2lU//fSTvvnmG33zzTe28vnz59sSqvxsW1mV+r4vX77crtxiseiVV15R5cqV7crz6hxy2j6y8r7n9LvgRurUqaN33nlHzzzzjJYtW6Zly5Y5rJf2jwJZ1bp1a509e1bPPvtsum21a9fO0XziKVOmaNCgQTp+/Lgef/zxdNsbNGjgcDX/3DRx4kSFh4frt99+02uvvZZhPTOPbALyCz20AFyuSZMmWrZsmUaPHq0GDRrIz89Pnp6eqly5sm655Ra9/PLLOf7LvbP27t2rqVOnytPTU++++266eWW33367Bg4cqPDwcI0fP962mIe/v7/mzp2rt956S+3atVPJkiXl4eGhMmXKqFGjRho6dKi+//77dCtC16pVS99995169uypkiVLytPTU9WrV9eoUaM0c+ZMh7c2claVKlW0aNEide7cWcWKFZOnp6ftQvCdd96R1er4V0VOzzGn6tatq8WLF+uuu+5SiRIlbO/N6NGjNWvWLMXExEi6tsK1JFmtVs2ePVsPPfSQypUrJ3d3d5UuXVpdu3bV4sWLbRfyaU2cOFGvvfaa2rdvr0qVKsnT01NlypRR06ZNNXHiRH355ZcZLiiTG3ISc17Ji8/4jjvu0MSJE1W3bt0MF4vL77aVFUOHDtU777yjJk2ayNfXV76+vmrVqpWtpzW/ziGn7SMr73tOvwuy4rbbbtPy5cv1yCOPqHbt2vLx8ZGPj4+qV6+uTp06acqUKTkaiRMYGKivv/5aDzzwgMqXLy8PDw9VrFhRjzzyiL788kuHK1rfSPny5bV48WI99thjqlWrlry9veXj46N69erp6aef1pdffqmAgIBsv252eHl5aebMmZoxY4Y6deqk0qVLy8PDQ6VKlVKDBg00ePBgffPNN+n+kAIURRaDP+0AAAq4c+fOqUOHDipdurTd8G/AWd26ddPRo0e1Zs0aVatWzdXh4D9r167VE088oa5du6ZbxwBA0UIPLQCgwJs3b56ka4tHAQCAooGEFgBQIBw+fFhPPfWU1q9fr9DQUNvCPK+//rrmzp0rSenm1gIAgMKNRaEAAAVCcnKyVqxYoRUrVjjcPmTIELVu3TqfowIAAK5EQgsAKBBq1aqld999V0uWLNGhQ4d0/vx5+fn5qX79+urfv7/tHrEAAKDoYFEoAAAAAECBxBxaAAAAAECBREILAAAAACiQSGgBAAAAAAUSi0LlkR07diglJUWenp6uDgUAAAAATC8hIUFWq1VNmjTJ8j700OaRlJQUmXG9LcMwFBcXZ8rYkD9oA6ANFG18/qANgDZQtJn58zcMQykpKdnahx7aPJLaM9ugQQMXR2IvNjZWe/bsUVBQkHx8fFwdDlyANgDaQNHG5w/aAGgDRZuZP//du3dnex96aAEAAAAABRIJLQAAAACgQCKhBQAAAAAUSCS0AAAAAIACiYQWAAAAAFAgkdACAAAAAAokEloAAAAAQIFEQgsAAAAAKJBIaAEAAAAABRIJLQAAAACgQCKhBQAAAAAUSCS0yDUJCQmKiIhQSkqKq0MB8lR0dLTOnTun+Ph4RUZGKjw83LYtLCxMUVFRLowOAACg6CChhdM2bNiggQMHqnnz5urevbuaNWum3r1764cffpBhGLl6rMTERJ07d05JSUm5+roFPRZXKIrnf/nyZfXv319t27bV/fffr82bN2vGjBkaNmyYrc7AgQP16aefujBKAACAooOEFk75+uuvNXz4cN1yyy3auHGjNm3apL/++ks9evTQyy+/rMjIyFw93r59+9ShQwcdP348V1+3oMfiCkXx/L/++mudP39eISEhWrdundq1a6dixYqpdOnSrg4NAACgSHJ3dQAouE6fPq3XXntNI0aM0OOPP24r9/Hx0ZAhQ1SjRg1ZrValpKTo/PnzkiSLxaJSpUrJ3d2+6aUOVy5Tpozc3NwUFRUlb29vu3qJiYmKiIiQJIWHh8vPz09Wq1Vly5a1e63Y2FjFxsaqZMmSGR7DarXq4sWLcnd3l7+//w3ju15uxuLm5qbIyEh5enrKy8vLVicqKkpubm7y8fG54b5eXl7y9PTMMN7cfk8yO//4+HhdvHhR5cuXtztWeHi4PD09FRAQkOmxixUrZtvn0qVLtnhuJDIyUgkJCSpVqpQMw9ClS5cUGBgoq9WaYb2EhARdunRJxYsXt71/8fHxioqKUvHixeXm5mbb7/z58zpw4IDKlStnO3dJ6tu3rx588MEbxpeUlKTLly+rWLFi8vDwuGF9AAAA3BgJLXLshx9+UFJSkh566CGH2zt16iRJioiI0P333y9JSklJ0eXLl9W8eXNNmjRJ1atXlyTt3LlTAwYM0NNPP62vvvpKUVFRiomJ0X333adJkybJarXq+PHjeuGFFyRJTz31lNzc3BQYGKhly5ZJkvbs2aPXX39d//zzj7y8vFSiRAm98sor6tChg90xxo4dqwULFkiS7r//fg0aNOiG8V0vt2IZPny4li1bpujoaMXGxqpfv37q3bu3Xn75ZZ04cUKxsbFq166dpk+fLl9fX7t9n3zySX311VeKiYlRQkKCHnjgAT3//PN2SZijOJ5//nmVKlXKqfcks/P/888/9cQTT2jnzp12CfqwYcPUqlUrPffcc5kee+zYsfr222/14Ycf6uLFi0pOTlaLFi30xhtvqFy5co4bo6QZM2Zo48aNat68uVauXKmEhAQFBARo4sSJuuOOO9LVu/nmm7V06VIFBATovffeU+XKlTVx4kT9+eef8vT0lNVq1UMPPaTRo0fLarVqxIgROnr0qJKTk23vjXQ1Qa5Ro4a+//57h3FFR0frjTfe0LJly2S1WpWcnKwHH3xQ48ePT5dsAwAAIHtIaE3EMAwdi4hVTGJynh0jLi5Ohy8lSqFR8va+NvfR18NN1Uv6yGKxZPm19u7dq4oVK6pEiRKZ1itZsqTWrVtnex4VFaVXXnlF48aN03fffWd3zLVr1+rLL79U+fLltXPnTj344INq1qyZ7r33XtWqVUsff/yx+vTpo/nz5ysoKMi235kzZzRo0CC1aNFCf/31l4oVK6avvvpKo0aN0qpVq1SpUiVb3VWrVunbb7+1K8tqfKlyK5a///5b3377rcqUKaMff/xRzzzzjFasWKH3339fLVq00JkzZ9SrVy/Nnz9fI0eOtIthyZIlWrBggapXr64tW7ZoxIgRqlixoh555JFM43j66af11ltv2b1Wdt+TzM4/u64/9rfffquXX35ZEyZMUP/+/RUfH69x48Zp7NixWrRoUaavdejQIdWtW1d//vmn3N3dNWvWLI0bN07Lly9XtWrV7Oq1atVKISEhtp7ZQYMG6cqVK1q7dq3Kly+vdevWafTo0SpRooQGDRqkJUuW6KWXXtLp06c1b94822tNnjxZW7duzTCmMWPGaN++ffr888/VuHFjHThwQEOGDFG5cuU0ePDgHL9vAAAAIKE1jZQUQz3nbNbyvefz6YgX0pX0qFdWPw5pKas1a0ltdHS0/Pz8snXUqKgoRUVFqW/fvho8eLBCQ0PthqY+/fTTtueNGzdWkyZNtGPHDt17772Zvu6CBQuUlJSkKVOmKDAwUJLUv39//fDDD5o3b55eeuklW92xY8faJW7ZiS8rshPLU089pTJlykiS7r77br300ku6++671aJFC0lSxYoV1aZNG+3YsSPdcUaNGmXrQW7RooX69eunuXPn2hLajOL4/vvvtXLlSltvcX68J5m5/tizZs1Sx44dNXDgQEmSr6+vJk2apI4dO2rLli2298YRT09PTZw4Ud7e3pKkJ554QkuXLtXChQvt3nd/f389//zztmT233//VUhIiObPn287t/bt2+u+++7T7NmzNWjQoByd265du/Tnn39qypQpaty4sSQpODhYw4YN0yeffEJCCwAA4CQSWpMIi07Ix2TWseV7zyssOkFlA7xuXFlS8eLFdfDgwRvWS05O1ttvv63vvvtO8fHxtjmUknT27Fm75Oj6pMrf3z9LC0vt27dPNWvWVHx8vM6dO2crr1mzpg4cOGBXt2bNmjmOLyuyE0va87VYLPL19VXFihXt6vj5+dndFiZV/fr17Z43aNBAs2fPVlRUlPz9/TOMo3r16jp8+LDdvnn9nmQm7bEjIyN16tQp3XPPPXYxS1KJEiV04MCBTBPaSpUq2ZJ36ep7Wq9ePR05csSuXuXKle3mHKdub9iwoV29hg0b6ssvv7S9p9m1d+9eSVJQUJDd+VSqVElhYWGKiIhIN68ZAOCclBRDyYah5JT//hmGklLsnyenGEoxpBQjzU9HZcZ1ZSkOynJaL8Xxvrl9hwhHEhITde5ctMpfOSlP1nUochISExUZHqMKNRLTrdVSEJHQmkRpP0/1qFfWpUltj3plVdov44WFrtesWTOtWLFCJ06cUNWqVR3WMQxD8+fP15IlS/TZZ5/ZeqkOHz6s7t27Kzk5d4ZXW61WHT582G5uY6q0Q00l2c0xlZTr8WUnFmckJibaPU9ISJDVarUlahnFYRhGulV58/o9kZTh/YnTHjt1TukXX3yhxYsX29Xz8PBQbGxspse4/j2Rrr4v1y+Ydf35pm5PSEiwG3Vw/XuaXanHGT16dLpt5cqV08WLF0loAeQJ478kLjE5RYnJ//3873lkdKyOXUmSERolN/cEJaakqZNsOHyelEF5Zs+TUtIkkoahpOQUJRtKl1gmXfc8syQ0OUXpXyvNfkkpeZ8MFi6XXR0AXGjpie3aOq7DjSuaHAmtSVitFi0b2jJ/5tAePqygoCDbsEzp6hzaGqV8s/Va9957rz744AO99957mjZtWrrtH330kQYOHKg9e/aocePGtsRIkjZt2pSj+FMTi+uTqhYtWig0NFTLli1LN+f1RglYTuPLi1iyIyQkRA0aNLB7HhQUZIsrozhiY2O1a9euTF87K+9JRuefmqBduHBBlStXlnR1ePrx48fVpk2bTI/r5+enevXqqVOnThozZky67RklxanOnDmjkydPqkqVKpKutvcdO3bccBXievXqyWKx6K+//lL37t1t5Zs2bVKtWrVynNA2b95cFotFn3zyierWrWu3LTk5OV1iDaBgMwxDCckpiktMUVxSiuISkxVve56suMQUxSf99zh1e1Jq3avl155frWOrn277tefxSSl2CWtqMnljrh0ZBsC1dodGuTqEXEFCayIWiyXbSWV2xca6S+Eeql/O3+khBgEBAZoxY4Yef/xxjRw5UoMGDVKVKlV07tw5LViwQGvWrNGgQYPUpEkTTZs2TatWrVKdOnW0ZcsWvfPOOzk6ZqVKleTl5aWff/5Zfn5+8vDwUNmyZfXQQw/pp59+0pgxY/TQQw+pbNmyOnPmjNasWaNy5cqlW1AprZzGlxexZMfMmTNVqlQpNWzYUL/99pt+/PFHvfvuu7btGcWxYsUKSemH16aVlfcko/OvV6+eypYtqzfeeENPPvmkYmJiNGPGDMXFxWXpvF588UWNHDlSPj4+at++vTw8PHTw4EEtXLhQEyZMUJ06dTLdf+zYsXrhhRfk4+Ojjz76SCkpKRmuxJ2qevXq6tOnj/73v//J3d1dNWvW1OrVq7VmzRp99NFHWYrbkWrVqumRRx7Rk08+qbFjx6pu3bqKjo7Wtm3b9Ouvv+rzzz/P8WsDyL6UFEPRCcmKSkhSVHySIuOTFBV/9XlkXJKiEpLtyiPjk2x1o+KTFesgKY2/LvkEMmK1SFaL5b9/Vzsz0pVZLMrG+pw5ZxhKSkqWu7ub8ueAMBXDkJclRS/fnvk1VUFBQguntGrVSj/99JPmz5+vadOm6fLlyypTpowaNGigFStWyN/fXw8++KCuXLmiWbNmKTo6WkFBQfrf//6n119/3dbz5enpqXLlyqW7/2uJEiXs5i76+/vrjTfe0Oeff67vvvtOfn5+WrZsmfz9/fX111/rs88+09SpU3XlyhVVqVJFd9xxh3r37p3pMbISnyN5EUvZsmXTLbQVGBjocCXpKVOm6IcfftDMmTMVEBCgqVOn2t2eJqM4OnXqpODgYKffk4zO38fHR59++qneffddjRo1ShUqVFDv3r3l5uZmNxc3o2O3bNlSixYt0pw5c7RkyRJZrVYFBwdr7NixN0xm69WrpwcffFAzZszQ2bNnFRQUpIULF6p48eK2OsWKFUs35FqSXnnlFVWuXFmzZs3S5cuXVbVqVc2cOVMdO3a0+yyuH/Z8/euVKVPG7jyfe+45NWjQQIsXL9aJEydUsmRJNW3aVG+++Wam5wIUdYZhKC4pxZZMXk0yk9IkmdfKohKu255BkhqdkHcjoAozDzeLPNys8rD+9zOT5+7XlblbLXL7r9zNcvWxW5rHqdsdltnqS+5W63/PlYP9HZe5pUkirdb0iaWjZDNL9Rwkqtm5i0R+iI2N1Z49e1S/fv1CMYcS2XPt869448oFgMXIj5nnRdDu3bslyW5IqBnwBVbwbdmyRQMGDNAvv/xiG9KbHYW1DaTePiej+8HimsLaBpA1rvj84xKTFRadoAtRCQqLvvrvQnS8g7IEXYpNtCWpyYV8PqSHm0Xe7m7ycrfK290qbw83ebtbM3juJm8P+8ep+3q53zjZvJpoWuRhtSo5KUEnjx9TnVpBCvDzkYc1zX7/1fFwu5YEmi0Zg/P4PVC0mfnzz0kOZeoe2oSEBG3atEmHDh2Su7u7atWqpTZt2jj8Ys1q3ejoaH3yyScOj9e6dWuHc/wiIiL066+/KjQ0VBUqVFCXLl3sVlIFAKCoSEkxdDE2URei4m1JqC0hzSBhLSg9o36ebgrwcpe/l7v8Pd0U4O0uf093+Xu5yd/TXT4eqYnk1WTTy81qSyy9Paz/PU+ThP73+Orz9Ptm9TZ5uS02Nla+V3Jn+hEAuJppE9rvv/9eb7zxhvz8/HT77bcrKSlJM2fOVPny5fXee+/ZraqbnboxMTGaNWuW2rVrp2bNmtkd8/qhj5K0efNmjRo1SnXq1FGzZs20ePFivfnmm/r444/VpEmTvHsDgAxkNFS3qMtoKDGAzMUkJNkSUfvk1HHCGhGTIDN0nHq5W/9LPq8mm6mPryWk18r8vf57fF2Smraun6ebyxJMAEDOmfaKeMeOHerTp4/Gjh0rj//ujzVy5Ejdc889Gj9+vL755psc1U3Vpk0bDR06NNMYoqKiNHbsWDVr1kwzZ86UxWJRSkqKHn30UY0ZM0arVq2yWykYyA+NGzfWunXrXB2G6Ti6NQ5Q1CUlp+jkpTgdDo+++i8sRvvPX9GBs5cUtfxPhcckKjYx/xcyslikUr6eKuPvqdJ+V/+V+e9nCR9PBXinTVLTJJ+e7grwvpp8erhZ8z1uAID5mDahffTRR2233khVpkwZdejQQd9//70uXrxoWygnO3WzY+XKlQoPD9cjjzxiG7pstVr1yCOP6NFHH9Uvv/yiHj165PAMAQBwXmxiso6Gx+hQ2H9Ja3iMLXk9GhGTL/fl9PdyS5OYel177G+frF4t81JxHw+50RsKAMgFpk1or09QU4WHh8tisdgNt8xO3VQ7d+7URx99JHd3d9WuXVtt27a19e6m2rp1qywWS7qhxU2bNpUk/f333yS0AIA8dzEm4WqiGnYtYT303+PTl7N2S6yscrNa7JJQ+17U9MlqKT9P+XhwT2UAgGuYNqF1ZNeuXVq/fr1atmxpd1uM7Nb18PBQfHy8YmJiFBYWplmzZqlEiRL68MMPVbduXVu906dPKzAwMN2wYn9/f/n5+en06dOZxmAYRrpbfLha6r1As3pPUBQ+tAHQBszHMAydjUzQ0YgYHYmI1eHwGB2NiNWRiFgdjYhVRGyi08fw8bCqZkkfVQv0UnFLvIIrlVG5QJ+rCaqvh0r5eqq0n4cCvd2zt6ptUoJik5wOD/mI7wDQBoo2M3/+hmFke2X1AnPbnkuXLqlv374KDQ3Vt99+m+n9KDOrGxsbqwsXLtgtFHXu3Dn16dNHnp6eWrVqle0+m3379tXZs2e1fv36dMdo06aNatWqpQULFjiMYffu3aZsJAAA10hKMXQ2OlmnIpN0KipZp6Ku/jwZmaTTUcmKT3b+13Ggp0WV/N1VJcBdlf3dVPm/n1UC3FXK28rtVwAApuft7V14btuTKioqSo8++qjOnDmj9957L9Nk9kZ1fXx87JJZSSpfvryGDh2qqVOnKiQkRO3atZN09c1MTHT8V/H4+PgbLgjl5eWloKCgrJxivomLi9ORI0dUs2ZNFrQqomgDoA3krZQUQ/+GRmn90YvaHxato+FXe1pPXI7LlfuqVizmpaCSPqpR0lc1S/qoZikf1fzvcXEfjxvuz+cP2gBoA0WbmT//w4cPZ3sf0ye0MTExGjFihPbu3atp06bptttuy5W610udhxsaGmorq1y5sjZv3qzY2Fi7+7RFRUUpOjpalStXzvQ1LRaLae/v5u3tbdrYkD9oA6AN5A7DMLTvfJR+PRimXw+F6ffD4YqIyfkQYXerRTVK+iqotK+CSvmpVmk/BZW6+rhGKd9cm6/K5w/aAGgDRZsZP/+cjCQydUIbHx+vxx57TNu3b9fbb7+tbt265UpdR44fPy7pam9tqhYtWuj777/XP//8ozZt2tjKt27dKkm6+eabs3UMAEDhcDQ8Rr8eCrMlseci47O1v5+nm4JK+SmotK9q/fczqJSfgkr5qUpxb7lzSxoAALLEtAltQkKCRo0apb///ltvv/22unfvnit1t2/fruDgYPn5+dnKTp8+rTlz5qhy5cpq2bKlrbxbt26aPn26Zs+erVatWslqtSo5OVmzZ89WpUqV1KVLl9w5WQCAqZ25HKffDl1NXn89FKZjETde8M/L3aomFYupdmk/W/Ka2uNa1t+T+awAAOQC0ya0b7/9ttatW6cGDRpo//792r9/v932gQMHqkyZMtmue/ToUT377LOqU6eOKleurAsXLujXX39VhQoVNGPGDNuCUJLk5+en9957T0888YT69++vZs2a6e+//9bZs2c1c+ZMeXl55fG7AABwhfDoBP1+OEy/HgzXr4fCtO981A33cbda1LJqcXWuVVqda5dWm2ol5M3tbAAAyFOmTWibN2+u4sWLZ7g97V+2s1P3vvvuU9euXRUSEqLjx4+rUqVK6tevn1q0aCGrNf0QrxYtWujnn3/Wb7/9pvPnz2vw4MHq1KmT/P39c3ReAADzMQxDm45f1OKdZ/XrwTDtOHtFN7oHgMUiNa0UeDWBrVVKbWuUUoC3aX+tAgBQKJn2N2/Xrl3zpK50tee1c+fOWa5frFgx3XPPPdk6BgDA/MKjE7Rg6yl9FnJCu89F3rB+/XL+th7YDkGlVNLX84b7AACAvGPahBYAgLyQkmLot0Nh+izkhL7/95wSklMyrFuzlO9/PbCl1alWKZUvZq7bGwAAUNSR0AIAioQzl+M07++Tmr35hI6ExzisE+jtrrsblFOXWmXUqVYpVSvpm89RAgCA7CChBQAUaptPXNT/1h7UT3vPKznF8cTY9jVL6tFWVdWnScVcu88rAADIeyS0AIBCaceZy5qwcr+W7Ql1uL2Mv6ceblFFQ1tVVZ2yLPQHAEBBREILAChU9oVG6pXVB/TNjjPptlks0h3BZTSsdVXdXb+8PN3Tr24PAAAKDhJaAEChcCQ8Wv+35oAWbj2l60cW+3u5adStNTSyTTXmxQIAUIiQ0AIACrRTl2L1+tqDmh1yQknXZbLe7laNaltDz3YKUhl/LxdFCAAA8goJLQCgQIpJSNIrqw/o/fVHFZ9kf+sdDzeLhreuphe71FbFQG61AwBAYUVCCwAocP4+cUkPfblN+y9E25W7WS16uEUVTbi9NkOLAQAoAkhoAQAFRlJyiv73yyG9+vMBu1vwWCzSg00r6ZU7glW7DCsWAwBQVJDQAgAKhAMXovTQl9u1+cQlu/I21Urok76N1bBCMdcEBgAAXIaEFgBgeiv2huqBBdsUGZ9kK3O3WjSpa7Ce61RL7m7cfgcAgKKIhBYAYFqGYei9P4/q6R93292Kp145fy3o31TNqxR3WWwAAMD1SGgBAKaUmJyiUd//q082nbArf/yW6nq7Z335eLi5KDIAAGAWJLQAANOJiElQ38+36tdDYbYyd6tFH97XSMPbVHNhZAAAwExIaAEApnIhKl6dZv6l3ecibWXFfTz03eAW6ly7tAsjAwAAZkNCCwAwjYiYBN3+8Sa7ZLZ2aT/99GhLBXM7HgAAcB0SWgCAKVyOTVTXTzZpx5krtrJbq5fQj0NbqqSvpwsjAwAAZkVCCwBwuci4JN35aYi2nLxsK2tdrYRWDmutAG9+VQEAAMe4cR8AwKViEpJ095zN+uv4RVtZs8qBWjmsFcksAADIFAktAMBlUlIMPbhwm/44HG4ra1QhQGuGt1ZxHw8XRgYAAAoCEloAgMu89fthLd0dantet6y/1o5oo1J+zJkFAAA3RkILAHCJ3w+F6cUVe23PKwV665eRbVQ2wMuFUQEAgIKEhBYAkO/OXonTAwu3KcW4+tzdatE3DzVXxUBv1wYGAAAKFBJaAEC+SkpO0QMLtio0Mt5W9tbd9XVLjZIujAoAABREJLQAgHz14op9Wnckwva8T+MKGtOuhgsjAgAABRUJLQAg3/y0J1Rv/X7Y9rx2aT/N7tdEFovFhVEBAICCioQWAJAvouKT9NjinbbnPh5WffdwCxXz5vY8AAAgZ0hoAQD54vWfD+rU5Tjb8/d7NVKjCsVcGBEAACjoSGgBAHlub2ikpv1xbahxu5olNaRlFRdGBAAACgMSWgBAnjIMQ6OX7FLSf/focbNa9OF9jZg3CwAAnEZCCwDIU2v2X9AvB8Nsz59sW4OhxgAAIFeQ0AIA8oxhGJqwar/teRl/T03qGuzCiAAAQGFCQgsAyDM/7QnV3ycv2Z4/37kWqxoDAIBcQ0ILAMgTKSmGJqbpna1QzEuP3VLddQEBAIBCh4QWAJAnlu4+p3/OXLE9f7FLbfl4uLkwIgAAUNiQ0AIA8sT0P47YHlcp7q1hrau6MBoAAFAYkdACAHLdtlOXtP5ohO35U+1rysud3lkAAJC7SGgBALluxp9HbY/9vdw0pCW9swAAIPeR0AIActX5yHgt2n7G9vzhFlUU6MPKxgAAIPeR0AIActUnm44rITnF9nxU2xoujAYAABRmJLQAgFyTnGJo1l/Hbc+71S2jOmX9XRgRAAAozEhoAQC5Zt2RcJ2+HGd7/sSt9M4CAIC8Q0ILAMg1X2w9bXtcxt9TXeuUcWE0AACgsHN3dQCZiY6O1p9//qlDhw7J3d1dtWrVUqdOneTm5vjWD6GhoVq9erVCQ0NVoUIFde3aVWXKOL6Yyqu6AFBUxScla/HOa4tB3d+kojzc+LspAADIO6a90vjqq6/Url07zZgxQ8nJyYqOjtarr76qHj166PDhw+nqr1u3Tt26ddP69esVGBio3377TXfeeac2b96cb3UBoChbsfe8Lscl2Z4PaFbJhdEAAICiwLQJ7b59+zR06FAtW7ZMY8aM0dNPP62lS5cqOjpazzzzjF3dK1eu6JlnnlG7du30ySefaPjw4Zo9e7ZatGihcePGKSYmJs/rAkBR98W2a8ONa5T0VetqJVwYDQAAKApMm9A+9thjeuKJJ+yGF5coUUJt27bV7t27FRERYStfuXKlLl26pEGDBtm9xuDBg3XhwgX9/PPPeV4XAIqyy7GJ+mlPqO35g80qyWKxuDAiAABQFJg2oS1XrpzD8vPnz8tiscjT09NWtmXLFlksFjVu3NiubpMmTSRJW7duzfO6AFCULdsTqvika/eeZbgxAADID6ZeFOp627Zt04YNG3TrrbfK3//afQ3PnTunwMBAuyRXknx9feXv768zZ87keV1HDMNQbGxsts8zL8XFxdn9RNFDG0BetIFlu659H9Yv66fqxdxN9/2Hq/gOAG0AtIGizcyfv2EY2R7hVWAS2rCwMI0bN04+Pj566aWX7LbFxcWlSzpTeXp6Kj4+Ps/rOhIfH689e/ZkWsdVjhw54uoQ4GK0AeRWG0hOMbRq33nb8xalLKb97sM1fAeANgDaQNFm1s/f29s7W/ULREJ7+fJlDRkyROHh4Zo5c6Zq1qxpt93HxyfD5DIuLk4+Pj55XtcRLy8vBQUFZVonv8XFxenIkSOqWbNmthsLCgfaAHK7DWw6cUlXEs7ang+4pY7q12BBKLPiOwC0AdAGijYzf/6O7mZzI6ZPaKOiojR06FAdOXJEH3zwgdq2bZuuTuXKlRUSEqKYmBj5+vrayq9cuaKYmBhVqVIlz+s6YrFYbpj0uoq3t7dpY0P+oA0gt9rAb0eP2x4X83ZXpzrluf9sAcB3AGgDoA0UbWb8/HOyoKSprziio6P16KOPat++fXr//ffVsWNHh/Vatmwp6eoc27S2bNlitz0v6wJAUfXboXDb4y61S5PMAgCAfGPaq474+Hg99thj2rVrl2bMmKFOnTplWLdr164qX768PvnkEyUlJUmSEhMT9emnn6patWp2++ZVXQAoimISkhRy4qLteedapV0YDQAAKGpMO+T4jTfeUEhIiOrXr6+//vpLf/31l932Rx991HZrHx8fH73//vt64okndN9996lp06batm2boqKiNGvWLLuFnfKqLgAURRuPXVRismF73jGolAujAQAARY1pE9r27duratWqGW738PCwe964cWOtWbNGGzZsUGhoqNq3b69bb73V4UTnvKoLAEXN74evDTcu7eep+uUCXBgNAAAoakyb0GY0XzYzPj4+uu2221xaFwCKknVHriW0HYJKyWrN/mIOAAAAOWXaObQAAHNLTE7RlpOXbM/b1ijpumAAAECRREILAMiRnWeuKDYxxfa8TTXuPQsAAPIXCS0AIEc2p+md9XSz6qZKxVwXDAAAKJJIaAEAOZJ2uHGTisXk5e7mumAAAECRREILAMiRracu2x43qxzowkgAAEBRRUILAMi2+KRk7T4XaXvenIQWAAC4AAktACDb9p2PUlKKYXt+U0USWgAAkP9IaAEA2bbzzBXbY6tFalDe34XRAACAooqEFgCQbTvPXhtuXLu0n3w93V0YDQAAKKpIaAEA2ZZ2/mzDCtyuBwAAuAYJLQAg2/aEXkto65djuDEAAHANEloAQLbEJibrxKVY2/N6ZQNcGA0AACjKSGgBANly8EK0jGsLHKtOWT/XBQMAAIo0EloAQLYcDIuye167NEOOAQCAa5DQAgCy5VBYjO1x+QAvBXizwjEAAHANEloAQLYcCY+2PQ4q5evCSAAAQFFHQgsAyJajEdd6aGuQ0AIAABcioQUAZMuxiGsrHFcvQUILAABch4QWAJBlhmHoZJpb9lQt4ePCaAAAQFFHQgsAyLKImETFJaXYnlctTkILAABch4QWAJBlZ67E2T2vFOjtokgAAABIaAEA2XD2uoS2fICXiyIBAAAgoQUAZENoZLztsbvVopK+ni6MBgAAFHUktACALAuLTrA9Lu3nKavV4sJoAABAUUdCCwDIsrQJbSk/emcBAIBrkdACALIsIibR9riUr4cLIwEAACChBQBkQ9qEtoQPCS0AAHAtEloAQJZdjruW0BYnoQUAAC5GQgsAyLLLcUm2x4EktAAAwMVIaAEAWXYlTQ9toLe7CyMBAAAgoQUAZENk/LUe2gAvEloAAOBaJLQAgCyLik+2PfYnoQUAAC5GQgsAyLKohGs9tP6ebi6MBAAAgIQWAJBFickpSkw2bM/9POmhBQAArkVCCwDIkpiEZLvnPh78CgEAAK7F1QgAIEtiE+0TWnpoAQCAq5HQAgCyJCbx+h5a5tACAADXIqEFAGRJbGKK3XNfFoUCAAAuRkILAMiSuOt6aL3d+RUCAABci6sRAECWxCXZ99B6kdACAAAX42oEAJAl1/fQMocWAAC4GgktACBL6KEFAABmw9UIACBL4kloAQCAyXA1AgDIkrQJrcUiuVstLowGAABAcnd1ADdy7NgxrVy5UsePH1erVq3Uq1evdHVWrlypP/74I8PXuOuuu9S2bVtJUmRkpCZPnuyw3m233abbbrvNYQw//fSTzp8/r/Lly+vuu+9WlSpVcnhGAFAwpU1ovdysslhIaAEAgGuZNqFNSEjQ/fffr9jYWLVr105LliyRp6enw4S2SpUqatmyZbry+fPna+/evbrnnntsZXFxcVqyZIm6d++udu3a2dWvVKlSutdYvXq1nn76aXXt2lUtWrRQSEiI7rrrLs2YMUMdOnTIhTMFgIIhPvnaolAMNwYAAGZg2oTWarXqf//7n+rXr6+IiAgtWLAgw7oNGzZUw4YN7cqioqL06quvqmrVqmrdurXDfe67775MY4iIiNCLL76o7t27680335Qk9e/fX2PGjNFzzz2ntWvXyt/fPwdnBwAFT0KSYXtMQgsAAMzAtFck7u7uql+/fo73X758uWJjY9W3b98cD4tbuXKloqKiNGDAALvygQMH6uLFi1q9enWO4wOAgiYh+dqQY0830/76AAAARYhpe2id9d1338nDwyPDXtgNGzbo+PHjcnd3V+3atXXnnXeqePHidnW2bdsmq9WqevXq2ZU3atRIkrR9+3b17t07T+IHALOxS2jpoQUAACZQKBPaQ4cOaceOHeratatKly6dbntgYKCqVKmi2rVr68KFC5o5c6beffddvf/++3ZzcUNDQxUYGChPT0+7/b29vRUQEKCzZ89mGodhGIqNjc2dk8olcXFxdj9R9NAGkNM2EB2XYHvsYZXpvt+QNXwHgDYA2kDRZubP3zCMbI+uLZQJ7eLFiyVJ999/f7ptxYoV0+rVq1WiRAlb2bBhw9SrVy+NGTNGa9eulZ+fnyQpPj5e7u6O3yIPDw8lJCQ43JYqPj5ee/bsyelp5KkjR464OgS4GG0A2W0DZ0Kv2B4nJyaY9vsNWcN3AGgDoA0UbWb9/L29vbNVv9AltImJiVq6dKkqV66sW2+9Nd12Ly8veXl52ZX5+/vr4Ycf1quvvqqQkBB17txZkuTr66v4+HiHx4mLi7Mlvhnx8vJSUFBQDs8kb8TFxenIkSOqWbNmthsLCgfaAHLaBoqfOCgpSpIU4Ovj1DoHcB2+A0AbAG2gaDPz53/48OFs71PoEtrffvtNERERGjx4cLa6q8uVKydJunjxoq2sWrVq2rRpk6KiouxWM7548aJiYmJueC9ai8UiHx+fbJ5B/vD29jZtbMgftAFktw0Y1mvzZr083Gk/BRzfAaANgDZQtJnx88/JYr6FblWPxYsXy93d/Ya35Lnevn37JEmVK1e2lbVq1UqStGXLFru6mzdvliS1adPGmVABoEBJe9seD7ecrR4PAACQmwpVQhsaGqr169erU6dOKlu2rMM6f/zxh86dO2dXtmvXLs2dO1d16tRRixYtbOW33367qlSpopkzZ9qGHsfGxurjjz9W7dq11aFDh7w7GQAwmcQUbtsDAADMxdRDjt977z2dPXvWtvhSSEiInn/+eUnSgAEDbLfPSbVkyRIlJyerb9++Gb5mYmKihgwZIl9fX1WuXFkXLlzQ9u3bdfPNN+uNN96Qm5ubra6np6dmzpypJ554Qj169FDjxo31zz//yMvLSzNnzrSrCwCFXWIyPbQAAMBcTJ3QNmzY0DZPtW3btnbbSpYsma5+gwYN9MYbb6hdu3YZvuZtt92mzp07a9++fTp27Jg8PDw0ZcoUVa1a1WH92rVra8WKFdq6davOnz+v/v37q1mzZiSzAIqchKRrPbQeVnpoAQCA65k6oe3SpUu26meWyKZltVpVv379LK/Q6e7ubptPCwBFVdohx/TQAgAAM+BP7ACALElKuTbkmDm0AADADLgiAQBkSdo5tO700AIAABMgoQUAZEliMnNoAQCAuXBFAgDIkrRDjumhBQAAZkBCCwDIkrQJLT20AADADLgiAQBkSdohx/TQAgAAMyChBQBkid2QYysJLQAAcD0SWgBAljDkGAAAmA1XJACALEk75Jjb0AIAADPgkgQAkCV2PbRktAAAwAS4IgEAZElSMnNoAQCAuZDQAgCyhEWhAACA2ZDQAgCyJCklzW17WBQKAACYAFckAIAsSdtDyxRaAABgBlySAACyhEWhAACA2XBFAgDIEhaFAgAAZkNCCwDIEhaFAgAAZkNCCwDIkmQjbULLrw8AAOB67tndoU6dOk4dcP/+/U7tDwBwjbRDjplCCwAAzCDbCW2qXr16Zav+kiVLcnooAIAJcNseAABgNjlOaKdOnZqt+iS0AFBwGYahNFNo5e7GHFoAAOB62U5o27Ztm6MD5XQ/AIDrJafNZiW5WUhoAQCA62U7oZ09e3aODpTT/QAArpd2QSiJVY4BAIA55GgSVEJCQrbqb9q0KSeHAQCYRNoFoSTJjYQWAACYQI4S2nHjxik5OTlLdUNCQjRy5MicHAYAYBJJKfTQAgAA88lRQvvzzz/r5ZdflnHdELTrbd68WSNGjJCnp2eOggMAmMP1Q47poQUAAGaQo4R20KBB+v777zNd6XjLli22ZHbu3Lk5DhAA4HoMOQYAAGaUo9v2vPjii4qMjNS8efNUrFgxPfHEE3bbt2zZomHDhsnd3V1z5sxRgwYNciVYAIBrsCgUAAAwoxwltBaLRZMnT1ZUVJRmzJih4sWLa8CAAZKkrVu32iWzDRs2zNWAAQD5L10PLbftAQAAJpCjhFaS3NzcNH36dA0fPlyvvfaaAgICVLlyZQ0bNkxubm6aPXu2GjVqlJuxAgBchDm0AADAjHKc0EqSp6enPvzwQz3yyCN64YUX5OnpKTc3N82ZM0eNGzfOrRgBAC7GKscAAMCMcrQoVEREhO1ffHy83nzzTVWoUEEpKSmaNm2aKleubFcnIiIit+MGAOSj5BR6aAEAgPnkqIe2TZs2GW4bPny4w/L9+/fn5FAAABO4PqGlhxYAAJhBjhLajh075nIYAAAzYw4tAAAwoxwltB9//HFuxwEAMDGGHAMAADPK0RxaAEDRwqJQAADAjEhoAQA3lK6HlvvQAgAAE8h2QnvPPffonnvuyfaBcrofAMD1GHIMAADMKNtzaPft25ejA+V0PwCA67EoFAAAMKMcLQolSSNGjMjNOAAAJsaQYwAAYEbZTmiLFy8uSfrnn39ytB8AoOBhyDEAADCjbCe0ISEheREHAMDEGHIMAADMiFWOAQA3xJBjAABgRiS0AIAbSrbPZ+XGbw8AAGACOV4UKr/s2bNHK1eu1PHjx3XrrbeqX79+6epcuXJFL7/8ssP9u3Xrpu7du6cr37dvn3788UeFhoaqQoUKuueee1S7dm2Hr5GdugBQGDGHFgAAmJFp/8YeHx+vrl276sUXX5TFYtHq1au1e/fuDOuuXr1aPj4+6t69u92/4ODgdPWXLl2q3r17KyoqSu3bt1dERIR69eql1atXO1UXAAorhhwDAAAzMm0Prbu7uz7++GNVr15dERER+vjjj2+4T3BwsLp165ZpnbCwME2aNEm9evXSq6++Kkm65557lJiYqJdfflmtW7dWYGBgtusCQGHGolAAAMCMTNtD6+bmpurVq+f66y5fvlwxMTHphi4/8MADunLlil3Pa3bqAkBhlraH1mKRLPTQAgAAEzBtD21O/P7779q7d6/c3d1Vu3Zt3X333SpbtqxdnZ07d8rNzU1169a1K2/YsKEsFov++ecf3X///dmuCwCFWdqEluHGAADALHItod2xY4d+//13nTt3TomJiXr77bcVEhKi5ORktWrVSm5ubrl1KIfKlCmjhg0bqnbt2goLC9OiRYv04Ycf6t1331X79u1t9c6dO6fAwEB5eHjY7e/l5SV/f3+FhobmqK4jhmEoNjY2F84u98TFxdn9RNFDG0BO2kBsfLztsZvVYrrvNmQd3wGgDYA2ULSZ+fM3DCPbo8CcTmiTk5P10ksvacmSJXblb7/9tr744gutXr1aH374oW677TZnD5WhwMBArVq1Sv7+/rayhx56SL1799b48eP166+/2rYlJiZmmFy7u7srISHB9jw7dR2Jj4/Xnj17sns6+eLIkSOuDgEuRhtAdtrAyVMxtscWwzDtdxuyju8A0AZAGyjazPr5e3t7Z6u+0wnt7NmztWTJEjVv3lzvvvuu2rVrZ9vWt29frV69Wt9++22eJrSenp7y9PS0K/Px8dFDDz2kSZMmadOmTbbj+/r6ZvjXiLi4OPn5+dmeZ6euI15eXgoKCsrOqeS5uLg4HTlyRDVr1sx2Y0HhQBtATtpASMxpSZckSR7uVtWvXz/vAkSe4jsAtAHQBoo2M3/+hw8fzvY+Tie03333nSTppZdeSjdfNfVerf/884+zh8mRMmXKSJIuX75sK6tWrZr++usvRUZGKiAgwFYeERGh2NhYVatWLUd1HbFYLPLx8cmt08lV3t7epo0N+YM2gOy0ATf3a78u3KxW2k4hwHcAaAOgDRRtZvz8c7LopNOrHJ8+fVqSVKtWrXTbSpYsKUmKjo529jA5knrf2rSJZ5s2bSRJISEhdnU3bdokSbrllltyVBcACrPklGuP3VgTCgAAmITTCW3qsNsrV66k23bhwgVJUqlSpZw9TKZ+/vlnHTt2zK5sy5Ytmjdvnho1aqRmzZrZyrt06aKaNWvqo48+UkzM1TlhUVFRmjlzpurXr283ZDo7dQGgMLNb5Zh70AIAAJNweshxy5YttWbNGv3yyy964IEH7Lb9+uuvkqTWrVvn6LXfeOMNnT592rb40saNG/Xkk09KkoYMGaKbbrpJ0tW5qmPHjlVCQoIqV66sCxcuaN++ferYsaNef/11Wa3X8nYPDw/NnDlTo0ePVteuXdWgQQPt2rVLZcqU0QcffJDjugBQmCUbJLQAAMB8nE5oH3/8cf3++++aOnWq3W0cvv76a02fPl0+Pj4aMWJEjl67Xbt2tp7fe++9125bhQoVbI/bt2+v9u3b69ixYzp+/Ljc3d0VHBxsm0N7verVq+vHH3/Url27dP78eY0ePVr169d3OGY7O3UBoLDiPrQAAMCMnE5o69Wrp1mzZumFF17Q1KlTbeUTJ05UuXLl9Oabb6pmzZo5eu3szlGtXr26qlevnqW6FotFjRo1yvW6AFAYMeQYAACYkdMJ7apVq5SSkqK1a9fq77//1uHDh2UYhqpXr642bdqku50OAKDgSUkz5NhKDy0AADAJpxPacePGKTk5Wfv379ett96qW2+9NTfiAgCYCHNoAQCAGTm9qlGlSpUkSeHh4U4HAwAwJ27bAwAAzMjphHbAgAGSrg49BgAUTsyhBQAAZuT0kOPmzZurW7dumjp1qs6cOaM2bdooMDAwXT0WVQKAgiuFIccAAMCEnE5o+/TpY3v82Wef6bPPPnNYb//+/c4eCgDgIsksCgUAAEzI6YR2woQJuREHAMDEGHIMAADMyOmEduDAgbkRBwDAxOwSWnpoAQCASTi9KBQAoPBLk8/SQwsAAEzD6R7aoUOHZqne7NmznT0UAMBF7OfQujAQAACANJxOaPft25euLC4uTlFRUZKkUqVKycLwNAAo0JhDCwAAzMjphHbDhg0Oy/ft26cxY8aocuXK+uCDD5w9DADAhZhDCwAAzCjP5tDWrVtXkyZN0vr16/XWW2/l1WEAAPmA2/YAAAAzytNFoRo3bixJWr58eV4eBgCQx1JSrj12YzlBAABgEnl6WRIWFiZJio+Pz8vDAADyWNoeWubQAgAAs3B6Dm1ERITD8lOnTunNN9+UJDVv3tzZwwAAXCjtHFqGHAMAALNwOqFt06ZNpttr1qypCRMmOHsYAIALsSgUAAAwI6cT2mHDhqUrs1qtKlmypGrUqKF27drJamXCFQAUZCkMOQYAACbkdEI7fvz43IgDAGBizKEFAABm5HTX6eTJkzV58uQcbwcAmJ/9HFoXBgIAAJCG0wnt/PnzNX/+/BxvBwCYX5p8ljm0AADANPJ0cmvq7Xo8PDzy8jAAgDxmtygUXbQAAMAkcjSHdsuWLTcsS0lJ0YYNGyRJ1atXz8lhAAAmwRxaAABgRjlKaAcMGJClMklyd3fXyJEjc3IYAIBJpF3lmPvQAgAAs8hRQvv666/bHr/88svpyiTJYrEoMDBQTZo0UdmyZZ0IEQDgatyHFgAAmFGOEtq+ffvaHu/duzddGQCgcElOufbYjVuLAwAAk3D6PrQTJ07MjTgAACbGkGMAAGBGTie0qRISEnTgwAGdP39eCQkJ6bZ369Yttw4FAMhnLAoFAADMKFcS2nnz5mnmzJm6dOlShnX279+fG4cCALhACrftAQAAJuT0TKjFixdrypQp8vLy0pQpU2zlU6dOVenSpXXXXXfp008/dfYwAAAXSr6Wz4p8FgAAmIXTCe2CBQskSa+++qruu+8+W3mvXr300ksv6aefftLFixedPQwAwIVY5RgAAJiR0wntkSNHJEnNmzeXdPV2PZKUkpKi1q1bS5I+++wzZw8DAHAhFoUCAABm5HRCGxAQIEky/rvY8fX1lSRFR0fL399fknT8+HFnDwMAcKFk5tACAAATcjqhrVu3riTp8OHDkqRatWpJuroIVGpZqVKlnD0MAMCFWOUYAACYkdMJbZ8+fSRJ33zzjSTpnnvukSQ9++yzGjNmjCTpzjvvdPYwAAAXSmFRKAAAYEJO37bnjjvu0Ny5c+XufvWlHnzwQYWGhmrx4sWyWCzq37+/nnzySacDBQC4DotCAQAAM3I6oV27dq1SUlLUvXt3SVcXhRo3bpzGjRvndHAAAHNIm9Ba6aIFAAAm4XRCO27cOCUnJ9sSWgBA4WM3h5YeWgAAYBJOz6GtVKmSJCk8PNzpYAAA5mR/2x4XBgIAAJCG0wntgAEDJEmrVq1yOhgAgDlx2x4AAGBGTg85bt68ubp166apU6fqzJkzatOmjQIDA9PVa9SokbOHAgC4SNpVjkloAQCAWTid0KbetkeSPvvsM3322WcO6+3fv9/ZQwEAXIRVjgEAgBk5ndBOmDAhN+IAAJhYst0cWhJaAABgDk4ntAMHDsyNOAAAJpbCHFoAAGBCTie010tISFBiYqL8/Pycfq2UlBRt3rxZK1eu1PHjx9WpUycNHjzYYd2DBw9q1apVOnjwoDw8PBQUFKQHHnhAJUuWtKt3+fJljRkzxuFr3Hvvvbr33nvTlW/ZskVLly5VaGioypcvr969e6tJkyZOnx8AFBTJdnNoXRcHAABAWrlyWXLmzBm98MILatOmjRo1aqRmzZpJkl577TU9+eSTCgsLy/ZrxsfHq0OHDvrwww9VqVIl/fXXXzp8+LDDujNmzNBdd92lAwcOqFu3burQoYP+/PNP3Xbbbfrrr7/s6iYkJOivv/5S1apVNXz4cLt/zZs3T/faX375pQYNGqRixYqpf//+8vX1Vf/+/bVkyZJsnxMAFFQp3IcWAACYkNM9tCdPntT999+vixcvqlOnTvr1119t20qUKKGFCxeqXr16euyxx7IXmLu7lixZotKlSysiIkLTpk3LsG5MTIw++OAD3X777baybt266Z577tFLL72kX375RZbrLsCqVaumW265JdMYzp07p6lTp+rBBx/UM888I0nq1KmToqOj9eqrr6pDhw7peoABoDBKuygUc2gBAIBZON1DO336dEVEROjJJ5/UzJkz7bZ16dJFkrRy5cpsv66bm5tKly6dpbpjx461S2YlydPTU82bN9fp06dz1EMsScuXL1d8fLx69+5tV963b1/FxMRw710ARYZdDy1zaAEAgEk43UO7ceNGSVeTvOtVqVJFknTs2DFnD5Mpb29vh+UHDhyQh4eHAgIC0m1btWqVNm/eLDc3N9WuXVu9e/dW1apV7er8+++/cnNzU3BwsF153bp1ZbFYtHPnTj344IO5dyIAYFLJKdcek88CAACzcDqhjY6OliQVK1Ys3Tbjv7/oW635v4LIihUrtGPHDvXs2TNdwlulShV17txZtWvX1oULF7Ro0SLNnTtXb775prp162ard/78eQUGBsrNzc1uf09PTwUEBOjChQuZxmAYhmJjY3PvpHJBXFyc3U8UPbQB5KQNpL1tT3JSkum+25B1fAeANgDaQNFm5s/fMIx0U0VvxOmEtlKlSjp27JiOHj2qunXr2m07cuSIJKlGjRrOHiZb9u/frwkTJqhcuXJ64YUX7LYVL15cy5cvl5eXl62sT58+6tu3r1588UW1adNGgYGBkqSkpKR0yWwqd3d3JSQkZBpHfHy89uzZ4+TZ5I3UzwZFF20A2WkDaW/bc/bMae3xiMiLkJCP+A4AbQC0gaLNrJ9/RqNvM+J0Qtu9e3d99NFHmjVrlt555x27bXPnzpUk9ejRw9nDZNmxY8c0dOhQeXp6as6cOekWbfLw8Ei3j4eHhx588EFNmDBBISEhuuOOOyRJ/v7+GfZCxMTEyN/fP9NYvLy8FBQUlMMzyRtxcXE6cuSIatasme3GgsKBNoDstgHDMGTojO151SqVVb9+ubwMEXmI7wDQBkAbKNrM/PlndFebzDid0A4bNkzr1q3TypUrtW/fPlt5r169tGfPHjVr1kyDBg1y9jBZcvLkSQ0ePFhJSUn6/PPPVatWrSzvW6JECUlSVFSUraxatWrasGGDLl26pOLFi9vKL1y4oLi4OFWvXj3T17RYLPLx8cnWOeQXb29v08aG/EEbQFbbQNoVjiXJx8uLtlMI8B0A2gBoA0WbGT//7A43lnJhlWNfX18tXLhQjz/+uJKSkmzlly5d0siRIzV37lx5eno6e5gbOnfunAYPHqy4uDjNmzdPderUydb+O3bskGQ/PLpt27aSlO5etqkLYbVv396ZkAGgQLg+oWVRKAAAYBZO99BKko+Pj8aMGaMxY8bY5pXmRxKbKiwsTIMHD1Z0dLQ+//zzdHN50/rxxx8VFBSkBg0a2Mp+++03ff7552rZsqWaNm1qK+/YsaPq1aunDz74QG3atFHx4sUVERGhjz76SE2bNlXr1q3z9LwAwAzS3rJH4rY9AADAPHIloZWk5ORk7d69W6dOnZIkVa5cWQ0aNMhwUaWsmDhxok6cOGHr+f3999/18MMPS5JGjRqlFi1aSJLeeOMNHTt2TFWrVtXUqVPTvc6rr75quyVPhQoVNHnyZJ08eVKVKlXShQsXFBoaqh49euill16y28/NzU0zZ87UuHHjdPvtt6t27do6cOCA6tWrp+nTp+eoSxwACpr0PbR89wEAAHPIlYT2559/1uTJk3X27Fm78goVKuill17S7bffnqPX7d27t+22QNdLOzT40UcfVa9evTJ8nVKlStke33zzzfryyy8VERGhY8eOyd3dXUFBQfLz83O4b4UKFbRo0SIdP35c58+fV/ny5W331wWAoiCZHloAAGBSTie0v/zyi0aPHi1J6tmzp2655RZJV+eZLlu2TKNHj9aHH36oLl26ZPu1mzRpkqV62Z0vK0klS5ZMtwJyZqpVq6Zq1apl+zgAUNBd10ErN3poAQCASTid0L7//vsyDENPPfWURo4caSvv1auXgoKC9M477+iDDz7IUUILAHA9FoUCAABm5fQqx4cOHZJ0dXjw9e677z67OgCAgodFoQAAgFk5ndCWKVNGkhwu/uTu7m5XBwBQ8LAoFAAAMCunE9r+/ftLklauXJlu24oVKyRJAwYMcPYwAAAXYVEoAABgVk7PoW3durW6du2qKVOm6PTp03aLQs2fP19du3ZVy5Yt9e+//9rt16hRI2cPDQDIBykp9s/JZwEAgFk4ndD27dvX9nj27NmaPXu23fbVq1dr9erV6fbbv3+/s4cGAOQDemgBAIBZOZ3QTpgwITfiAACY1PVzaLltDwAAMAunE9qBAwfmRhwAAJO6fpVjFoUCAABm4fSiUACAwi1dDy1DjgEAgEmQ0AIAMpVsn8+S0AIAANNwesixJG3YsEFffPGFjhw5ooiICKVcvySmpC1btuTGoQAA+Sz9kGMXBQIAAHAdpxPa+fPna/LkyZKk+vXrq3nz5rIwvwoACg2GHAMAALNyOqH97LPPJEmTJ09Wnz59nA4IAGAu1/fQssoxAAAwC6fn0F6+fFmS1L17d6eDAQCYT/J1s0hY5RgAAJiF0wltgwYNJEkRERFOBwMAMJ/k63toWU4QAACYhNOXJePHj5e3t7dmzpzpcDEoAEDBlsIcWgAAYFJOz6Ft1qyZFi5cqCFDhmjnzp1q3LixvLy80tWbOHGis4cCALjA9T20DDkGAABm4XRCe/jwYY0dO1ZXrlzRlStXdODAAYf1SGgBoGBKt8oxCS0AADAJpxPaSZMm6dSpU+rUqZPGjh2rChUqcNseAChEuG0PAAAwK6cT2p07d0qS/u///k/lypVzOiAAgLlcl8+KfBYAAJiF04tClSpVSpLk4+PjdDAAAPNJv8oxGS0AADAHpxPagQMHSpJ+//13Z18KAGBCzKEFAABm5fSQ45tvvll33nmnJk2apPPnz+umm25yuMpxo0aNnD0UAMAFUq5f5ZgeWgAAYBJOJ7R9+vSxPX7rrbcyrLd//35nDwUAcAF6aAEAgFk5ndBOmDAhN+IAAJgUc2gBAIBZOZ3Qps6hBQAUTqxyDAAAzMrpRaGul5CQoOjo6Nx+WQCAi6QdcmyxiHuNAwAA03C6h1aSzpw5o/fff1+///67IiIiJF2dM/vaa6/pwoULmjhxokqXLp0bhwIA5LO0Ca2VZBYAAJiI0z20J0+eVO/evbVkyRLddNNNdttKlCih1atX69tvv3X2MAAAF0k7h5YFoQAAgJk4ndBOnz5dERERevLJJzVz5ky7bV26dJEkrVy50tnDAABcJCXl2mO3XJ+oAgAAkHNOX5ps3LhRktS3b99026pUqSJJOnbsmLOHAQC4SNoeWoYcAwAAM3E6oU1dAKpYsWLpthn/XQRZrfxJHwAKqrRzaLllDwAAMBOnM81KlSpJko4ePZpu25EjRyRJNWrUcPYwAAAXSWEOLQAAMKkcJbQXLlzQhQsXJEndu3eXJM2aNcvWI5tq7ty5kqQePXo4EyMAwIXsVzl2YSAAAADXydFte9q2bSvp6q15hg0bpnXr1mnlypXat2+frU6vXr20Z88eNWvWTIMGDcqdaAEA+c5ulWMyWgAAYCJODzn29fXVwoUL9fjjjyspKclWfunSJY0cOVJz586Vp6ens4cBALgIc2gBAIBZ5aiH9no+Pj4aM2aMxowZo4SEBEkiiQWAQiJNPsscWgAAYCq5ktCmRSILAIULPbQAAMCsnEpo582bl+W6Dz/8sDOHAgC4CPehBQAAZuVUQjtlypQs1yWhBYCCiR5aAABgVk4ltNOnT8+tOAAAJmU/h9Z1cQAAAFzPqYSW+8sCQOFHDy0AADArp2/bAwAo3LgPLQAAMCsSWgBAplJYFAoAAJhUrt+2JzclJCRo/fr1WrlypY4fP67bb79dw4YNy7D+n3/+qR9++EGhoaEqX768evfurTZt2uRrXQAobBhyDAAAzCpHPbT79+/X/v37czsWO3FxcerYsaO++eYbNWnSRDt27NDJkyczrD9nzhyNGDFCNWvW1OjRo1W1alUNHTpUixYtyre6AFAY2SW09NACAAATMW0Praenp1avXq2AgABFRETotddey7Du6dOnNX36dA0ePFhPPPGEJKlVq1a6dOmS3njjDd12220qU6ZMntYFgMKKObQAAMCsTDuH1mq1KiAgIEt1ly9frsTERPXq1cuu/L777lNsbKxWrVqV53UBoLBKTrn2mNv2AAAAMzFtQpsdu3btkru7u4KCguzK69SpI6vVql27duV5XQAorJhDCwAAzMq0Q46zIywsTIGBgXJzc7Mr9/DwkL+/vy5cuJDndR0xDEOxsbE5Pa08ERcXZ/cTRQ9tANltAwlJideemPB7DdnDdwBoA6ANFG1m/vwNw5Alm+t1FIqENikpSVar485mNzc3JSYm5nldR+Lj47Vnz54bhe8SR44ccXUIcDHaALLaBsLDL9kex8VEm/Z7DdnDdwBoA6ANFG1m/fy9vb2zVb9QJLQBAQGKiYlxuC0mJsZuLm5e1XXEy8sr3XBlV4uLi9ORI0dUs2bNbDcWFA60AWS3DQTs2yPp6ndhsQB/1a9fP48jRF7iOwC0AdAGijYzf/6HDx/O9j6FIqGtUaOG1q9fr4iICJUsWdJWHhoaqvj4eNWoUSPP6zpisVjk4+OTG6eY67y9vU0bG/IHbQBZbQOWNCNVPNzdaTeFBN8BoA2ANlC0mfHzz+5wY6mQLArVrl07SdLGjRvtyjds2CBJ6tChQ57XBYDCitv2AAAAsyoUCW379u3VpEkTvf/++7aFmkJDQ/XBBx+oVatWatmyZZ7XBYDCitv2AAAAszL1kONnn31Wx44dU1JSkiRp7dq12rdvnyRp3Lhxat26taSrXdMffvihnn/+ed1xxx2qVq2ajh07ptatW2vKlCl2r5lXdQGgsOK2PQAAwKxMndAOHTo0w9tDVK9e3e55mTJlNHv2bJ0/f14XLlxQuXLlVLp0aYf75lVdACiMGHIMAADMytQJbZ06dbK9T9myZVW2bFmX1gWAwsSuhzYHizUAAADklUIxhxYAkHdS0vTQWkloAQCAiZDQAgAyxRxaAABgViS0AIBMMYcWAACYFQktACBTzKEFAABmRUILAMiU3X1o+a0BAABMhEsTAECmGHIMAADMioQWAJAphhwDAACzIqEFAGSKVY4BAIBZkdACADLFkGMAAGBWJLQAgEwx5BgAAJgVCS0AIFMMOQYAAGZFQgsAyBRDjgEAgFmR0AIAMsWQYwAAYFYktACATDHkGAAAmBUJLQAgU8nX8lm58VsDAACYCJcmAIBMMeQYAACYFQktACBTLAoFAADMioQWAJAp5tACAACzIqEFAGQqiSHHAADApEhoAQCZoocWAACYFQktACBTJLQAAMCsSGgBAJlKuyiUOwktAAAwERJaAECmmEMLAADMioQWAJAphhwDAACzIqEFAGQqbULLkGMAAGAmJLQAgEylnUNLDy0AADATEloAQIYMw1CafJaEFgAAmAoJLQAgQ2mHG0sMOQYAAOZCQgsAyFDSdQktqxwDAAAzIaEFAGTo+h5ahhwDAAAzIaEFAGQo7YJQEgktAAAwFxJaAECGmEMLAADMjIQWAJChdHNoSWgBAICJkNACADKUbg4ti0IBAAATIaEFAGTo+h5ahhwDAAAzIaEFAGSIVY4BAICZkdACADLEHFoAAGBmJLQAgAylu20Pc2gBAICJkNACADKUlHzdHFo3EloAAGAeJLQAgAxd30PLolAAAMBMSGgBABlK10NLQgsAAEyEhBYAkKF0c2hJaAEAgImQ0AIAMsR9aAEAgJmR0AIAMsR9aAEAgJm5uzqA3DBv3jwtXrw4w+3Dhw9Xz549JUkXL17UQw895LBe//79NWDAgHTla9as0ffff6/z58+rfPny6tOnjzp37pw7wQOAiSWlpNg9d7fyd1AAAGAehSKhveuuu3TLLbekK3/55Ze1Y8cOBQcH28qSkpJ08OBBDRkyRL169bKrX6pUqXSv8eGHH2rmzJkaP368mjdvrpCQEI0ePVrPPPOMHn744Vw/FwAwk2T7fJYhxwAAwFQKRUJbunRplS5d2q4sNDRUu3btUpMmTVS3bl2H+6RNdB05ceKEPvroIz366KO25LVRo0YKCwvTtGnTdOedd6pcuXK5dh4AYDbX99Ay5BgAAJhJoR07tmTJEiUnJ6tv3745fo0VK1YoKSlJd999t135Pffco4SEBK1cudLZMAHA1FgUCgAAmFmh6KF15Pvvv5e/v7969OjhcPt3332n5cuXy93dXbVr11a/fv3UuHFjuzq7d++Wh4eHatasaVdeq1YtWa1W7d69O8/iBwAzYFEoAABgZoUyod28ebOOHz+uBx54QL6+vum2N2zYUA888IBq166tsLAwLViwQP369dOkSZPUr18/W72wsDAVK1ZM1usWQfHw8JC/v7/Cw8MzjcMwDMXGxubOSeWSuLg4u58oemgDyE4biI6Lt3ueGB8nJRXawT1FAt8BoA2ANlC0mfnzNwxDFkv2/nheKBPa7777TpLsktNUJUuW1LfffmuXpHbp0kUDBw7U5MmT1aVLF9t83JSUlHTJbCo3NzclJiZmGkd8fLz27NmT09PIU0eOHHF1CHAx2gCy0gaOn7D/o9z+fXtlzeYvGpgT3wGgDYA2ULSZ9fP39vbOVv1Cl9BGRUVp9erVatiwoerXr59uu5ubW7oyi8Wi++67T1u2bNHmzZvVvXt3SZK/v7+io6MdHic6OlrFihXLNBYvLy8FBQXl4CzyTlxcnI4cOaKaNWtmu7GgcKANIDttYFfiOUkXJUlWi9SwQYN8iBB5ie8A0AZAGyjazPz5Hz58ONv7FLqEdvny5YqNjXXYO5sZf39/SVd7VVPVrFlT69evV1hYmN0qymfPnlVCQsINk1WLxSIfH59sxZFfvL29TRsb8gdtAFlpA1b3a78m3K1W2kwhwncAaAOgDRRtZvz8szvcWCqEqxwvXrxYvr6+GS4GlZHNmzdLkt2tfDp27ChJWr9+vV3dP//80247ABRWaVc5dit0vzEAAEBBV6guTw4ePKidO3fqrrvukp+fn8M6X3zxhf744w8lJydLujrx+Ntvv9WiRYvUpUsXNUgznO7WW2/VzTffrBkzZuj06dOSpJMnT+rDDz9U+/bt1axZs7w/KQBwobQJrQcZLQAAMJlCNeR48eLFkqT7778/wzrNmjXTzJkzNXbsWJUqVUphYWHy8vLSI488oieffDJd/ffff1+vvPKK7rzzTpUvX16hoaHq0qWL/u///i/PzgMAzCJtQss9aAEAgNkUqoR24MCB6tu3r2rVqpVhnXr16mnGjBlKTk7WmTNn5O7urvLly2c4XrtEiRKaMWOGIiMjFRYWpjJlytjm2wJAYZeUTEILAADMq1AltFWqVMlyXTc3t2zVDwgIUEBAQE7CAoACK9lIm9Ay5BgAAJgLVycAgAyl7aFlCi0AADAbLk8AABlKSkmxPWZRKAAAYDZcnQAAMsSiUAAAwMxIaAEAGUpkUSgAAGBiJLQAgAylHXLMolAAAMBsuDoBAGTIbsixGz20AADAXEhoAQAZSpvQejDkGAAAmAwJLQAgQywKBQAAzIyEFgCQocTkNHNouW0PAAAwGa5OAAAZoocWAACYGQktACBDaW/b48GiUAAAwGRIaAEAGeK2PQAAwMy4OgEAZIgeWgAAYGYktACADKVdFMqDHloAAGAyXJ0AADLEolAAAMDMSGgBABliyDEAADAzEloAQIbshhxzH1oAAGAyXJ0AADLEkGMAAGBmJLQAgAzRQwsAAMyMqxMAQIYSU5hDCwAAzIuEFgCQoYQkbtsDAADMi6sTAECG6KEFAABmRkILAMgQc2gBAICZcXUCAMgQ96EFAABmRkILAMiQXQ8tc2gBAIDJcHUCAMgQc2gBAICZkdACADKUdpVjT3d+ZQAAAHPh6gQAkKHElDQJLYtCAQAAk+HqBACQoYQkhhwDAADzIqEFADhkGAY9tAAAwNS4OgEAOJScYsi41kFLQgsAAEyHqxMAgEMJaW7ZI7EoFAAAMB+uTgAADiUmG3bPPazMoQUAAOZCQgsAcCg+yb6H1oseWgAAYDJcnQAAHEo35Jg5tAAAwGS4OgEAOMQcWgAAYHZcnQAAHGLIMQAAMDuuTgAADjHkGAAAmB1XJwAAh67voSWhBQAAZsPVCQDAIYYcAwAAs+PqBADgEAktAAAwO65OAAAOkdACAACz4+oEAOAQCS0AADA7rk4AAA6lTWgtFsndanFhNAAAAOm5uzqA3BAREaF7773X4bZHHnlEjzzyiF2ZYRj67rvvtGTJEoWGhqpChQrq3bu3w9fITl0AKEzSJrTe7lZZLCS0AADAXApFQpucnKzQ0FA99thjeuCBB+y2+fv7p6v/1ltv6YsvvtDEiRPVokULhYSEaMKECTp16pRGjRqV47oAUJjEJiXbHvt4uLkwEgAAAMcKRUKbKiAgQOXLl8+0zuHDhzV37lyNGjVKvXv3liRVq1ZNp06d0qxZs3TvvfeqcuXK2a4LAIVNXOK1hNbbnYQWAACYT5GbQ7ty5UqlpKSoe/fuduV33XWXEhMTtWrVqhzVBYDCJi7tkGOPIvfrAgAAFACFqof2iy++0FdffSU3NzcFBwfrgQce0C233GJXZ+/evfLw8FD16tXtymvWrCk3Nzft3bs3R3UBoLCJTdNDywrHAADAjApNQtu6dWs9+OCDqlWrlsLCwrRgwQI98sgjevbZZzV06FBbvfDwcAUGBqZb3MTd3V3+/v6KiIjIUV1HDMNQbGxsLpxd7omLi7P7iaKHNoCstoHI2ATbYx93q+m+z5AzfAeANgDaQNFm5s/fMIxsL0JZKBLa0qVL6/PPP7c9DwoKUqtWrTR06FC98847uuuuu1SuXDlJmb9JFotFycnXeiSyU9eR+Ph47dmzJ7unky+OHDni6hDgYrQB3KgNnA69ZHtsJMSZ9vsMOcN3AGgDoA0UbWb9/L29vbNVv1AktBklnXfddZfWr1+vLVu2qEePHpKkYsWKaf/+/enqGoah6OhoBQYG2sqyU9cRLy8vBQUFZedU8lxcXJyOHDmimjVrZruxoHCgDSCrbcBr725JMZKkUsUDVL9+/XyKEHmJ7wDQBkAbKNrM/PkfPnw42/sUioQ2I6kfUGJioq2sVq1aWrdunc6fP6+yZcvayk+fPq3ExES7BDQ7dR2xWCzy8fHJrdPJVd7e3qaNDfmDNoAbtYGElGt/LAzw9qC9FDJ8B4A2ANpA0WbGzz8n97wv1Kt8bNy4UZLsehU6deokSfrjjz/s6qY+79KlS47qAkBhE5NmUShf7kMLAABMqFAktHPmzNGyZcsUFRUl6Wo3+uzZs/Xtt9/q7rvvVnBwsK1uy5Yt1a5dO7333ns6ePCgJGnfvn368MMP1bVrVzVq1ChHdQGgsEm7yrGvJwktAAAwn0Ix5LhTp06aPXu2Xn/9dUnSlStXVKFCBT311FMaMmRIuvrvvvuupkyZor59+8rb21vx8fHq2bOnnn/+eafqAkBhEpNADy0AADC3QpHQ1qhRQ6+//rpef/11Xbp0yXZbnYz4+/tr8uTJmjRpkq5cuaLAwEC5uzt+K7JTFwAKk+g0Ca0PCS0AADChQpeZFS9ePMt1PTw8VKpUqVyvCwCFQWR8ku1xgFeh+3UBAAAKgUIxhxYAkPtIaAEAgNmR0AIAHEqb0BbzJqEFAADmQ0ILAEgnISlF8Ukptuf00AIAADMioQUApJO2d1YioQUAAOZEQgsASOdK3HUJLUOOAQCACZHQAgDSuRibYPe8pK+HiyIBAADIGAktACCdiJhEu+clfUhoAQCA+ZDQAgDSuRhrn9AWJ6EFAAAmREILAEgnPPrakOMAL3e5u/HrAgAAmA9XKACAdM5eibc9Lh/g5cJIAAAAMkZCCwBI59TlWNvjysW9XRgJAABAxkhoAQDpnLoUZ3tcOdDHhZEAAABkjIQWAJDO6SvXEtpKgfTQAgAAcyKhBQCkc+pSmiHHJLQAAMCkSGgBAHYuRMXrclyS7XmV4gw5BgAA5kRCCwCws/30ZbvnTSoWc1EkAAAAmSOhBQDY2XbqWkJb0tdDVUvQQwsAAMyJhBYAYGfV/gu2x80qBcpisbgwGgAAgIyR0AIAbP48Eq4/DofbnveoX86F0QAAAGTO3dUBIH8di4jVwr1RKhZ6RB4eHq4OBy6QmJio8xciVZY2UOgZjsqMa22g5JnDsrq5KSYxWZdjk3TyUqx+S5PMerhZ9MBNFfMvYAAAgGwioS1CYhOT1eXTLTobGS/piqvDgctFujoAuFzmbeC5TrVUvhi37AEAAOZFQluExCUmKzQq3tVhADA5N6tF4zsEaVLXOq4OBQAAIFMktEVICV9Pvdezrt5fd0iGmycLvRRRhmEoPj5eXl5etIGiyjCUkJAgX28vubu5ydvDqkBvd5Xw8VSTisV0X6PyqlsuwNVRAgAA3BAJbREz9ObKauN3RfXr15ePD7fiKIpiY2O1Z88e2kARRhsAAACFBascAwAAAAAKJBJaAAAAAECBREILAAAAACiQSGgBAAAAAAUSCS0AAAAAoEAioQUAAAAAFEgktAAAAACAAomEFgAAAABQIJHQAgAAAAAKJBJaAAAAAECBREILAAAAACiQSGgBAAAAAAUSCS0AAAAAoEAioQUAAAAAFEgktAAAAACAAomEFgAAAABQIJHQAgAAAAAKJBJaAAAAAECBZDEMw3B1EIXR9u3bZRiGvLy8XB2KHcMwFB8fLy8vL1ksFleHAxegDYA2ULTx+YM2ANpA0Wbmzz8+Pl4Wi0VNmzbN8j7ueRhPkWa1WpWSkuLqMNKxWCzy9vZ2dRhwIdoAaANFG58/aAOgDRRtZv78LRaLrNbsDSKmhxYAAAAAUCAxhxYAAAAAUCCR0AIAAAAACiQSWgAAAABAgURCCwAAAAAokFjluIgxDEPR0dHy9/d3dShwkejoaMXHxyswMFBubm6uDgf5LCUlRUlJSfL09HR1KHCRxMREGYZBGyji4uPjFR0dLU9PT64JiohLly45vAMHbaBoSkpKUkpKSqH4XcAqx0XElStXNHXqVK1cuVKS5OXlpf79+2vUqFEkNUXApUuXtGrVKq1cuVJbt25VYmKili1bpuDgYFeHhnwQFRWlH374QT/88IMOHTokwzBUokQJ9e3bV0OGDJGPj4+rQ0Qei4yM1OLFi/X999/r1KlTSkxMVOnSpXXvvfdq2LBh8vPzc3WIyEdJSUnq37+/du7cqY4dO+rjjz92dUjIB61atVJMTIx8fX3tyjt37qwpU6a4KCrkt99++00zZ87Unj175O3trZo1a+qpp55SmzZtXB1ajtFDWwQYhqHHH39cZ86c0eLFixUUFKRNmzbpscceU0xMjF544QVXh4g8tmbNGu3Zs0cjR45USEiIZs6c6eqQkI/WrFmjt99+W6NHj1a/fv3k6+urdevW6amnntLWrVs1e/Zs091YHbkrJCREUVFRevfdd1WjRg2lpKRo9erVeu6557R79259+umnrg4R+WjWrFkKDQ2VuzuXgUVNjx49NHXqVFeHARf54osv9Oabb+rll19Wz5495eXlpT179ui7774r0Aktc2iLgF9++UV///23nnvuOQUFBUmSWrdurcGDB2vBggU6ffq0iyNEXrv//vv16quvqk2bNvTIF0GlS5fWokWLNHToUPn7+8tqtapjx44aMmSINmzYoH///dfVISKP3XbbbRo9erSCgoJktVrl7u6uHj166M4779S6det08eJFV4eIfPLvv/9q5syZmjRpkqxWLgOBouLYsWOaMmWKxo0bp759+8rLy0uSVL9+fU2YMMHF0TmHb7Ii4JdffpGbm5vatWtnV965c2clJyfrt99+c1FkAPJD+/btVa9evXTl5cuXlySFhobmd0gwiYSEBHl6ejLkuIiIi4vTs88+q65du6pz586uDgcuEhcXp+joaFeHgXz29ddfS5L69Okj6ep0pOTkZFeGlGsYa1IEHDp0SOXKlUs3Z6JGjRqSpAMHDrgiLAAutmrVKklS7dq1XRwJ8kvqonBXrlzRL7/8ol9++UXPP/98oVgUBDf29ttvKyIiQi+//LKrQ4GL/PTTT1qxYoUSEhJUqlQp9ezZU6NHj053jYjCZ+vWrapatao+//xzLVy4UJGRkZKktm3b6qWXXlLlypVdHGHOkdAWAVeuXHG4ep2/v78sFouuXLnigqgAuNIPP/yg9evXq0ePHqpevbqrw0E+ee+997R06VLb9/6jjz6qfv36uTgq5Ie//vpLCxcu1BtvvKGSJUu6Ohy4QI8ePdS3b18FBwcrISFBP/30kyZPnqx//vlHCxcuZEpSIXfhwgWdPXtWixcv1ieffKKGDRtq7969GjVqlB566CH9+OOPCggIcHWYOcKQ4yLC0WLWhmHIMAzm0ABFzObNmzVx4kTVrFlTr7zyiqvDQT568cUXFRISoh07dujdd9/VF198oREjRjj8HYHCIzIyUi+88ILatWune+65x9XhwEUmTpyoevXqyc3NTT4+Purbt6+efPJJbdu2TT///LOrw0Mes1gsMgxD48ePV8OGDSVJ9erV0wsvvKAzZ85oyZIlLo4w58hkioASJUro0qVL6covX75s2w6gaNixY4dGjhyp8uXLa968eQoMDHR1SHABT09Pde3aVY899pg2bNigTZs2uTok5KE5c+YoIiJCY8eOVUREhO2fdPUWPhEREYqLi3NxlHCF1PVVdu7c6eJIkNdSr/dvuukmu/KmTZtKkvbu3ZvfIeUahhwXAfXq1dM///yjy5cv2128Hjp0SJJUt25dV4UGIB/t2bNHjz76qEqVKqX58+erXLlyrg4JLpY63PzcuXOuDQR5KiUlRT4+PhoyZIhdeUJCgkJCQnTnnXfqiSee0KBBg1wUIVwlMTFRkriFUxHQoEED7dq1S0lJSXblqW3Aw8PDFWHlCnpoi4A777xThmHYFoBJtXz5cnl7e6tLly4uigxAfjlw4IAeeeQRBQYGav78+bYVjlE0ZDSkePPmzZL4w2Zh99RTTykkJCTdP09PT916660KCQkhmS3kMvoOWLFihSSpZcuW+RkOXKBHjx6Srs6nT2vDhg2SpObNm+d7TLmFP8cUAS1btlSPHj00bdo0lSpVSg0bNtSvv/6qb775RuPHj2dxiCIgKSnJtghMbGyspKuLhUVERMhqtap48eIujA557fjx4xoyZIg8PDw0Y8YMeXl52YYbSpKfn5/tfnQonJ5++mnVrVtXN998sypUqKDw8HAtX75cCxcu1AMPPODwtk4ACo9Fixbp33//1V133aVq1aopKipKP/30k+bMmaPu3burbdu2rg4ReaxVq1bq2bOnpk2bJj8/P910003auXOn3nzzTbVo0cKW8BZEFoOVIIqExMREzZ07V8uXL1d4eLgqV66s/v37szhEEbFjxw4NHz7c4bbSpUtr+fLl+RwR8tMXX3yhGTNmZLj9+eefV69evfIxIuS3S5cu6euvv9a6det08uRJeXp6qnbt2rrnnnvUrVs3V4cHF2nfvr1uvvlmTZs2zdWhII8lJSVp9erV+vHHH3Xo0CGlpKSoRo0auuuuu9SrVy9ZLBZXh4h8kJSUpIULF+rHH3/U+fPnVbJkSd1xxx169NFH5e3t7erwcoyEFgAAAABQIDGHFgAAAABQIJHQAgAAAAAKJBJaAAAAAECBREILAAAAACiQSGgBAAAAAAUSCS0AAAAAoEAioQUAAAAAFEgktAAAAACAAomEFgAAAABQILm7OgAAQMHy119/6dSpU+rbt6+rQykw/vjjD0VERKhXr16uDsUpMTExWrp0qRo0aKDGjRs7/VpbtmxRaGiokpKSbOU+Pj669957nYzUtSIiIrR69Wrb8/r166tJkyYui2fRokW2xxUrVlSHDh1cFgsA5DaLYRiGq4MAAOS/LVu26ODBg7bnnp6eCggIULVq1RQUFCR3d8d/8xw/frxWr16tf//9N1vH27Bhg86cOVNoE+HMzm/EiBH6559/FBIS4oLIcs+5c+fUoUMHjRw5Uk899VSOX+fkyZMaMGCAQkND020rXbq0NmzY4EyYLvfvv/+qT58+tufDhg3T+PHjXRZPnTp1bI/btm2r2bNnuywWAMht9NACQBG1YsUKffHFFw63BQYGqlevXho9erT8/f3ttrVp00aBgYHZPt7XX3+tP//8s9AmtIX9/HLT7NmzFRoaqhYtWigoKMhWvm7dOiUmJrowstzVvHlz1apVSzfddJNL4+jXr58kaenSpS6NAwDyAgktABRxd9xxh0qUKKGUlBRduXJFhw4d0uHDhzVv3jz99ttvWrRokUqVKmWr37t3b/Xu3duFEaOgO3z4sEqXLq2FCxfKYrHYyocOHap9+/a5MLLc1b17dw0cONDVYejVV1+VJP3yyy8ujgQAch8JLQAUccOHD1ejRo3syvbu3avnnntO+/fv16uvvqr33nvPti2jObQRERHauXOnLl68qIoVK6phw4by8/OTJP300086efKkkpKS7ObzdezYURUqVJAkGYah3bt36+jRo7JarWrcuLGqVKmSLt6081GjoqK0YcMGxcbGqmnTpqpWrZrDc7xy5Yq2bdumiIgIVapUSU2bNpWnp2e6epcuXdKWLVt06dIllStXTjfffLO8vb1v+B5m5fxS3Sjm68/vr7/+Unh4uPr06SN3d3clJSVp+/btOnnypLy9vdWsWTOVL1/e7jXCw8O1Zs0atWzZ0q4HVLo21Pz++++Xm5ubrTwmJkYbN25UVFSU6tevr+DgYFvdvn37OhyCfvDgQe3evVsBAQFq06aNfH19M32fTpw4oQ0bNujUqVOSpK+++kqS1LBhw3RtMK3Lly9r9+7dOnfunEqXLq2bb75ZPj4+dnWun9+7Z88eHThwQOXLl1erVq1sifPFixcVEhKixMRE3XLLLXZ/rLnegQMHtG/fPqWkpKhevXp2Q3dzw+HDh7V3715JUr169ew+q7w4HwAojEhoAQDp1KtXT7Nnz9Ydd9yh1atXKzw83Hah/N1332n16tV2Ce28efM0ffp0xcfH28qKFy+ul19+WXfffbfee+89nThxQpI0adIkW51PP/1UFSpU0B9//KHJkyfr+PHjtm0Wi0X9+/fXxIkT7XrxvvzyS/3zzz+qUqWKHn/8cV2+fFmSZLVa9dxzz+nhhx+21TUMQx9//LFmzZql2NhYW3nFihU1bdo0NWvWzFb28ccf66OPPlJcXJytrEyZMnrnnXd08803Z/p+3ej8Um3ZsuWGMaeeX7ly5fTkk08qMjJSknTXXXfp1KlTGjNmjI4dO2ar7+bmpkGDBunZZ5+V1Xr15gUnT57UpEmT9Prrr6dLaH/88Ud9/fXXuu+++2wJ7fbt2zVq1CiFhYXZ6g0YMECS9MUXX6hnz57pEtrXXntNCxcutD2vUKGC5s+fr6pVq2b4Pv37779270/q41GjRmWY0P7f//2fvv/+e7vPpWTJkpo+fbratGljK7ty5YomTZqkkSNHatGiRfr+++9t29q2bauZM2fqjz/+0LPPPquYmBhJkp+fn+bMmZNuSPD58+f19NNPa/PmzXblXbp00VtvvWX7Q01OhYaG6plnnkk3p7pz58764IMP5ObmlqvnAwCFGQktAMChMmXKqGvXrlqyZIm2b9+u2267zWG9c+fOaerUqXJ3d1fbtm1VtmxZnTt3Tjt37tSGDRt0991366677tKyZct09uxZu+HKFStWlCRt2rRJZ8+eVbNmzVS1alVFRkbqr7/+0pdffqk6derogQcesDtmfHy8Ro8erZIlS6p9+/YKDw/Xxo0b9dZbb+n2229XpUqVJF2dq/nOO+9Ikpo2baoqVaro3Llz2rFjh3bu3GlLaFMTck9PT7Vv316lS5fWyZMn9ffff+vxxx/XihUrVKZMmQzfqxudX3ZiTq371FNPqVSpUurYsaN8fX0VFxenYcOG6fz587Ze5kuXLumvv/7S3LlzVaJECY0YMSJLn21aly9f1hNPPKHw8HDVrFlTDRo0UGhoqL788st0Pb+pli1bpnPnzunWW29V6dKltW3bNp08eVL/+9//NGvWrAyPVbVqVfXr108///yzkpKSdOedd0q62kObkR9++EHFihVTq1atVKJECR09elQ7duzQ2LFjtWbNmnTzuX/88UdduHBBHTp0UEBAgDZs2KD169dr+vTp+vLLL1W9enXVrVtXhw4d0u7duzV16lRbT7EkJSQkaOjQoTpw4IAqVaqkxo0by83NTdu2bdMvv/yi1157TVOnTs3OW2wnPj5eQ4YM0aFDhxQYGKimTZvK399fe/fu1a+//qqkpCS7nnNnzwcACjsSWgBAhmrWrClJunDhQoZ1Tpw4IcMw9PLLL9slnqnDRCVpzJgxOnz4sMLDw23z+dLq2LGjHn74YZUrV85WFh4err59++rbb79Nl9DGxsaqV69emjBhgq1Xcvbs2XrzzTe1/v/bu/+YqOs/DuDP+wKX8ev4oRgdk9W8Qgw8hQGZHYrBGbVKo26xCLdGW85ak2OoYzKXViv/6LczgzJUUuNSQg/OM0KdmgKzDpYcMWclyE8RCI/7Ad8/3H3i490hKObI5+Mved/77t7vO/7wyfv9fr2PH4dGo4HFYsHWrVshlUqxfft2JCUlCc9va2sT5mS1WvH5559j1qxZKCkpEYW4I0eOYNWqVdi3bx9WrVrl8TO40fzGO+bRfdPS0vDOO+8IK6MlJSXo6OjA0qVL8eGHHwpbpmtra5GdnY2ioiK8+uqrHqtTe3LgwAF0d3fj+eefx9tvvy2EqcOHD2P16tVun9PZ2YnS0lLhKhqr1Yrly5fj+PHjsNls8PHxcfu8mJgYxMTEoKGhAYODgx4/q9E2bdoEtVotmtf+/fuRn58Pg8HgsvW9u7sbe/fuRXR0NADg4sWLWLZsGb766iu89tpryM3NBXBt9T4nJwfHjh0T7UA4dOgQzGYzsrOzsXbtWuG7stlsePPNN1FeXg6tVovp06ffcOzulJeX4/fff0dCQgI++eQTBAUFCY8dOXJEFGYnYz5ERP91DLREROSR8z/Xw8PDHvtERUUhKCgIZ86cQXJysrDFViaTYeHCheN6n8TERFitVpw+fRqtra2wWCwYGRlBWFgYGhoaXPpLJBLk5uYKYQO4Vtzq/fffx6VLlwAADQ0NGBgYQFZWlijMAte2xzrHaTKZcOXKFSxYsADV1dUu7+Xr64tff/11XPMYy3jGPFpubq4oxNXX1wMA8vPzRed/4+PjkZ6eLgSlqKioCY3L+bparVYUplJTUxEXF4e6ujqX56SlpYnuVZVKpUhOTkZRURF6enpEf5i4VU899RTa29thMplw+fJl2O12DA8PQyKRoKmpyaW/Wq0Wwh8AyOVyKBQKNDU1iQK6RCJBcnIyjh07htbWViEAOq8MCgsLw549e0SvPWPGDDgcDjQ2Nt70Xa6nTp0CABQWForCLHBtS/Nkz4eI6L+OgZaIiDxyngsNDg722CcwMBA7d+7ERx99hPT0dAQGBkKpVEKtVuPJJ58UnX/1xGg0oqCgAJcvX3b7uMViERVnkslkLtcJOc81Oq996e7uBgAoFIox39vZr7q62m2gBSCcY70V4xnz6PbrQ2Fvby+8vLzcnlF1npP19PmNpbe3F/7+/ggJCXF5LDIy0m2gjYiIcGlzzm0yr92x2WzYsGEDvv/+e4yMjLg87u57Gb3N28nPzw8hISG45557XNoBCGdQgX9+Hz744AOP4+rr6xvfBNzo6emBl5eXsPvhRm51PkRE/3UMtERE5JbFYhGu+YiNjR2zr0KhwKeffgq73Y7z58/jzJkz2LRpE6qqqkQVkt3p6+tDXl4eLBYLEhISEB4eLoTX+vp6NDc3w+FwTHj8zoDV2to6Zj9nCHDeGeqOp+rJt4u7Lbu+vr5wOBzo6upyOc/b3t4O4J+5OFdwRxdScrp++7ifnx/+/vtvDA4OulQpHmur+b/h22+/hU6nQ2hoKJRKJYKCgoRV63379k3o92I8f1gBrn0eEokEL7zwgsfn3Mrvg7+/PxwOBzo6OjyeUR6P8c6HiOi/joGWiIhc9Pf3Iz8/H52dnUhISHC7Iud08eJF+Pn5CWFDoVBAoVCgpaUFO3fuRE9PD0JCQuDj44OhoSHY7XbRVlqz2YzBwUGsWbNGVNRoaGhIdK50oh555BH4+Phgz549yMzMFK14Wq1WdHZ2Qi6XC/28vb1RUFDgcp1PX1/fuFbkPM1vssydOxdGoxHFxcXIz88X2tvb21FRUQGpVCqsRjuDUm1tLbKysoS+Fy5cELa8OkVHR8NoNGLXrl3IyckR2pubm136/tt++eUXSCQSHDx4ULRL4PTp0y7bgSfL/PnzYTAYEBcXh+eee87l8d9++w1z5sy56ddXKpUwGAz4+OOPsXnzZlEw/eOPPyCXy13O0RIRkWcMtEREd7nDhw+joaEBw8PDGBgYgNlsRk1NDfr7+xEQEIDCwsIxn//zzz9j48aNWLJkCWbPno2AgAC0tLRAp9PB29tbWG0MDw+Hw+FAfn4+5s+fDy8vLyxevFio7ltSUoLBwUFMnz4dXV1dqKysFF0jM1EymQwZGRkoLS1Feno6nnnmGcyaNQuXLl2C0WhEVlYWVq5cCZlMhszMTOzYsQNPP/00li5dipkzZ2JgYADnz5/Hjz/+iPXr17sUH7qep/ldfw/tzVqxYgW++OILFBcXo6WlBQkJCejt7UVZWRn6+vrw0ksvCXezhoSE4KGHHkJlZSXeeustKJVKtLW1oayszCUsPfvss9i2bRu2bNmCxsZGxMbGor29Hd999x2kUilsNtsdWw2Uy+UYGRnBmjVr8Pjjj0MikcBsNuOnn366baEvIyMDxcXFWLduHQ4dOoR58+bB398fbW1tOHv2LEwmk1Ds7GasWLEC27dvR1lZGc6dOweVSiVUOa6qqkJdXR0DLRHRBDDQEhHd5bZt2+a2PSkpCRs2bHC5x/R6crkc06ZNg16vF7V7eXkhLy8PAQEBAK5dbfP111+joqICFRUVAK7d06pSqZCZmYndu3eLrnxZtGgRHnvsMezateum57Z27Vp0dnbCaDRi9+7dQrtUKhWtOufl5aG/vx86nQ7FxcWi15DJZGOuUDt5mt9kBdr77rsPW7ZsgVarRU1NDWpqaoTHkpKSkJeXJ+qv1Wrx+uuvQ6/XC99NamoqgoODsXfvXqFfREQENm7ciIKCAlHfxMREzJw5E+Xl5S5nNf8tL7/8MnQ6HU6cOIETJ04AALy9vfHee+9h/fr1t+U9AwMD8eWXX2L16tUunzNw4+33NxIcHIytW7fijTfeQGNjoygcR0ZGMswSEU0QAy0R0V0qPj4edrtd+FkqlcLf3x+RkZGIi4tzW3wIAB599FHR3Z+JiYk4evQoqqurYTabcfXqVYSHhyM1NVUU5qKiorB//35UVVWhq6sLDodDKHhTWFiIlJQU1NbWwmazITY2FqmpqTAYDLDb7aIzpSqVym1BnWnTpkGj0UCpVIraPvvsM9TV1eHkyZO4cuUKIiIikJqaKiq24+Pjg3fffRfZ2dk4evQoOjo6EBQUhAcffBApKSmiglSejDW/iYzZU18AeOKJJ2AwGKDX6/Hnn3/i3nvvRXx8PFQqlcsqanJyMnQ6HSorK3H16lXMmzcPy5Ytw8GDByGRSETBafny5YiJiYFer8fAwACio6ORnp6OV155BaGhoUJfX19faDQat6Fu7ty50Gg0wjnesajValitVpf2xYsXi6o0z5gxA3q9HgcOHMCFCxcgk8mgVqsxe/ZsnD17VlT9d6yxpaSkoKenx6X9gQcegEajQVhYmKg9KioKer0e1dXVMJlMGBoawv33348FCxZMKNA6V1ujo6NFVaGd25oNBgOamprg7e2NOXPmIC0tTdiuPpnzKS0tBeD+TDUR0VQnGXFXNpCIiIjuGn/99ZfLKvSpU6eQnZ2NJUuWiFbO6cZMJhMyMjKEn3NycqDVau/YeB5++GHh34sWLUJRUdEdGwsR0WTjCi0REdFdbseOHaivr8fChQsRHByM5uZm/PDDDwCAF1988Q6PbuoJDQ0VFTQbvQJ/J4wey42usSIimmq4QktERHSX++abb7B582aX9pUrV2LdunV3YERERETjw0BLREREOHfuHE6ePInW1lbIZDKoVKpbLoBERER0uzHQEhERERER0ZT0vzs9ACIiIiIiIqKbwUBLREREREREUxIDLREREREREU1JDLREREREREQ0JTHQEhERERER0ZTEQEtERERERERTEgMtERERERERTUkMtERERERERDQlMdASERERERHRlMRAS0RERERERFMSAy0RERERERFNSf8HBu36WSEmSZsAAAAASUVORK5CYII="
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fuel_temperature_celsius = 100.0\n",
+    "burner_pressure_bara = 1.01325\n",
+    "fuel_rate_kg_per_hour = 10.0\n",
+    "oxidizer_rate_kg_per_hour = 50.0\n",
+    "\n",
+    "fuel_fluid = fluid(\"srk\")\n",
+    "fuel_fluid.setTemperature(fuel_temperature_celsius, \"C\")\n",
+    "fuel_fluid.setPressure(burner_pressure_bara, \"bara\")\n",
+    "fuel_fluid.addComponent(\"methane\", 0.50)\n",
+    "fuel_fluid.addComponent(\"ethane\", 0.25)\n",
+    "fuel_fluid.addComponent(\"propane\", 0.24)\n",
+    "fuel_fluid.addComponent(\"nitrogen\", 0.005)\n",
+    "fuel_fluid.addComponent(\"CO2\", 0.005)\n",
+    "fuel_fluid.addComponent(\"oxygen\", 0.0)\n",
+    "fuel_fluid.setMixingRule(\"classic\")\n",
+    "\n",
+    "fuel_stream = jneqsim.process.equipment.stream.Stream(\"fuel gas\", fuel_fluid)\n",
+    "fuel_stream.setFlowRate(fuel_rate_kg_per_hour, \"kg/hr\")\n",
+    "\n",
+    "oxidizer_fluid = fuel_fluid.clone()\n",
+    "component_names = [\n",
+    "    str(oxidizer_fluid.getComponent(index).getName())\n",
+    "    for index in range(oxidizer_fluid.getNumberOfComponents())\n",
+    "]\n",
+    "oxidizer_composition = [\n",
+    "    0.21 if component_name == \"oxygen\" else 0.79 if component_name == \"nitrogen\" else 0.0\n",
+    "    for component_name in component_names\n",
+    "]\n",
+    "oxidizer_fluid.setMolarComposition(oxidizer_composition)\n",
+    "\n",
+    "oxidizer_stream = jneqsim.process.equipment.stream.Stream(\"oxidizer\", oxidizer_fluid)\n",
+    "oxidizer_stream.setFlowRate(oxidizer_rate_kg_per_hour, \"kg/hr\")\n",
+    "\n",
+    "burner = CanteraUnitOperation(equivalence_ratio=1.0)\n",
+    "burner.setName(\"Cantera premixed flame\")\n",
+    "burner.setFuelStream(fuel_stream)\n",
+    "burner.setOxidizerStream(oxidizer_stream)\n",
+    "burner.setWidth(0.015)\n",
+    "\n",
+    "combustion_process = jneqsim.process.processmodel.ProcessSystem()\n",
+    "combustion_process.add(fuel_stream)\n",
+    "combustion_process.add(oxidizer_stream)\n",
+    "combustion_process.add(burner)\n",
+    "combustion_process.run()\n",
+    "\n",
+    "flame_results = pd.DataFrame([json.loads(burner.toJson())]).set_index(\"name\")\n",
+    "display(flame_results.round(4))\n",
+    "display(burner.plotFlame())\n",
+    "\n",
+    "assert 0.05 < burner.getFlameSpeed() < 2.0\n",
+    "assert float(np.max(burner.flame.T)) > fuel_stream.getTemperature(\"K\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "35c609b1",
+   "metadata": {
+    "id": "lO7jrTAkewDG"
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9843a2a1",
+   "metadata": {
+    "id": "cmHtZrXNVHXY"
+   },
+   "source": [
+    "## 5. `fluids` for an ISO-style orifice calculation\n",
+    "\n",
+    "The `fluids` package supplies standard engineering correlations. The original example called a\n",
+    "permanent-loss helper with an assumed downstream pressure. The repaired unit instead solves the\n",
+    "meter equation from the NeqSim mass flow, density, viscosity, and heat-capacity ratio. The bore\n",
+    "diameter is smaller than the pipe diameter, and the calculated differential pressure is applied\n",
+    "to the cloned outlet stream."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e6e04cb3",
+   "metadata": {
+    "id": "RNGqpmB3Wu_h"
+   },
+   "source": [
+    "For mass flow $\\dot{m}$, discharge coefficient $C$, bore area $A_o$, upstream density $\\rho$,\n",
+    "expansibility $\\epsilon$, and diameter ratio $\\beta$, the incompressible form illustrates the\n",
+    "governing dependence:\n",
+    "\n",
+    "$$\n",
+    "\\dot{m} = C\\epsilon A_o\\sqrt{\\frac{2\\rho\\Delta p}{1-\\beta^4}}\n",
+    "$$\n",
+    "\n",
+    "The library call below uses its compressible-gas meter solver rather than rearranging this\n",
+    "illustrative equation by hand."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "9c909ea6",
+   "metadata": {
+    "id": "DtbjHggBVSHg"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fluids 1.3.1 is ready for the orifice calculation.\n"
+     ]
+    }
+   ],
+   "source": [
+    "from fluids.flow_meter import differential_pressure_meter_solver\n",
+    "\n",
+    "print(f\"fluids {fluids.__version__} is ready for the orifice calculation.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "ab8e0d34",
+   "metadata": {
+    "id": "q6mrVs8rVRGC"
+   },
+   "outputs": [],
+   "source": [
+    "class Orifice(unitop):\n",
+    "    \"\"\"Calculate orifice differential pressure and update a cloned outlet stream.\"\"\"\n",
+    "\n",
+    "    def __init__(self, name):\n",
+    "        super().__init__()\n",
+    "        self.setName(name)\n",
+    "        self.input_stream = None\n",
+    "        self.output_stream = None\n",
+    "        self.pipe_diameter_metre = None\n",
+    "        self.bore_diameter_metre = None\n",
+    "        self.discharge_coefficient = None\n",
+    "        self.differential_pressure_bara = None\n",
+    "\n",
+    "    def setInputStream(self, stream):\n",
+    "        self.input_stream = stream\n",
+    "        self.output_stream = stream.clone()\n",
+    "\n",
+    "    def getOutputStream(self):\n",
+    "        return self.output_stream\n",
+    "\n",
+    "    def setOrificeParameters(self, diameter, diameter_outer, C):\n",
+    "        self.pipe_diameter_metre = diameter\n",
+    "        self.bore_diameter_metre = diameter_outer\n",
+    "        self.discharge_coefficient = C\n",
+    "\n",
+    "    def calculate_downstream_pressure_pascal(self):\n",
+    "        fluid_system = self.input_stream.getThermoSystem()\n",
+    "        fluid_system.initPhysicalProperties()\n",
+    "        phase = fluid_system.getPhase(0)\n",
+    "\n",
+    "        return differential_pressure_meter_solver(\n",
+    "            D=self.pipe_diameter_metre,\n",
+    "            D2=self.bore_diameter_metre,\n",
+    "            P1=self.input_stream.getPressure(\"Pa\"),\n",
+    "            m=self.input_stream.getFlowRate(\"kg/sec\"),\n",
+    "            rho=phase.getDensity(\"kg/m3\"),\n",
+    "            mu=phase.getViscosity(\"kg/msec\"),\n",
+    "            k=phase.getGamma(),\n",
+    "            meter_type=\"ISO 5167 orifice\",\n",
+    "            C_specified=self.discharge_coefficient,\n",
+    "        )\n",
+    "\n",
+    "    @JOverride\n",
+    "    def run(self, calculation_id):\n",
+    "        upstream_pressure_pascal = self.input_stream.getPressure(\"Pa\")\n",
+    "        downstream_pressure_pascal = self.calculate_downstream_pressure_pascal()\n",
+    "        self.differential_pressure_bara = (\n",
+    "            upstream_pressure_pascal - downstream_pressure_pascal\n",
+    "        ) / 1.0e5\n",
+    "\n",
+    "        outlet_fluid = self.input_stream.getThermoSystem().clone()\n",
+    "        outlet_fluid.setPressure(downstream_pressure_pascal / 1.0e5, \"bara\")\n",
+    "        self.output_stream.setFluid(outlet_fluid)\n",
+    "        self.output_stream.run(calculation_id)\n",
+    "\n",
+    "    @JOverride\n",
+    "    def toJson(self):\n",
+    "        results = {\n",
+    "            \"name\": self.getName(),\n",
+    "            \"pipe diameter [m]\": self.pipe_diameter_metre,\n",
+    "            \"orifice bore [m]\": self.bore_diameter_metre,\n",
+    "            \"discharge coefficient [-]\": self.discharge_coefficient,\n",
+    "            \"differential pressure [bara]\": self.differential_pressure_bara,\n",
+    "        }\n",
+    "        return json.dumps(results)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "359dc6b5",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "qDg0C0p7afKQ",
+    "outputId": "a46f8f2b-dc2e-4773-cb32-f704b74baa8a"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>pipe diameter [m]</th>\n",
+       "      <th>orifice bore [m]</th>\n",
+       "      <th>discharge coefficient [-]</th>\n",
+       "      <th>differential pressure [bara]</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>name</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>gas measurement orifice</th>\n",
+       "      <td>0.07366</td>\n",
+       "      <td>0.05</td>\n",
+       "      <td>0.61</td>\n",
+       "      <td>0.30083</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                         pipe diameter [m]  ...  differential pressure [bara]\n",
+       "name                                        ...                              \n",
+       "gas measurement orifice            0.07366  ...                       0.30083\n",
+       "\n",
+       "[1 rows x 4 columns]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "orifice_feed_fluid = fluid(\"srk\")\n",
+    "orifice_feed_fluid.setTemperature(30.0, \"C\")\n",
+    "orifice_feed_fluid.setPressure(10.0, \"bara\")\n",
+    "orifice_feed_fluid.addComponent(\"methane\", 1.0)\n",
+    "orifice_feed_fluid.setMixingRule(\"classic\")\n",
+    "\n",
+    "orifice_feed = jneqsim.process.equipment.stream.Stream(\n",
+    "    \"orifice feed\",\n",
+    "    orifice_feed_fluid,\n",
+    ")\n",
+    "orifice_feed.setFlowRate(3_000.0, \"kg/hr\")\n",
+    "\n",
+    "orifice = Orifice(name=\"gas measurement orifice\")\n",
+    "orifice.setInputStream(orifice_feed)\n",
+    "orifice.setOrificeParameters(\n",
+    "    diameter=0.07366,\n",
+    "    diameter_outer=0.05000,\n",
+    "    C=0.61,\n",
+    ")\n",
+    "\n",
+    "orifice_outlet = orifice.getOutputStream()\n",
+    "orifice_outlet.setName(\"orifice outlet\")\n",
+    "\n",
+    "orifice_process = jneqsim.process.processmodel.ProcessSystem()\n",
+    "orifice_process.add(orifice_feed)\n",
+    "orifice_process.add(orifice)\n",
+    "orifice_process.add(orifice_outlet)\n",
+    "orifice_process.run()\n",
+    "\n",
+    "orifice_results = pd.DataFrame([json.loads(orifice.toJson())]).set_index(\"name\")\n",
+    "display(orifice_results.round(5))\n",
+    "\n",
+    "assert 0.0 < orifice.differential_pressure_bara < orifice_feed.getPressure(\"bara\")\n",
+    "assert orifice_outlet.getPressure(\"bara\") < orifice_feed.getPressure(\"bara\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "integration-architecture",
+   "metadata": {},
+   "source": [
+    "\n",
+    "## 6. Integration architecture and model boundaries\n",
+    "\n",
+    "Each Python wrapper is added to the same `ProcessSystem` as its input stream. NeqSim remains the\n",
+    "owner of process temperature, pressure, flow, composition, phase equilibrium, and equipment\n",
+    "connectivity. The external library receives only the quantities required by its focused model\n",
+    "and returns explicitly labelled results. This separation makes unit conversion and model scope\n",
+    "reviewable.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "integration-workflow-figure",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<Figure size 1200x504 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABKQAAAHsCAYAAADsEHV2AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjExLjEsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvctoD+AAAAAlwSFlzAAASdAAAEnQB3mYfeAAAtDBJREFUeJzs3Xd4VGXaBvB7+iST3iuEAJOE3jsi0sEOUi2IuvZPLIsNWUEUsa+7uoggogKiKKJIlyK9Q6gJBBJCes+kTD/fH2GGDDPpyUwI9++62PWcOeV53zP1yfs+RyQIggAiIiIiIiIiIiInEbs6ACIiIiIiIiIiurUwIUVERERERERERE7FhBQRERERERERETkVE1JERERERERERORUTEgREREREREREZFTMSFFREREREREREROxYQUERERERERERE5FRNSRERERERERETkVExIERERERERERGRUzEhRURERERERERETsWEFBERERERERERORUTUkTUpO68807ExMQgKSmpUY43ffp0xMTE4MiRI3Xa75577kFMTAwSExMbJY6bSWNfA7JV3+dWdnY2XnnlFQwYMABxcXGIiYmx+dehQ4cmirhp5OTkYNasWTbtWbdunavDqlZ9r11934dqcurUKcTExGDixImNelxqOTIzMxETE4MRI0a4OhSnulXb7WrsdyJqalJXB0BEDfPiiy9iw4YNAICePXti5cqVVW67cuVKzJ0717p85swZSKV8GyByNrPZjMcffxwJCQmuDqVRCIKAJ554AufOnXN1KHSL0ul06NKlCwBAIpHg999/R7t27RxuGxMTAwDYtWsXQkJCnBajI4cOHcKqVatw4sQJ5OTkwN3dHcHBwVCr1Rg2bBhuu+02eHh4uDRGIiKipsIRUkQtyNGjR5GSklLl42vXrnViNERUlePHjyMhIQGBgYFYt24dzp49i4SEBOu/m83Jkydx7tw5u/bcc889LotpypQpiImJwYkTJ1wWw60qJSUFMTExGD16tEvObzKZ8Omnn7rk3HXx6aef4qGHHsKGDRuQnp4Og8GAoqIiJCYmYv369XjxxRfxwQcfuDrMZs3Vz7WbGfuOiJoDDo0gaiE6duyIM2fOYO3atZg5c6bd40lJSYiPj7duR0Suc/nyZQDAoEGDEBsb6+JoGs4yHbSltKcm3377ratDoGq4ublh27ZtOHnyJLp27erqcBzat28fFi1aBKBiWvXDDz+MqKgoyGQypKenIzExEdu2bYOnp6fNfiEhITdl0rqhbtV2uxr7nYiaGkdIEbUQw4cPh6enJ9atWwdBEOwe//XXXwEA999/v7NDI6Ib6HQ6AIC7u7uLI2kcWq0WQMtpD93cHnroIQDARx995OJIqrZ+/XoAwODBg/Hxxx+ja9eu8Pb2hru7O9q1a4exY8fik08+wT//+U8XR0pERNR0mJAiaiEUCgXGjh2L9PR0HDhwwOYxk8mE33//HT4+PrjjjjuqPU5RURE+/fRTjBs3Dl27dkX37t0xfvx4LFu2DHq93uE+mZmZeP311zFw4EB07twZo0aNwueff2790V0Vo9GIn3/+GQ8++CD69OmDTp06Yfjw4Xj33XeRl5dXtw6og23btmHq1Kno0aMHunfvjoceegi7d++ucvu69kmvXr0QExNTZftHjx6NmJgYu+mVlQss79+/H48++ih69eqFrl27Yvz48di4cWOVMdbnGhQXF+Onn37CY489hjvuuAOdOnVC37598cgjj1h/LN2ocoy7du3C9OnT0adPH8TExODw4cPo168fYmNjq506+tBDDyEmJgZ//vlnldtYTJ06FTExMTh+/LjN+vT0dGvx76+++spuv1GjRiEmJgbp6ek26+t6Latrb22mgn3++eeIiYnBsGHDcOnSJWzbtg0xMTGYN28eAGDFihXWdtx55501Hq+ubWjs/rtRXdrjrL4/ceIEYmJicOzYMQDApEmTbIrF//333w73q8trrqqi5rWNeceOHZg2bRq6d++Onj174sEHH8TOnTurbFNNzp07h5iYGNx///3QarX49NNPMWLECHTu3BmDBg3C7NmzkZ2d7XDfxMREfPzxxxg/fjz69u2LTp064Y477sDrr7/u8EYIlc+l0+nw3//+F2PHjkWXLl0wevRozJkzByNHjgRQMRKwct8PHDgQALBp0ybExMRg2rRpVbYpNTUVsbGx6N27tzXhWVvTpk1DSEgIDh06VO17uyNZWVlYsGABxowZY32eTpo0CT///LPDP/ZYVHVNqypUn5OTAwDo0aNHneKrqsi0o+fAyJEj0blzZwwZMgQLFy609mN2djbmzJmDIUOGoFOnThg1alSdR/1ZXvsvvviiw8ctr8MpU6ZUGafBYMBXX32FMWPGoHPnzujbty9mzpyJ1NTUWrW7Ns+12oqPj8cLL7yAQYMGoVOnTujfvz+efvppHDx40G7bhrzegLo/x2p6zVnU5bVc276rqah5ffutLtceAI4dO4bnnnvOep5BgwZh8uTJWLZsGYqLi6vsayJq/jhlj6gFue+++7B69WqsXbsW/fv3t67fs2cPsrOzMW3aNMhksir3v3r1Kh5++GGkpaXZrD99+jROnz6NzZs3Y+nSpVCpVNbHkpOTMW3aNOTm5tqs++KLL3D48GEYjUaH5yorK8NTTz1l96UlNTUV3333HTZv3owffvgBrVq1qlMf1OSHH37A6tWrbdYdOnQIhw8fxty5czFp0iSbx+rTJw21Zs0afPfddzZfTE+fPo2ZM2dCp9Ph3nvvtdm+vtdg4cKFWLNmjc26wsJCHDhwAAcOHMDx48fx1ltvOdx35cqVWLVqlc06iUSC+++/H0uXLsVPP/3k8C/7ly9fxqFDh+Dr61uru/YMGDAAR48exb59+9C9e3fr+v3791v/e9++fXjyySetyxkZGUhOTkZUVBTCwsKs6xtyLR2112w2Vxm3wWDAW2+9hbVr16Jjx45YvHgxAgICcOnSpRrbXJ26tqEx+8+ZcVdW176vj7q+5mpSXczfffcd3n33XZvHDh8+jMOHD9u9/9SVwWDA9OnTbRKQOTk5+Pnnn/H3339jxYoViIyMtNnn3nvvhclkslmXlpaGX3/9FRs2bMDSpUvRq1cvh+d69NFHcfToUeu66hI2lQ0fPhxBQUE4cuQILl686LD4uOXH+T333AOlUlmr41rI5XI899xzmD17Nj799FMMGjQIIpGoxv2OHj2Kp59+GkVFRTbrT5w4gRMnTuDAgQP46KOP7I5Vn2saFBQEoOK1+PTTT9cqvtowGAyYMWOGzXXJzMzEN998g6SkJLz99tuYOHGiNSEGVHxeLFiwAOXl5Xj66acbJY6aGI1GPPHEEzbvRXq9Hhs3bsThw4fx+++/w9/f3ymxrFmzBnPmzLF5HeTn52P79u3Yvn07Zs2ahccee8xuv/q83ur7HLOcr7rXXH1fy/VV336r67XfuXMnnnnmGZvz5OTkICcnB8ePH0d6ejrefPPNRmsXETkXR0gRtSDdu3dHmzZtsHXrVpSWllrXW4qZ33fffdXu/+qrryItLQ1hYWH43//+hxMnTuDw4cN49913oVKpcPz4cbsCq6+99hpyc3PRrl07LF++HKdOncL+/fvx6quv4tixY9ZaOTeaO3cuDh48iJCQECxYsAA7d+7E8ePH8fPPP2PgwIHIysrCrFmzGtgj9lavXo2RI0diw4YNOHXqFDZv3ow777wTgiDgnXfeQXJycoP7pKGWL1+OcePGYd26dThx4gQ2bdpkHdn22Wef2f3oq+818PHxwSOPPIKVK1di9+7dOHXqFHbs2IE5c+ZApVLhhx9+QHx8vMN9V61ahREjRmDt2rWIj49HQkICevTogcmTJ0MkEuHXX391OOrlp59+AlDxXJTL5TX2Rb9+/QDAbtSf5YusWq3GsWPHbEZQWB6z7GvRkGtZVXsdKSkpwZNPPom1a9diyJAh+OGHHxAQEACg4od4QkKCNdE3bdo0ayHzqkalNaQNjdl/jtS2Pc7qewDo1q2bzTarV6+2KRh/22232e1T19dcTaqK+eLFi1i4cCEAYOLEidi2bRtOnTqFP/74A7fffrtdsryuEhMTcebMGcyePRv79+9HfHw8lixZglatWiErK8vhj7YOHTrg7bffxu+//46jR4/i6NGj+PXXX3HfffdBq9XiX//6V5XnOnv2LF5//XVs27YN58+fx+bNmzFv3jxs2bIFANCmTRubvt+7dy8AQCqV4oEHHgAAh202Go3Waeb1TdLdf//9iI6OxpkzZ6odXWqRn5+PZ599FkVFRbjtttuwYsUKHDlyBPv27cOHH36IgIAArF+/Hj///LPNfvW9pvfeey9EIhEOHTqE8ePH49tvv8WJEyfqPBrsRomJibh48SLmz5+P3bt349ChQ3jnnXcgkUiwa9cuPPjgg3B3d8eiRYusI8hmzJgBAFi8eDHKysoadP7aSkhIwKlTp/DWW29hx44dOHbsGBYvXozAwEDk5ubi+++/r/EYtXmu1cSSpDOZTBg1apT1u8GWLVusJQ4++ugju1GmQN1fb/V9jlU+n6PXnEVdXssN7buG9Ftdr/2iRYtgMplw1113Yf369Th58iQOHDiAn376CTNmzIC3t3eN8RJRMyYQ0U1t5syZglqtFpYsWSIIgiAsWrRIUKvVwpo1awRBEISioiKhc+fOwrhx4wRBEITs7GxBrVYLarVaMBgM1uOcPHlSUKvVQmxsrHDu3Dm78/zxxx+CWq0WOnbsKBQUFNjs07FjRyE1NdVun88//9x6rosXL1rXJycnC7GxsUK3bt2EpKQku/10Op0wbtw4Qa1WC/Hx8TaPPfLII4JarRYOHz5cp366++67BbVaLdx5552CyWSye3zixImCWq0W3n33Xeu6+vSJIAhCz549BbVaLWi1WoexjBo1SlCr1UJycrLDGJ966im7fTQajfW4lfer7zWoyfLlywW1Wi188sknDmOcOnVqlfvOmDFDUKvVwp9//mmzXqfTCX379hViYmKEy5cv1yoOvV4vdOvWTejYsaNQVlZmXT9w4EBhzJgxwldffSWo1Wphz5491sdeeeUVQa1WCxs3brSuq++1rE17LdskJCQImZmZ1uXZs2cLRqPR4T7ff/+9oFarhblz5zp8XK1WC3FxcTbr6tOGxuq/mlTXnqbs++pMnjxZUKvVwvHjx6vcpj6vOUGo+n2oppjffvttQa1WCzNmzLB7TK/XCyNGjBDUarXwwAMP1KKF1509e9b6Ord8FlSWmJgoxMbGCmq12uE1qMq9995r1/7K5/rpp58c7pecnCyo1Wph1KhRVR47IyNDiIuLE3r37m33Xrl582ZBrVYLkydPrnWsWq3WGldeXp4gCIKwceNGQa1WCyNHjrT5vLNsl5GRYV332WefCWq1Wnj00UcdfkYcPnxYUKvV1s9Si4Zc059++kno1q2bNR7L6/7ee+8VPvvsMyE7O9tun4yMDEGtVgvDhw+3WV/5umzfvt1uv5deeklQq9VCly5dhCtXrtg8ZjabrZ9LBw4csNvXka1btwpqtVqYOXOmw8ePHz/u8BpWjnPLli12+61du9bhflW1uzbPtepYrt/9998vmM1mu8ctn2fPP/+8wzbU5fVW3+dYbV5zNXH0Wq7t69RRvze03+py7YcNGyao1WqhqKio1u0lopsHR0gRtTD33nsvxGKxdVTU+vXrodPpahwddfjwYQDAwIEDHd4la9y4cQgNDYXBYLDWQrHsM2LECERERNjt8+ijjzocdr57926YzWYMGjQI0dHRdo/L5XIMGzYMAKx1YBrLww8/DLHY/q1v+vTpACqm71nUp08aw4QJE+zWeXh4WKe1VJ5qUd9rYLFt2zY89dRTGDx4MDp16mStIWGZfnLjFCuLG+uCOHrsxpEBW7duRUFBAfr06YOoqKgq969MJpOhd+/eMBgM1no9Fy9eRE5ODgYMGIABAwYAqJh2ZnHgwAGIRCL07dvXuq6h17K69lpcuHABEydOxPnz5/HCCy9YRyU0lvq0obH6z9lxV1abvm+ourzmaqOqmC198cgjj9g9JpPJrMW460sqlTqsy9S+fXsMHjwYAOymSZeUlOB///sfHnjgAfTq1QtxcXHW94GzZ88CcPw+oFAoMH78+HrHGhISgqFDh6KoqMhuBJPlvaOhUxhHjx6Nzp07Izk52W568o127doFAHjwwQcdfkb06tULwcHBuHDhgk3NmoZc0wceeADbt2/HnDlzMGLECISEhMBkMuHs2bP48ssvMXLkSOzYsaNWbbXw8fHB0KFD7dZ36NDB2o4bp5GJRCLExcUBqPtzvb68vb0dTtu23BXRWXFYrt9jjz3m8LPSMuWs8ncDi7q+3ur7HLOo6TVX39dyfTSk3+p67S3P3e+++w7l5eUNC5yImh3WkCJqYYKDgzFgwADs3bsXqampWLt2LSQSCe6+++5q98vKygIAh7U8gIovrNHR0cjIyLBum5mZCaBiuLcjHh4eCAwMtCvuefXqVQAVCQrLFw3h2pQYQRBspsfUprj59OnTbWoRWBw7dsyuJk1VsVoSY5Y2AfXrk8YQHh7ucL2lLZWnwtX3GgDAggULaixkW1Uh++pqew0dOhShoaE4ePCgtRYRAPz4448AgMmTJ1d7zhv1798fu3btwr59+zB48GDrte7fvz86dOgAHx8f67qkpCRkZ2ejQ4cO8PX1tR6jodeyNrXMZs2aBaPRiGeeeQbPPPNMndpYG/VtQ2P0nyvitmjsOnKO1OU1VxtVxVzT69VRgj4zMxNDhgyxW2+5cUFloaGhVdZbio6Oxq5du2ze4/Lz8zFlyhS7qco3cnRzhIiICIc/qutiypQp2LZtG1avXm2t03X16lXs27cP3t7eNgWb6+ull17Co48+ii+++AL33ntvlf1j+aH+3HPPAbD9TKr8/0DF55KXlxeA+l3Tynx9fTFt2jRrYiM7Oxu7d+/GV199hZSUFLz44ovYsmWLteZUTap6LlvugFnT43V9rtdXVXF4eHg4NQ7Le07btm0dPm5ZX1BQAL1ebzPVvK6vt/o+xyyqe8015LVcHw3pt7pe+1mzZuHcuXP4z3/+g8WLF6Njx47o1KkT+vXrh8GDB9dq+j8RNV8cIUXUAt13330QBAGffPIJ4uPjMXjwYAQGBla7j+WLUH0Kq1a3j+Cg9oqluK8gCDCZTDCZTDCbzTCbzXbbGwyGOsdTH47a35A+qc25qlKfH3l1vQYJCQn49ttvIZFI8OKLL2LDhg04duwYzp07h4SEBHz66afVnq+6IsMSiQQTJ06EIAjWmlHJyck4fPgw/Pz8MHz48Fq2qoKlQL+lDtL+/fshkUjQp08fiMVi9O3bF+fOnUNBQUGV9Y8aei1rU1TZkvRdsWJFlbW3GqK+bWiM/nNF3BZ1LWhdHw1NrNyoppir6oua3htqUpv3gcrbLF68GMnJyWjVqhW++OIL/P333zh16pS1loxllIcjjXFdBg4ciNatW+PYsWO4cOECgIpi5mazGXfffXejnGPAgAHo378/srOz8d1331W5neVzydFnUm0+lxrrmgYFBWH8+PFYtWoVvLy8UF5ejq1bt9bpGM1BTe1u7M/V+mrq7z6Vt2noc6y610NDXsv10VT95khERAQ2bNiA//znP7jvvvug0+mwatUqPPPMMxg2bJjd3U6J6ObCEVJELdCIESPg6emJDRs2AKi5mDlQMX0CgMPbfAMVXz4sdwgLDg622aeqO4eVlJTY3PnNIjQ0FEDFdIX58+fXGFtN6nK76suXLzu8y4yl8LelbUD9+gSA9U6GpaWlUCgUNvuYTCZkZGTUOt6a1PcaWIbR33PPPXjqqafsHq+qzbX1wAMP4Msvv8TatWsxc+ZMrF69GoIg1LqYeWUxMTHw8/PDuXPnkJubi0OHDqFz587w9PQEUJFw2bx5Mw4cOGAz+qey+l7Lunj00UfRqVMnvPPOO3j00Ufx1VdfNeodjerbhsboP1fE3VDN5QdvZSEhIdBoNLh06ZLDKbaObkAQEhKChISEWh0/PT0dWq3W4Q9XR+9xlveBd999F3369LHbp753haxt34tEIkyePBkLFy7E6tWr8dprr+GXX34B0PDpepW9/PLLmDBhApYsWVLlCM2QkBAUFxdj5cqV6NmzZ62PXZ9rWhv+/v5Qq9U4cuRIo47AbSyVP+ccSU1NdUocDX2dW65fUlIS1Gq13eOW14Cvr6/dZ1ddX2/1fY7VRn1eyw3pu4b0W33IZDKMHDkSI0eOBFBxp+a1a9finXfewQsvvIBdu3ZBKuXPWqKbEUdIEbVACoUCY8eOBVBRT8Jyt6jq9O7dGwCwZ88e61+qK9u4cSMyMjIgk8nQrVs3m322bt3qsC7BsmXLHP6V1PKXuqr2a0rfffedw1vGW5Jalb/I1adPAFhHozkaJfPHH3802pD5yjHW9RpYhsQ7+iJdXFzc4Lt9BQYGYtiwYcjPz8eGDRvw22+/QSQSYeLEiXU+lkgkQr9+/SAIApYuXQqNRmMzgseSPNm7dy8OHToEmUxmlwiq77Wsq2nTpuHdd99FWVmZ3W2tG6q+bWiM/nNF3A1l+RFU1Q9mV7D0xfLly+0eMxgMtbqzWHWMRiNWrFhht/7ChQvYvXs3ANjUBqvufWDDhg31fn+uS9/ff//9UCgUWLduHTZu3IicnBz06NED7du3r9e5HencuTNGjRqFoqIiLFmyxOE2lrsvLl++vE6jmprqmpaUlFiTuJa7dDYnls+5c+fO2U2xEgTBepfEptbQ17nl+lX1h62lS5cCgMMkT11fb/V9jtVGfV7LDem7hvRbY3B3d8e0adOsd+a7cuVKk5yHiJoeE1JELdS8efOQkJCAgwcP1uqvU126dEHPnj1hMpnw9NNPY9euXSgvL4dGo8Gvv/5qva37+PHj4ePjY92ne/fuMBgMePLJJ3HgwAHo9Xrk5+fjm2++waJFixyeq127drjrrrtQWFiIBx98ECtXrsSVK1eg0+mQn5+Ps2fPYvny5ZgwYYLD0T0NkZiYiBdeeAFJSUkwGAxISUnBK6+8ghMnTkAmk2Hq1KkN6hPg+hfQ9957DwcPHkRZWRnS09Px7bffYu7cuY3anvpeA0sB219++QVr165FcXExCgsL8ffff2PatGmNUlDWUth5/vz5yM/PR9++fWtdzPxGlqSJ5cu/pRg3AERFRSEsLAy///47iouL0bVrV2s9FIv6Xsv6GD9+PD766CPo9Xo8+eST1kK2DdWQNjS0/1wVd0NYRmL+8ccfKCgoaLTjNsTUqVMhlUqxZ88ezJkzB6mpqTAYDEhMTMRzzz2HlJSUBp/js88+w/fff4+CggLodDrs2bMHzzzzDMxmM/r27WtTWN7y33PnzkV8fDy0Wi1SU1OxZMkSvPHGG/WOwd/fHzKZDDk5Odi+fXu1SXgfHx+MGTMGxcXF1vfHxhwdZTFz5kxIJJIqp+1Nnz4dPj4+2Lx5M5588kns3bsXOTk50Ov1SEtLw4EDBzB//ny89tprNvvV95rOnj0bM2fOxNq1a62jF/V6PbKysrBhwwY8+OCDKCgosLnJR3PSvn17+Pr6Ijs7G7Nnz0ZqairKy8tx9uxZvPDCC42ajK9OXZ5rjjz44IOQyWQ4ceIEXnrpJet3gytXruDNN9/E7t27IRaLrTc+uVFdXm/1fY7VRn1eyw3pu4b2W13cdddd+OqrrxAfH299nVy9ehWff/45srOzIZVKG63mIRE5H8c2EpHVBx98gIcffhipqan4xz/+Yfd4t27dMGvWLJt177//PqZOnYoLFy7Y3WWoT58+yMnJcThl4Z133kFBQQH27NlTbZKmsf+KOGnSJKxevRpbtmyxe2z27Nl2CZP69MmMGTPw+++/IyUlBQ8//LDNY0OHDsWlS5ca5YenRX2uQf/+/dG7d28cPnzY7suvVCrF5MmTrUXI66tfv36Ijo62Dt1vyI9MS0JFp9NBqVSie/fuduey/EW+qulm9bmW9TVu3DgoFArMnDkTzz77LD755BPrVIOGqG8bGqP/XBF3Q4wePRq//vor1q5da73rKAB8/fXX1pEKzta+fXvMmjUL7733HlavXm03EtHy/lRfarUaKpUK8+fPt5sOHRQUZL17psU//vEPbNu2DadPn8YDDzxgdyxfX1+7u/LVhkwmw7Bhw7Bp0yY8/fTT1vUBAQHYu3ev3fZTpkzBb7/9Bo1GA29vb4wZM6bO56xJdHQ07rvvvirvthcYGIhFixbh2Wefxa5du6pMJA8aNMhmub7XtLi4GJs3b7a7w2BlMpkM8+bNq7IItCvJZDI8//zzmDdvHtatW4d169ZZHxOLxXj44YerrdnVmHHU5bl2o7Zt2+Ltt9/GnDlz8Oeff+LPP/+02+aVV15Bjx497NbX9fVW3+dYbdTntdyQvmtIv9VVYmIiPvnkkyoff/LJJ5mQIrqJcYQUEVlFRETg119/xZNPPono6GgoFAq4u7ujY8eOePXVV/H999/b3bUuKioKv/zyC+6//37rX9tatWqFp556CkuWLKlyTr+bmxu+/vprfPrppxgyZIh134CAAHTq1AkzZszAzz//XGMx9rp68MEH8fnnn6N79+5wd3eHu7s7evfuja+//tphbZH69EloaChWrlyJkSNHwtvbG3K5HG3btsUrr7yC//73v41eQLk+10AkEmHx4sWYPn06QkJCIJVK4e/vjxEjRuCnn35qtAKoliRUfYqZVxYZGWmtz9KrVy+7UX+VR/xUVZC7PteyIYYPH47//e9/1sLxf/zxR4OPWd82NEb/uSLuhhgyZAjeeecddOjQAW5ubo167IZ45JFHsGjRIvTo0QNubm5QqVTo2bOn9XbtDSGTybBs2TI88cQTiIyMtL6nTpgwAWvWrEFkZKTN9mq1GitWrMBtt90GlUoFhUKBqKgoPPHEE1i1apX1rlf1MW/ePEyaNAmhoaE11nbp1q0bYmJiAFTUtbux9l5jef7556s9dvfu3bF+/Xo8++yz6NixI1QqFeRyOSIiIjBw4EDMmTMHH3zwgd1+9bmm8+fPx2effYbx48ejQ4cOCAgIgFQqhYeHB2JjY/Hwww/j999/r1UNSFeZNm0aFi5ciA4dOkAul8PDwwMDBgzA8uXLMW7cOKfFUZfnmiMTJkzAqlWrMGrUKAQEBEAmk8HX1xdDhw7F8uXL8dhjjzncr66vN6D+z7Ga1Pe13JC+q2+/1dUff/yBp59+Gl27doWfnx8UCgUiIyMxcuRIfPvtt/i///u/RjkPEbmGSGjs4QdERETXvP/++1i2bBkee+yxRh8BQ0QVzp07h3vvvRcdO3Z0Wu2exmQ0GjFkyBDk5ubizz//RLt27VwdUqM5deoUJkyYgK5du1rvOko3t5v99UZE1JxwhBQRETWJ8vJy61Sp+hQzJ6Jbw5YtW5Cbm4sePXq0qGQUERERVY81pIiIqNFpNBp8+OGHKCwsxIABA+pdzJyIWi5BEHDx4kVrfRjLjRCIiIjo1sCEFBERNZr8/HybothisZj1HYjIztKlS21q5ajVaowdO9aFEREREZGzccoeERE1OqlUivbt2+Pf//633R3diIgsPDw8MHToUCxatKheBamJiIjo5sWi5kRERERERERE5FQcIUVERERERERERE7FhBQRERERERERETkVE1JERERERERERORUTEgREREREREREZFTMSFFREREREREREROxYQUERERERERERE5FRNSRERERERERETkVExIERERERERERGRUzEhRURERERERERETsWEFBERERERERERORUTUkRERERERERE5FRMSBERERERERERkVMxIUVERERERERERE7FhBQRERERERERETkVE1JERERERERERORUTEgREREREREREZFTMSFFREREREREREROxYQUERERERERERE5FRNSRERERERERETkVExIERERERERERGRUzEhRURERERERERETsWEFBERERERERERORUTUkRERERERERE5FRMSBERERERERERkVMxIUVERERERERERE7FhBQRERERERERETkVE1JERERERERERORUTEgREREREREREZFTMSFFREREREREREROxYQUERERERERERE5FRNSRERERERERETkVExIERERERERERGRUzEhRURERERERERETsWEFBERERERERERORUTUkRERERERERE5FRMSBERERERERERkVMxIUVERERERERERE7FhBQRERERERERETkVE1JERERERERERORUTEgREREREREREZFTMSFFREREREREREROxYQUERERERERERE5FRNSRERERERERETkVExIERERERERERGRUzEhRURERERERERETsWEFBERERERERERORUTUkRERERERERE5FRMSBERERERERERkVMxIUVERERERERERE7FhBQRERERERERETkVE1JERERERERERORUTEgREREREREREZFTMSFFREREREREREROxYQUERERERERERE5FRNSRERERERERETkVExIERERERERERGRUzEhRURERERERERETsWEFBERERERERERORUTUkRERERERERE5FRMSBERERERERERkVMxIUVERERERERERE7FhBQRERERERERETkVE1JERERERERERORUTEgREREREREREZFTMSFFREREREREREROxYQUERERERERERE5FRNSRERERERERETkVExIERERERERERGRUzEhRURERERERERETsWEFBERERERERERORUTUkRERERERERE5FRSVwdARERERHQzMBgMOHXqFLKzs1FSUgK9Xu/qkIiIqJGoVCp4eHggLi4OYWFhrg7nlsCEFBERERFRFQwGA/bv3489e/bg4IG9KCnKhWA2AIIZgODq8IiIqLGIxIBIDJHEDdHt4jBo0CAMGTIEUVFRro6sxRIJgsBPUiIiIiKiG2i1WsydOxeH9m2H2VCC6CAdercXISpIBJUSkEsBkauDJCKiBjMLQLkeKCoVcDJZwNEkCUr0Ssjc/PDG7LcxZMgQV4fYIjEhRURERER0g9LSUsyePRsnj+zEbTEaTBwkRoAX009ERLcCk1nA6RTgy40ilAjBePmfb2D06NGuDqvFYUKKiIiIiOgGb7zxBg78/SdGdy3Dw0NFEIuZjCIiutVkFgiY/xOQpw/Cwg8/Q69evVwdUovCu+wREREREVWSm5uLQwf2oHvrUjxyB5NRRES3qhBfEd6cCJh1Bdi8ebOrw2lxmJAiIiIiIqpk586dMBs0uL2TCCIRk1FERLeyUF8RYkJ12LtnF8rLy10dTovChBQRERERUSV//bUNSkkZurdlMoqIiIBBHUTQluZj7969rg6lRWFCioiIiIjoGrPZjIsXEtAh3AS5lAkpIiICurYRASYdLl686OpQWhQmpIiIiIiIriktLYXZZISXu6sjISKi5sLLHRAEE0pKSlwdSovChBQRERER0TU6nQ6AGUo5R0cREVEFpQwABJSVlbk6lBaFCSkiIiIiIiIioirwBhdNgwkpIiIiIiIiIiJyKiakiIiIiIiIiIjIqZiQIiIiIiIiIiIip2JCioiIiIiIiIiInIoJKSIiIiIiIiIiciompIiIiIiIiIiIyKmYkCIiIiIiIiIiIqdiQoqIiIiIiIiIiJyKCSkiIiIiIiIiInIqJqSIiIiIiIiIiMipmJAiIiIiIiIiIiKnYkKKiIiIiIiIiIicigkpIiIiIiIiIiJyKiakiIiIiIiIiIjIqZiQIiIiIiIiIiIip2JCioiIiIiIiIiInIoJKSIiIiIiIiIiciompIiIiIiIiIiIyKmYkCIiIiIiIiIiIqdiQoqIiIiIiIiIiJyKCSkiIiIiIiIiInIqJqSIiIiIiIiIiMipmJAiIiIiIiIiIiKnYkKKiIiIiIiIiIicigkpIiIiIiIiIiJyKiakiIiIiIiIiIjIqZiQIiIiIiIiIiIip2JCioiIiIiIiIiInIoJKSIiIiIiIiIiciompIiIiIiIiIiIyKmYkCIiIiIiIiIiIqdiQoqIiIiIiIiIiJyKCSkiIiIiIiIiInIqJqSIiIiIiMhlxG6hkPn3dHUYdsTKoIq4RBJXh0IEAJB4RkPq06Fe+0q9YyDxbNfIERE1DBNSRERERETUZEQKP0h9OkDi2Q4iqcrucbeo8fAdshIQy10QXdUU4WPgO2QlRDKvOu0ndgu+lmBzzU8tiVcMJB5tXHLu5kDqHQeJZ1tXh9EkPDq+DK/eH9drX88e78Gjy2uNHBFRw0hdHQAREREREbU8iohxUMU8CYlHaxg1lwGIIPVsA6PmIsovfg/tlbWuDrFaZm0W9LlHAbOhTvspI++GR6dXkPNHLwgGTRNFVwWRFL63/YCyhEUou7DUueduJrx6fQBTWRqK9j/l6lCIqAZMSBERERERUaPy6Pwq3No9gtJz/0XZhW8AkxYAIJJ5wV39D6g6vtjsE1K6tE3QpW1ydRh1IgvsA7HcC7qMv1wdChFRjThlj4iIiIiIGo08ZCjc289A2fkvUXb+S2syCgAEQzFKz3wEzfG3qtxf4hENqXcsIKr+b+cSVStIfTtDrAy0e+zGulQSz7aQeEQ7PJfESw1AZH+MampIid3CIPXpCJHc94aYIiF2DwcAyPy6QebfEzL/ntapinZxeURB6tvl+nqxzL6hYgVk/j0hVgY57ohKFKHDYCxOgqkkucptHPaNVwwc/TSsKt7KRDJvSH06XZsmZ38MqU9Ha9+LpCpIfTpC7BZafUPEcki9YyrqJUmU1R4TEiWk3nEQu0dA6tcNIqkbRHJva99LfTpe38dL7fh0bmHXrnXVzzmbdkjcIfXpYHf9LetrulY19VnluKQ+HSCSuFd7vIqNq+8zouaII6SIiIiIiKjRuLd7BIKxHGUXllW5jT5zl906iVswvHp9AJFUBbFbCASTFkUHnoWx4JTNdvKQofDs8gZEcm+YytIh9WgNfd5RFB95FYIuD0BFXSpV3PPI2zqm4phiOSSqSBgKTqFo31MQK/3h1ecziMQyiFURMJdeReGeGTDrcq3nUYSPgWfXN5Czvh8EfQEAQOrbFV49F0Cs8IOpLA1it2CYSq5Ac+JtmIoTIQ8bAUXwYACAKvZZCIIZAKA5/hZMmqTrcW0ZA69eCyGSukEs90PRwf+D75AVKD76OrQpv9q01y1qPDy7/Qv5OybArM2utu8VoXdAm7q+2m2u981YePX+ECKRFGL3cAgGDYqPzIIh95D9tjfEm7thAERSD3h2nwdF+EiYSlIgVvgBgoCS0wuhvbLOegyvPp/CWHQO+owdUHX4PwiGUkg8o6HP3ofiwy9DMBRfD04kharji3CPngqzLh+CWQ+xWzDKEr5GWcL/7I6pS98Gjw4zIQhG6LP2QOoRBbHCHyKZJ1QdXwYAmMszUXz4Jbi1mQRl5F3I3TAYgrHEpk+8+3wMkdwX+VtHV9lv1nakb4cq7jkIZj0kqlYoPfsZyi4shbLVfVDFPQvBpIXEMxrlST+gJP49m2PUts9Ecl949/4YssC+MGkuQSRToeTMZ44Dq2WfETVHTEgREREREVEjEUHm3xPGwjMQjKV12lPVYSaKDr8Cc1kaRFIP+A5ZCc9ub6Ngx3jrNrKgAfDu/0XFj/1THwCCESKFH3wGfA2f/l+iYOck22PGPoui/c/ArM2G2D0cfnf8BlXHFyFxD0XRgedgLs+A2C0UfsN+g3vccyg58Xa1MXr3+RjGogTk/3UXIJgAVCSpJKoImIoTUX7hG4hEEnh0egWF+56osoaUquOLKDr0IsxlVyH1joOx6ByMRQlwazPFPiHVZjKMRQl2ibkbSb3jIHEPgy59W7XbWWPoMBNFB56HuSwNECvg3fczePdfhPxtd8Jcnl5tvADg1fczyHw6oWDnZBgLT1ds12kWvHp9ALNBA33G9uuxebaFoC9E3qbhAMyQeMXAd9AyePX+CEX7/mHdzrPHPCjDx6Bw/zMw5OwHUHHNfQZ8BcGgQfmlH2yPGVCIvC0jAcFk7Ue/YX84rCFVfmlFRVKq9X0oT/q+Ur/FQObfAyWnP6qxz6SebWH2yaw4JwS4RU+DZ7c5EIxlkHirkbd5JAAzlG0mw6v7XOiuboIh/5h1/9r2mXefzyDxjEb+X3fDpEkCRFJ4dp8HiUeUXUx16TOi5oZT9oiIiIiIqFGIZF4QSeQwXxupVBe6tM0VyREAgrEE5ZdWQebbyToFDgA8OrwIU0kKSuLfBwRjxba6fJSc/rBiilxAH5tjatM2WkcVmcvSoMvYDvd2D0Obuh7m8oyK9eUZ0KX/BWXYiBoaJ4XYPQzG4gvWZBQAGAtO2iRfatXW9K0wl12t2L/oHABUtNevC6Q+nazbyfx7Quodg/LkX2o8piJsGEzaHBgLTtYuhkr9DbMOmhNvQySRwy16ao3xSn06QBE8GGUXl1kTKwBQeuZjmEqvQhVjmwwSK4MrEoioGDFmKk5A6YUlUIQMsU6jk3i0gVvr8ShNXGJNrACAIXsftFf+gHvME7bHdAu9lpQ0WeOqjrEoAfq8Y3BrM8VmvVv0VAhmA7RXfqt2fwAQKwJQcuYTAAIAoPzyTxBMWqg6zkTJqYXW9mmT18BsLIUi/PpzqrZ9JvXpCHlQP5QlLq5IRgGAYETJqQV2Ux3r2mdEzQ0TUkRERERE1CgEs67iP8TyOu9ryD9hs2y6lgCRWH6ES5SQ+naCqSQZUt/OkPp1u/avO0TXzif16WBzDGN+vM2yZeSPId82aWMqS4NYGVB93IIR+qzdcFc/Bs+eC6EIHwOxIqCuzaw4f94xu3XaK+tgNmhsEkJu0VMhmPTQpv5e4zHlocPqlBgz5B21WTaXZ8FUlg6ZXxcH29rGa6kjZcg9YruhYIIh7/i1uk3X63IZixPsRswZcivObzmfLKBXxSH0BZD6drVeW6lfdwjGEkjcQiBS+FU6ZmKdR+GVJ62A1KstZIH9AFTUtFJE3AV95t8wa3Nq3N9YlABYnuMAIBhg1uZWJCkr1UqDYIRZmwOxW5h1VW37TGbZ7obrIxg0MGku2Kyra58RNTecskdERERERI3DpIWpLANSzzZ13tWsL7RZFkwVP/xFUrdr/+8OkUgMqXcsPDq/are/PveobT0ih8fUV/y/vujGk1ecQ6KAcO2/HSk68Bzc2kyGInQYPHu+C7FUBX3uUWiOz4FJc7HGNlpPV6lW1fXYyqC9sg5urcej5NT7gFgKRdhI6DL+stawqorYLRQynw4oPftZrWNwlMwRDBqIJG41xiu6VjTb7GBKotmogUgsBSQKa5LG4bmMmmvHslzfisLvytbjoYi40257fe5RiETSa2OTALPWvg9rokvbDLP2dbi1mQJDzgEoW90LsUyF8pQ1tdrfbCi0b4dZb/98AgCTHiKJwrpY6z67tp1gsO8zs0EDiczr+jHr2GdEzQ0TUkRERERE1Gh06Vvg3u4RSH062UxNsiGWAWZDnY4r6AphNpTCkHsExUf+2QiR1oPZgPKk7ytqEIkkkAf2g2evhfDq/SEKtt9X++NcK3Z+o/JLK+He9kEoW98HkUQJkUQObXLNyRJF6DCYjaXQZ++vcVsLiXsYjEXFN6wLh75SUfOq4jWXZ1m3NxUn3nCMCJh1BTYjhiSVRgpV3g4ATJapk2UVo9dKz34GfdbuWrTAcR+iuvSLYEB58s9wVz8OsTIIbm0mw6TNdlhkv7HVts/M5ZkAALF7GEylKXbbVW5f3fuMqHnhlD0iIiIiImo0ZQmLYdLmwLP7XIikHnaPixR+8Or9ST2ObIbu6nrIQ++wqStlJZZV/GsqIpntlD7BBH32XhhyDlqTKwBgvjZKSyR1r/MpTJok6HMOwq3NFLhFTYSpLB367L017qcIGwZ91h7rSK/aUEbebbMsDx0GscIX+vS/atxXn70XZmMp3NpMtFkvdo+APKg/dBm2hdUlnm0g9e1se/6o8TAbSmDIPlBxzKw9MGvz4Nb2QYfndPRccsRs0FTb9+WXVwMQwavnAki91dCm/GZTE6yp1LbP9Nn7IBjL4NZ6vM12Mv+ekKgibNY1Vp8RuQpHSBERERERUaMx63JRuGcGvPv9F37D/0D5pZUwFp4DRGLI/LrBLXoKzLr8eh275NQHkHqp4Xv7jyi/8C2MxYkQSVWQesdCGXkXCnY/fL1QdyMTK3zge/tqaFPXw1h4FmZ9EWS+naAIG46yi9fv2mbIOwZBMME95inorm4CBCOMRedrXe+oPGkFvPt9DgAoPfdfVDviBxVJB1lAL2iOza5TewSzHh5d3oQ+azcknm2givs/6LJ216pelWAoRsmJefDs+R68en8M7dU/IZb7QRX3LExlaSg5/bHN9vqs3fDo+BJ0aVtgKs+AInwUFGEjoTn6BgRjScUxTWUoOvQivPt/AZ/B30Gb8gtM2hxI3MIgD+wLkdwHRftqLtJtyD0M93bToYy8B6ayqxBMWhgLz1gfN5dnQJ+5E4qw4QAAbUrNBeMbQ237TDAUQXNqIby6z4Vg1kKXvhUS93AoQodDn70XElWr68dspD4jchUmpIiIiIjolnL+/HnMmTMHaWlpePzxx/Hoo4+6OqQWx1SciPyt46CIGA15UH/IA/tDMOthKkuH5sRc6NKvj6AxlWVAn3sUEGwTL4JBA33uUZgr1ecRjCUo+PtBKCPGQR48GPLg22DW5cFYdA75Ox+AcC3RVdUxzeXpFbWmbhgRYyrPrNjefH29WZt1bZ3h2nIO8rffD7fW46EIHw2RzAPm8kwUHXjOZrqUqfgCig7+H5QRd0EV9xwgkkBz/C2YNElVxlWZLmMbTNociBX+KE/5tca+locMASCGLmNnjdtWVnr+Sygj74Rb9BRAJEXp2c9RfmklKifAqotXe+U3GDVJcGs9Ae5tH4Zg0qL80kqUX1ppl3wTzHoUH30d7uonoAgbAbO+AIV7HoUh54DNdobcg8jfOgbKqAcq+lisgOna3RF16Vus2xkLTttNZ7O2K2ERIBihiLwTIqk7zOVZKD78ks025ZdXQxE2HPrcwzCVJNeqv6o6p7HgDEzl9klQQ+FZu0Lpte0z7eUfYS5NhbL1eLi3fQSGwrMoOjQT7urHIOhta1DVus+KzkHQ207RJHI1kSBU825IRERERNRCnDt3DkuWLMGuXdfrxXh6emLHjh3W5dzcXEx64B6M6pCN6cNY3YKcTyTzRMDYvTDkHkHh3hk1bu/V+xOIlQEo3P1wrY6vinsOqrjnkf1b5zpN8asvv5FbYCw6h+KDLzT5uWpLGfUAvHrMR/GRV6G98purw6GbxKSPxBg6egrmzJnj6lBaDI6QIiIiIqIW7dSpU1iyZAn27rWvxePnx1uiU/OiCBsJkURxrdZRzUQyFbTJzpl21lIoI+6EWV8IbdomV4dCdEtjQoqIiIiIWqTs7GzMnTsXBw8erHKbO+64w4kREVVN4tkWEo/WUMU+A0PBaZvpVtUp2vdkE0fWUogh8+8OmV83yIP6QXNqoc2dAInI+ZiQIiIiIqIW6f333682GQUAcXFxToqGqHrKVvdB5tcFuqzdKDv/JWoqZl5ftalj1Ziqq/fkTCKJEqqOL0MwlUET/x7KLy53dUhEtzwmpIiIiIioRQoODgYAiMVitGnTBklJSXbbxMTEODssIodKz3zklPNoU35x2p3lANgVFHcVwVSGwr+nujoMIqqECSkiIiIiapFefvll3HHHHcjIyMC8efPsHvfw8EBYWJgLIiMiIiLeOoSIiIiIWiSpVIrw8HB89tln1nWVR0Sp1WqIRCIXREZERERMSBERERFRi6TX6/Haa6+huLgYQMUUvoEDB1of53Q9IiIi1+GUPSIiIiJqkT777DOcPXsWACCRSLBgwQIUFBQAAEQiEYYPH+7K8IiIiG5pTEgRERERUYuzZcsW/PTTT9blF154AV26dAEALFmyBEqlErGxsa4Kj4iI6JbHhBQRERERtSjJycmYP3++dfmOO+7AlClTrMvdunVzQVRERERUGWtIEREREVGLodVq8eqrr6KsrAwAEBkZiTlz5rB4ORERUTPDhBQRERERtQiCIOD9999HUlISAEAul+P999+Hh4eHiyMjIiKiGzEhRUREREQtwrp167B+/Xrr8qxZs3gnPSIiomaKCSkiIiIiuuklJibiww8/tC7feeeduOeee1wYEREREVWHCSkiIiIiuqmVlJTg1VdfhU6nAwC0bdsWr732GutGERERNWNMSBERERHRTUsQBMydOxepqakAAHd3dyxcuBBKpdLFkREREVF1mJAiIiIiopvWqlWrsGPHDuvy7NmzERUV5bqAiIiIqFakrg6gKZlMJly5cgUajQalpaUQBMHVIRFRFcRiMVQqFby8vBAZGQmxmPnypmAwGJCammp9XySilkMul8PT0xPBwcHw8fFxdThOER8fj3//+9/W5QceeAAjR450YURERERUWy0uIaXT6XD06FHs27cPu/fuQ3ZeAcyCALMgAMxHETVfIhHEIkAiEiE0OAC3DRqEgQMHomvXrpDJZK6O7qam1Wpx6NAh7NmzB3sP7Ed+cdH190UiajFEIkAMEeQSKbp37oJB195Hw8LCXB1akygsLMTrr78Ok8kEAOjQoQNefPFFF0dFREREtdWiElJXrlzBK/+cheS0TJQZTNCpAoGIPoDSE5ApARFHXBA1W4IJMOiAsiLkZCYiYeUarFyzFuo2rfHRhx8gODjY1RHelBISEvDPV19FRn4uyox66AK9IOrWCnBXAHIZIGbBX6IWQQBgNAE6PYTMfGQfP4i/jx2Gx5df4NGHHsajjz7aogp8m81mvPXWW8jKygIAeHl5YeHChZDL5S6OjIiIiGqrxSSkLl68iFf+OQuJ6bkwxAyBqFUXiD38XR0WEdXLGOiLs6FLPoFj5/fghZkz8fFHHyE8PNzVgd1U4uPjMeuN15FSlAfjwA4QxURC4uXu6rCIyAnMBiNKUrJQsu8sFi9fhrKyMjzzzDMtZjr0N998g/3791uX582bh9DQUBdGRERERHXVIr6VpKenY+aLLyMhIx+GPpMg7jAUIiajiG5qIq8giLuMhL7HfYi/dBXP/98LKCgocHVYN40LFy7g5VdnIVmTD9P4gRD3joGIySiiW4ZIJoW4XThEk29HbpA7vvv5R3z99deuDqtRHDp0CF999ZV1efr06Rg0aJALIyIiIqL6aBEJqc2bNyM1twDGnvdDHB7n6nCIqBGJo7rD0HkskjNybO6iRNX7888/kVlcAPO9AyCKDHJ1OETkIiK5DOLxtyHfS4Zf1/0GrVbr6pAaJCcnB7Nnz7beqKZHjx546qmnXBwVERER1cdNn5ASBAHb/voL5RJ3iMI7uDocImoCoqjuKDOLsX37dleHclMwGAz4a+cOaH3dIWrFZBTRrU4kk0LUORr5JRqbaW43G6PRiNdffx35+fkAAH9/f7z33nuQSltMBQoiIqJbyk2fkDp//jwuXUmDENEZohZSF4GIbImkchhD43Di9Bmkp6e7Opxm78iRI8gqyAPiWrs6FCJqJkSxrVBq0t/Uif0vvvgCJ06cAACIxWK8++67CAgIcG1QREREVG83fQYnPj4e5QYTRGGxrg6FiJqQKCwW5Xoz4uPjXR1Ks3fq1CmUGw0QtWuZt3onoroTqZTQB/vg2MkTrg6lXnbt2oXvv//euvzUU0+hV69eLoyIiIiIGuqmT0gVFxfDZBYANy9Xh0JETUjk5gWTIKCkpMTVoTR7xcXFMAsC4OHm6lCIqDnxUEJTUgKTyeTqSOokLS0Nb7/9tnV54MCBmD59usviISIiosZx0yekysrKKn54yeSuDoWImpJMATMTUrVSVlYGMwRALnN1KETUnChkEAQBZWVlro6k1nQ6HV577TVoNBoAQEhICObOnQsxyzQQERHd9FrQp3kLagoR2ROJXB3BTUckZp8RUSUiEQRXx1BHn376Kc6dOwcAkEqleP/99+Hj4+PaoIiIiKhRMItDRERERM3Opk2bsGbNGuvyzJkz0alTJxdGRERERI2JCSkiIiIialYuX76Md99917o8fPhwTJo0yYURERERUWNjQoqIiIiImo3y8nK8+uqrKC8vBwC0atUKs2fPhohTt4mIiFoUJqSIiIiIqFkQBAHvvfceLl26BABQKBRYuHAhPDw8XBwZERERNTYmpIiIiIioWfj111+xceNG6/Jrr72G9u3buzAiIiIiaipMSBERERGRy50/fx4fffSRdfnuu+/GXXfd5cKIiIiIqCkxIUVERERELqXRaPDqq6/CYDAAANq3b49Zs2a5OCoiIiJqSkxIEREREZHLCIKAuXPnIi0tDQCgUqmwcOFCKJVKF0dGRERETYkJKSIiIiJymRUrVmDnzp3W5bfeegutWrVyXUBERETkFExIEREREZFLnDhxAv/5z3+sy1OmTMHw4cNdGBEgEokAiGAyuzQMIiJqRkxmAQAgkUhcHEnLwoQUERERETldfn4+Xn/9dZhMJgBA586d8X//938ujgrw8PAAIEapVnB1KERE1EyUlAMikfjaZwQ1FiakiIiIiMipTCYTZs+ejZycHACAt7c3FixYAJlM5uLIAIVCAZWHJzILXR0JERE1F5kFAERS+Pj4uDqUFoUJKSIiIiJyqiVLluDQoUPW5Xnz5iEkJMSFEdnq138gkrIVyCrkKCkiIgL2nRcgkqrQv39/V4fSojAhRUREREROc+DAASxZssS6PGPGDAwcONCFEdkbNmwYxFIP7D3LhBQR0a3OZBawP0GMyKj2aN++vavDaVGYkCIiIiIip8jKysLs2bMhCBWJnt69e+PJJ590cVT2evbsCS+/EGw9KUI2R0kREd3S/jwsoFjvjmHDhl+78QU1FiakiIiIiKjJGY1GvP766ygsLAQABAQEYP78+c3yjkVSqRRPPvk0ikzB+NcqEdLymJQiIrrVCIKAX/aZsXKPElHtumLcuHGuDqnFkbo6ACIiIiJq+f7zn/8gPj4eQMVts9977z34+/u7OKqqjR49GnK5HO+/Nw9zVmZgcAczercXITYCkIj5F3IiopaqqFTA0SQB+88LOHVVBXXnfnj//YUsaN4EmJAiIiIioia1Y8cOrFixwrr89NNPo0ePHi6MqHbuuOMOKJVKfPHf/2DzmRRsOlkKD7kWkf4meLgBMgnA2RtERDc/QQDKdEBRKZCcK4cgcYdU7olBdwzGP//5T3h6ero6xBaJCSkiIiIiajJXr17F22+/bV0ePHgwHn74YdcFVEcDBgxA//79kZSUhD179mD//n24mpGO0nxNRS0szuYjIrr5iQCFXAGVhycGj+iCgQMHol+/fkxENTEmpIiIiIioSWi1WsyaNQulpaUAgLCwMLz99tsQi2+uMqYikQjt2rVDu3btMH36dACA2WyG0Wh0bWBERNQoRCIRZDKZq8O45TAhRURERERN4uOPP0ZiYiIAQCaT4f3334e3t7eLo2ocYrEYcrnc1WEQERHdtG6uP08RERER0U3hzz//xNq1a63LL730Ejp06ODCiIiIiKg5YUKKiIiIiBpVUlISFixYYF0eOXIkJkyY4MKIiIiIqLlhQoqIiIiIGk1paSlmzZoFrVYLAGjdujXefPNNiHg7OiIiIqqECSkiIiIiahSCIODdd99FSkoKAECpVOKDDz6ASqVycWRERETU3DAhRURERESNYs2aNdiyZYt1+fXXX0fbtm1dGBERERE1V0xIEREREVGDnT17Fp988ol1+b777sO4ceNcGBERERE1Z0xIEREREVGDFBcX47XXXoPBYAAAqNVqvPLKKy6OioiIiJozJqSIiIiIqN7MZjP+9a9/IT09HQCgUqnwwQcfQKFQuDgyIiIias6YkCIiIiKievvuu++we/du6/Lbb7+NiIgIF0ZERERENwMmpIiIiIioXo4dO4b//e9/1uVp06Zh6NChLoyIiIiIbhZMSBERERFRneXl5eGNN96AyWQCAHTp0gXPP/+8i6MiIiKim4XU1QEQERER0c3FZDJh9uzZyM3NBQD4+PhgwYIFkEpb/ldLvV6PoqIilJSUQK/XuzocIiJqBCKRCCqVCiqVCt7e3hCJRK4O6ZbQ8r81EBEREVGjWrx4MQ4fPgyg4kv8/PnzERwc7OKomo5Go8H+/fuxd+9eHD54CNpyLSAIEFwdGBERNQrRtf8RiUQIi4zAoEGDMGjQIMTFxUEs5sSypsKEFBERERHV2t69e7F06VLr8uOPP45+/fq5MKKmtXr1aiz5egmMWh0EgxnRfuGICG8Pd7kSMokUIvCv6ERENzuTYIbOoIdGW4pzKZew6sL3WL1iFcJbR+L9999HeHi4q0NskZiQIiIiIqJayczMxJw5c6zLffr0weOPP+7CiJqOIAj49ttv8f2y5QiQemJ419vRObw9PJUqV4dGRERNyCyYcSU/E8dSzmJ74mHM/L8X8MFHH6JNmzauDq3F4dgzIiIiIqqRwWDAa6+9hqKiIgBAYGAg5s+fD4lE4uLImsayZcvw/bLlCFf64+URj2BA225MRhER3QLEIjGi/MNwf4/hmNH/XuSmZeHFmS8iNTXV1aG1OExIEREREVGNPv/8c5w+fRoAIJFIsGDBAvj5+bk4qqZRXl6OX35eg0CpF14YNg0qhZurQyIiIhfo0SoOj/W/F4VZuVi/fr2rw2lxmJAiIiIiompt27YNq1atsi4/99xz6Natm+sCamL79u1DmaYUg9v3gFKmcHU4RETkQl0jYuCv9ML27dthMplcHU6LwoQUEREREVUpJSUF77zzjnV5yJAhePDBB10YUdPbvn07YDCjR+sOrg6FiIhcTCQSoVfrjsjNzEF8fLyrw2lRmJAiIiIiIoe0Wi1ee+01lJaWAgDCw8Px9ttvQyRquXeWEwQBx44eRbRfGLxYM4qIiAB0i4yFYDDi6NGjrg6lRWFCioiIiIgc+uCDD3DhwgUAgFwux8KFC+Hp6eniqJqWTqeDXquHn8rb1aEQEVEz4afyhiAI0Gg0rg6lRWFCioiIiIjs/PHHH/j999+tyy+//DJiY2NdGJFzlJSUQBAEuMmVrg6FiIiaCaVMAQgVnxHUeJiQIiIiIiIbFy5cwPvvv29dHjNmDO6//34XRkREROQ6ErEYAgQIguDqUFoUJqSIiIiIyKqkpASvvvoqdDodAKBNmzZ4/fXXW3TdKCIiInI+JqTIadxkYrQPUMFNxqcdETlXhLs3Im6RejChbp5opfJxdRjNFvuneoIgYP78+bhy5QoAwM3NDR988AHc3d1dHBkRERG1NMwM3KTkkorkTvsAFSQO/mLpo5SifYAKconzLrFCKkaEtxLuMonDxzuHemH9433RLax5/Ch0l0mYICNyoSClB9p7BVj/RXn4wl0iq/fxwty9EFlFouG9XmPxce+7633sm8nsbsPxRX/bqVXV9U1LVF17HfUPXbd69Wps27bNuvzmm2+iTZs2LoyIiIiIWiqpqwOg+on2d8e6GX0AAPO3JuL7o1dtHr+nUwjeGK7GPd8cwvnspi28NriNH164LRoxgR7IKtHBWylFfpkBa+IzsPLYVZTqTQCAcr0JiTklKDOYmjSe2uoZ4Y0lk7rhoZXHcOhKoavDIbrlvNjxNtwf1RkXi3NhFgR4yBQIUnrgYM4VzDuxBcklBXU63rzuoxCgVOHev75tmoBvEullxbixvMGt1jfVtddR/1CF06dP47PPPrMujx8/HqNHj3ZdQERERNSiMSF1kzOZBTwzMAq/nsqwJn6caUCULxZP7Io/z2Zhxo8nUKwzQiISYXyXULx6Rzscu1qIo1eLAACnMjW4a+khp8dIRM3bA9u/Q5nJAADo6BOMZYMnY+mgSRiz5Wvozc0jgX0zeffkX64OoVlj/zhWWFiI1157DUajEQAQGxuLl156ycVRERERUUvGuUo3ud9OZ8JbKcM/+rWu034quQRRvm7wUVadkxQBiPBWwtetYgqNTCxC+wAVvBTX9xnfJQwAMHdLIop1FV9iTYKAn06m48GVx1CkNVq3dVRDSiWvmDankFas81ZKEeqlsIvFSyFFpI8b6lpOVSkVI9LHzW4aoZdCijDvits5R3i7Wac/Wtp2Y1weCgna+rtDKraNIMhDjta+bg6nRvq5y6zHbevvjmBP+3YBQIinAq193azLYV5KeCrsr0uolwJ+7vWfzkR0MzhTmIXVl08gQuWN3gGRiHD3RmsPX4fbeskUaO8VAIVYitYevnCXyqGQSK1TANt6+jvcTwQg3N0Lforqa+JIRWJEqLwR6ubp8PHKdalqe8zKWnv4IsTBsYOUHoi+Ifa6nOvGGkl16Zsb1aUPxBAhwt0bvnI3h9tWFnItRpnI/r3zxraGunlaz195mmdbT38EKlV2+9fU3upqSDX1NW+uzGYz5syZg8zMTACAh4cH3n//fSgUjj+3iIiIiBoDR0jd5BKyNfj9DPBI70isPJ6GLI2u2u2jfN3w1sgY9Gnlg+wSHQJVcpxML8abG87jSmG5dbvbov0wd1Qs/NxlKNIacS5Lg//suYxfpvfGmxvOYU18BgBAIgIEATCazXbnOpdlO1Wwc6gXvp/aA9NXHcf+lIqpOP1a++LL8V3w8MpjeKBrGHpH+sDHTYakvDI8teYkirRGvDc2Dr0ivOHtJkNOiR5P/xKPi7ml1bbT102G98bFYVCUHzI1OngppbhSUI73t1/A0atFGNjGD//oX5HEe3ZglHUa4Zd7k7HxfLZNXPd3CcWA1n7wcZdh9OIDSCvS4q4OwXjhtmj4u8tRpDXAx02GVcfT8PHOJBjNFXNBxsYFY1K3sGv9JEKwpwJlehM+/fsSfj2VYY319WHtERfsgefXnsYnd3eEu0yCIE85vj9yFe9vv4iOwZ5YeGccVHIpQrwU2HguG7PWn7Weh6ilyS6veO/wkbuhd5tIPKHuh2GbFiGzXGOz3eyuwzEsrD0G/vlfvNZ5KGK9AyERi/FJn4paUXqzCeO3L7fZp7NvCD7ofScUYilC3b2wN+syXji4DqVGvXUbiUiE/+swGA+17QGtyQiFRIoyox7/PrsHa5Ljrdu912ssFGIp5p/cWuMxHfl64AM4V5iNFw7+ZrP+2bgBGBsRh95//Lte55rdbThaqXxx17ZvAKDWfVNZXfvgw9M7sKDnWEjFEoS4eWJP1mXMOrweBfpym+NObtMNz8QNgEoqR6lRDw+pHN9cOIwvzu2FcMMxF57ajvd6joFKqkB8QTqe3b8WE6K6YExELABAJhYjyM0TBbpyLIzfji3pibVq7439U5/21veaN1fffvst9u3bZ12eO3cuIiIiXBgRERER3QqYkGoBPvv7EsbEBuGFwdF4Y8O5KrcL9lRg5YM9cTG3FHd8uQ85pXqo5BJ8ek9HfDulO+5aehClehNiAlX44v4u2JyQjTc2nIfeZEbPCG+8OKSt3TF3JOVhTFwwFoyNw8e7LiG1sNzBmWv2ZP8ofLU/Ga/8cRY+Sil+fLgX5o6ORUaRFmtOpuPl38/ASyHFjw/1xJyRajy88ni1x5s9Qo22/u4Y+r99yC2t+IHQIdgDPSN8cPRqETaez0aJzoglk7rh9Q3nqqwh9ezANlh66ApeXX8OrX3doDWYMKFLKN4dG4ePdyZhycEUmAWgU4gnvp7YFTKJCPO3XgAA/HD0Kn6oVNtLIhLhkd4ReGdMDC7mliI+o9j6mJtUgif6tsK0H46iUGvE4DZ+WDKpG64UlGNQtB8eWnkcBeUGDIjyxbLJ3bEvOd+aFCRqabr6VSRyL5fk42jeVTyh7ofJbbrhs7O7rdv4yt0wOiIWv105Da3JiKf3/4olAx+otk6St1yJh9v1wqQd36PYoENn3xCsHDIN/4jph0/P/G3d7rUud2BydHf889Af2JSWABGAZ+MG4t2eY2A0m/HbldN1PmZjqO+5atM3N6pLH/golHiobS+M374cxQYd2nr6Y+mgifjfgPGYvPMH63ZPqPvipU5DMO/EFqy6dAIA0CcgEosGToAA4Itze22O+Ui73pi04wcUGbTo6R8OAPjy/D58ef564kQmluDZuAH4qM9duPevZbikyW/y9jrzmjvDkSNHsGjRIuvyQw89hCFDhrgwIiIiIrpVcMpeC5Cp0eH7o1dxb6cQxATaT1+w+Ee/1vBUSPHy72eQcy1JU6o3YfbG8wj1UuCeTiEAgBl9W0FnNONfmxOgN1WMfDp6tQjHrhbaHXPd6Ux8tOMi+rb2xban+mP70wPw5fjOmNYjHB4Kx3fbc+RMpgYHryWFCrVGrDmZjtvb+kNrNFlHUxXrjPjpZDr6tvKFfw1T19oHqHAxt9SajAKAs1kldsXfa5KYW4JdSXkAgJSCchSWG/Hy7W3xd1IeFh+oSEYBwOlMDb4+kILJ3cKtUxwtlFIxWvu6IdrfHbsv5aNcb8aw9gE22wR5KvDV/hQUXpviuPtyPhKySzB7hBqf776MgvKK+jr7kgtwJlODsXHBdWoHUXPW1ssf7b0C0M0vDC91vA3jIuOwNS0RZwuzkFmuwc7Mi5jQpguklaZ3jY/qDIVEijWX46s5sq1IlQ8+Pr0LxYaKkaSnCjKxIzMJ4yLjrNv4KdwxJbo7fk85g01pCQAAAcB/z+3FmYJMPN9hYJ2P2Vicda769MFHp3da40rS5OGzM7vR3T8c/YMqRqKqpHI8EzcAf1w5Y01GAcCh3FSsSDqGx9r3hkx8/TOjlcoXn5zZhSKDFgBwNC/N5pwqqRxRHr6I8vDF5qsJkIjEuC3E/o8mTdVeZ13zppabm4s333wT5mujnLt164Znn33WxVERERHRrYIjpFqIRfuTMaFLKP45tB0e/+mkw236t/bFlcJyeCqkFTWKRBU1MEQiEfJK9egS6oWVSEO3MG+czdbYFUk/WMUooq8PXsE3h1LRIcQDMYEe6NPKF6/e0Q5PD4jCEz+ftJu658jRG5JdVwvLIRaJrAXRreuLKkZghXkpkVdmqPJ4+5Lz8UjvSHx0VwdsSczBkdRC5FezfVVuHDkVG+QBP3c5EnJKEO3nDktRKxGAgnIDZBIx4oI9sC+5AK193TBnZAz6tfZBbokeGp0RAgCFTIzwa/WrLIq1Bly4YRri1aJyRPgo7e6SeLWoHOqAqhOPRDeb93uNg1kQYDCbkKUtwb+Ob8YvlaZJrUg6juFhaowIV2Pj1fMQAZjUphsSi3IQX1D7kYJpZUV20/6ulBRgaGg7iFCRhOjsGwKZWIL9Ocl2+x/IScFj6r4IVKqQoy2t9TEbi7POVdc+yCjTILW00Ga7gzkpAIAefuHYn52C7v7hcJfKcaE4F9GefrC8eYoA5GpLoZIp0M7TH+eKsgEAWeUapDi4y2KMdyDmdBuBbn7hyNaWoNSohyAIEIkq6jk5o73OvOZNyWg04o033kBeXsUfXXx9ffHee+9BKuVXQyIiInIOfutoIUp0JvxvXzLeGK5G/9aOCwB7KqVwl0nw7/s62T1WUG6A5lpRcne5BJpKxcgtisqrTuiYBAGnMjQ4laHBmvgMfHPIAz8/3Auzh6sxbcWxGuMvuOHYWmPFX2sLb1ivM1Ssd5NXP/rqgx0XkVJQjjFxQfjwzg6QS8WITy/G+9sv4HhacbX7VpZbYlsPxPNaEfhxccEY0ta+KHBiTkXySARg8QNdoTWacMf/9tvU9jrwf4MgFtkWR7+x/QCgNZgdrtcZzHCT1X70GVFzV/kue47sy07GZU0epkZ3x8ar5zE4JBqtPHzxXh3vllags59SrDUZIRdLIBNLoDeb4C6VAwCK9Fq7bQuvrVNJ5chBaa2PWRWhitSFxEGh74aeqy7q2gcag/12ln0tx/KUVRTHnhzdDXe36mi3fWJRjk27c7X2dQIVYimWDpqIlJICDN7wBfJ1ZQAqiqmfuu8Vu/fV2nLmNW9OFi1ahGPHKj6fRSIR5s+fj6CgIBdHRURERLcSJqRakJXH0vBgz0jMuqMdfjudafd4lkYHmUSEe745XO1xckr0CHFwR7hQL6XdOolIBJNg/6PqfHYJkvJKERvkUYcWNB6zAKw6noZVx9MgE4vQM9IHb41QY/EDXTHwP3utUxFrcmPbLImlH45exdJDV6rcL9rPHVF+7nhr43mbZJS3Ugpfd3k9WkR0a1t16QTe6DoMbT39MSW6O/QmI36/cqbRz2MpqB7qYLRNmLsXTILZOlKmoQp1WnjL7d9rQ+o50qex1LUPHN0p0LJvtrbiWFnXRhR9cW4ffk05VWMMjj5XOvkGI1DpgbnHt1qTUQAQ6eEDqbj+FQicec2bi/379+Pbb7+1Lj/55JPo27ev6wIiIiKiWxJrSLUgBrOAT3YloUOwJ+7uYF9jaP3ZLLQP8ED3cMc/duSSiqfDzqRcdAjxRFt/21tZ393R/phvDm+PziH2P0Y8FBJEeLshrcj+L87OYGkLUNEvB1IKsPZUBryUMgR5VCSELCPClNLavwwu55fhTKYG93YOgUxi/9d4y3lL9BXHVt1QR2tajwiYeHc8ojr7NeUUyox6vNxpCIaERGN7xkW7O7hpDDooJQ37O0t8QQZytaW4t5XtSFJ3iQyjw2NwJCe10e6klqTJQ6x3kE3tpBA3T/Tyb/y7m9Wlb+raB15yJQYHt7HZ9p5WHWEWBOzKTAIAnMxPR2ppIR6I6gJH45jk4ppHfZZcO6dKapvUf7BtD5hvSGA1ZXtvdmazGQsWLLAu9+/fHzNmzHBhRERERHSr4gipFmbj+Ww8ml6ErmHedo/9cPQq+rbywaIJXbHkQAqOpRVBJBKhrb877u8cisUHUvDXhVx8c+gKxsYGYfHErvhoRxKyS3QYExfksAaTl1KKHx/uibWnMrHpfDYKyw1o7euOGX0joZCK8dHOJGc0286v03thx8U8HEsrRLZGj1a+bpjSIxxHUwtx9VqS7GJeKTRaIyZ0DUNBmQFaoxlZGh2KdfbTFSubtf4svp3cDase7Illh1JxpaAM/io5uoR54a4OIRjx1X5kl+ix53I+/tGvNXJK9EgrKseQ6AC08nVDhsY1STqim5nGoMP61HOY2KYrAGBNsn0x8xP56RgVEYM7I+OQWJQDkyAgSZNXp/MYzCbMO7EVn/S5G5/2uRurL5+AUiLDM3EDIBKJ8M7JbY3SHgD47uIR3NOqIxb2GocVSUcRqPTAhDZd8VfGBdwWHN1o5wHq1jd17YMzBZmY2rYHgt08kVSchwHBUXhM3RdLEw8i+VodKJMg4OVDf2DxwAn47rYp+CHpGNLLihCk9EB3/3AMCIrC/duXV9uGC0W5OJWfgRc6DkaZUY88XRlGhqshFYlRfsOUz6Zs703NLMBQroX+WhHz4OBgvPPOOxA3YIQZERERUX0xIXWT0hnNSMwpcVhjaOH2i3h7VIx1OwujWcDTv5zC2LggjIoJwujYIJTqTbiYW4p5WxJxJqtiSkWJzoQpPxzDk/1bY0afVigzmPDb6QwcTS3CI70jbc71zz/O4pf4DIxQB2JGn1bwdZehWGvEwZQC/PP3s7iUf31aRbnehMScEpQZrtfXKL22TmuwrblR4mDbytuX66uv0TH1h2OY0DUUE7uGIdBDgdxSPb45eAW/xF8vgFyiM+G5tafwSK8IvDMmFhKxCF/uTcbG89lVxgUAF3NLcdfSQ5jSPRwTuobCSylFlkaHE2nFmPjdEet2/7f2FP7RrzWmdg+HGcDfSXmYtf4sFk3ogsxKSamMYi3cZPY/BjI1Wnjl2b9EMzRam34lullllWusyYLaWJl0DBPbdEV6WTH2ZF12+Liv3A1To3vAQ6aAwWzC+GtJjqulRZA7+NGdrytDYlEOhEoxbE5LwOSd32Na2x54pdPtMApmnMxPx8yD65Bedr0GXV2O6cj5omw8sfdnPNKuF97oOgxnC7PxxpENmBDVBWHutn9UqMu50suKceOpq+sbR2rbB0DFFOlZh9fj+bhBmNSmK0qMerx1bJPd1LyT+em4a+s3mBrdHdOiu0MlUyCjrBhH8q7i4b9X1dhWMwQ8sfdnPBXbH4+q+8BgMmJbxgV8f/EoOvmGWKfe1dReR/3jrGvuam5p+RCuJaMkEgkWLFgAHx8f1wZFREREtyyR0Ny/PdXg3//+Nxav+BmGsa9CpOSdx5pSKx83bH2qP97ccA5r4mt/ZyuixiAUZ0O5/Qu89NRjmD59uqvDaVJarRYJCQmIjo6Gp6f9lNiazJs3D6s2/QHzyxOaIDrX6R/UGt8Onowvzu3F52f3uDocAvDdbVOgEEsxaef3rg6FaiA9mwq3dQesyy+++CKmTZvmwoiar9zcXEwc/wAGhXfGxF6jXB0OERE1E8/8+C6G3zkac+bMcXUoLQZHSBERNTMvv/wyDh48CJVKhalTp2LKlCnw8nJtoevmYGxEHIxms8PpekRUNVGeBsqN10fwDh48GFOnTnVhREREREQsak5E1OykpqYCAEpLS/H111/jrrvuwldffYXi4uIa9myZ2nr6Y3R4DO5u1QG/pMTbTRkjourJj1yA6NrNNkQiEWbNmgWRyFF5eSIiIiLnYUKKak1vqqhbVaStvug3ETXMe++9h6ioKOvyrZ6Yer/XWDyu7osfL53Aeyf/cnU4VMnV0iKklha4OgyqgeBVcddcQSyCzE0JDw8PF0dERERExCl7VAeZGh3uWnrI1WHQLUqecgQyYzn++9//4r///a+rw3EJS2Jq6dKlmDt3LsaMGePqkJzigR2sT9RcvXF0g6tDoFrQ942BsVUgjMcvIOhyvqvDISIiIgLAEVJEdJOQJx8BJ5hUMJvNWLFihavDIKKbhVgEQSmH5/l06EpKMWfOHPz222/Izc11dWRERER0C+MIKSK6KeijekGRsJNJKQBisRgPPvigq8MgopuI9GI6xAYTAGD37t3YvXs3ACAmJgaDBg3CwIED0bFjR0gkEleGSURERLcQJqRuIQEqOZ4bGIXYYE+o5LZfOCd/fxSlepOLIqPq3N0xGE/0a42pPxyDRldz/a66bn+z0LfuBXHSQbz01GOYPn26q8NpUqdOncLbb7+NlJQUm/Ut8a57bTz88Hm/e7Egfjv2ZSe7OpybGvuSHDKboVx7ANLkLJjkEkhu+KxPSEhAQkICli5dCh8fH/Tv3x8DBw5E//794e3t7aKgiYiI6FbAhFQD+Cil+H5aj1pt+/nuy9iamNPEEVXvP/d1hkQMvLftgjX5NKFrKKb3bgUx77bTbPm6yaAO9IBUfP0aTegSikd6RzpMJDranm4ub775JtLT063LLTERZaGQSKH2DoSnTGFdF+MViI/63IV3T27DgZwrLozu5uKoL11pWGg7zOx4G+7ZtgxmCK4Op0bN4XnXFDGIyvSQJaYBAMRiEWRubnh8+nQcOXIEx44dg8l0/TOksLAQGzduxMaNGyEWi9GlSxcMHDgQgwYNQrt27XhnPiIiImpUTEg1gEZnwkvrztismzNSjR4R3rj3m8M267M0OmeGZsfPXYYeEd54a+N5nEi/foeu3FKDC6Oi2lh3OhP7kgtQpL1+rXzd5VAHejhMJDranm4ukZGRSE9Pb9GJKItLmjzcuXUp0suuvy8ppTKovQOhaiaJlZuFo750JS+5EmrvQIhEwE2Qj2oWz7umiEFQKWDy94QkTwORWYDZaMTEiRPx2GOPoaSkBAcPHsTevXuxd+9e5OXlWfczm804ceIETpw4gS+++ALBwcEYMGAABg0ahN69e8Pd3b3RYiQiIqJbExNSDWASBFzILbVZZxmtcuN6VwvyqPhyW6JvOVO4bhWFWiMKtbW/bnXdnpqfjz/+GImJiWjTpg08PT1dHU6T0ptNuFDMwsqNgX1JDolE0A/pBLdf9wMATAYDsrOz4enpCQ8PDwwbNgzDhg2D2WxGYmIi9uzZgz179uDMmTMQhOuZxKysLKxduxZr166FTCZDz549rbWnIiMjXdU6IiIiuokxIdUMTe0ejik9wnH/t4cxuVs4RsUGQSISYc/lPCw9eAVao7lOx5s1tC2GqwOv/Xc7PD0gChnFWvzj5/gq9wlUyTG9dyS6h3tDLhXjUl4ZVhy7ipPXRlepA1X4+O6OmLclEYdTCwEA/u4yfDulO4q1RkxbccymPRO7hWHS90ehq2Ps7jIJJnUPw8AoP/i6yZBcUI6fTqTh4JXCWsdqicHSpxO7hmFMXDDMgoDVx9Px57ksAMCDPSMwMiYQMrEIf57Lxg9Hr9rEUtfrUpu4FFIxJncLw6A2/vB1lyGtSIu/LuTg9zNZ1m1urAn1zIAoTO0RDgD48aGeMF/7wfDK72eQkFNaZQ2pOvXTssO4p1MI7u4UAoVEjL3J+Vi0LwV6U92uH9WPUqlEly5dXB2GjdtD2uLlTkPw7P5fcaW00LreR67E97dNxdcJB/B76lkAQGffELzXcyz+dXwzJCIxZrTvjSA3D5wvzMHn5/Ygq1xj3f/GukeDg9tgTrcRAIA3uwzDzA6DAQDLLx7BmuSq37MAYFxEHEZFxCDc3QvZ2lL8lX4BvyTHWwfnyMUSTInujiEhbeEjVyKrXIM/r57D+tRz1mPUNvYQN08sHvgAViQdxerLJ23iUEqkWDFkGralJ+J/5/db198V2QGjI2IQ6uaFYoMWOzKSsDLpGAyC2e7ccrEUD7friXB3b8w8uA6XS/IxMkyNO1t1QKibJwr05TiSexU/XDyKMpPBYV9aNGa7ncmZ17Om511116ZAX4bvb5tqPafebMLV0iL8kXoG29Iv1Lpdgxrw3K+JUR0OU6gvJBkFAIDvvvsOc+fOtdlGLBYjNjYWsbGxePzxx1FQUIB9+/Zh79692L9/PzSa688Bg8GAAwcO4MCBA/joo4/QqlUr69S+7t27Qy6XNyheIiIiujUwIdUM+akqpmO9PKQtyg0mfLIzCdH+7vjn0Hbo19oX01edgEmo/fyH5Ueu4lSGBp/d2wnfHUnF7kv51SYWIn3c8ONDPZFXqse/d1+CRmfEA13CsPLBHnht/Tn8cTYLl/LKEO6lxB3tA6wJqYFt/NDWXwWJWIT2ASrrKLHRcUHQGc11Tkb5usmw8sEecJdJ8J89l3EhtxRhXko8NSAKOuMlnEgvrlWslfv0hcHRKNWb8PHOi+jf2g8f3d0BOpMJPcJ9UKo34tNdSejTyhdvDm8PrcGENfEZ9boutY3r/XFx6B7ujY92JiE5vwzBngoMVwfCz12Obw+nWvuhck2oNfHp8HaTYnrvVnhzwznrqLwrheUOt69LPJY2PjMwCgKAz3ZdQrsAFV4f1h7+7nL8a3NCna4htRxeMgXU3oFQSGw/NqQiCdTegfBVXJ++4yapmHY0PKw9ApUeWH7xKNykUrzRZRi+8Z+IO7cutSYVbqx7dDwvDf8+uxsf97kbyy4cxoGcisLuudqqR52KAHzW9x7cHtoWi88fwPILR+Ahk2NYWHv4yJVYkngIMrEEywdPRrSXPz46tQsXi3PRP6g13u81Dr0DIvGv41vqFHtmuQblRgMebtfLLiE1OjwWnXxD8O7JbdZ1n/S5G7eHROOL8/twNPcgwt298Urn2zE4uA2e2PszhErnHhMRiwCFCt8nHUW0p/+1xEs3vNF1OD45vQtf516Fp0yB3gGRmN9zDF469LvDvgTQ6O12Bldcz5qed9VdG41BZ70GAOAlU2JQcBv8u++9mHtiC3669vyoqV0/XjpR5+d+7TtVBN3tneG+6m8AwMaNGzFjxgy0bt26yl18fX0xbtw4jBs3DkajEadOncLevXuxZ88eXLx40WbbK1eu4MqVK1i1ahXc3d3Rp08fDBo0CAMGDEBQUFDD4yciIqIWiQmpZkxvMuPfuy8DAI6lFSG7RIevJ3bDfZ1DbBIlNcnS6JB6LVmRqdHVOJ3wtTvawU0qxiOrjqOgvOIv74euFMJPJceckWpsv5iLUr0Jh1ILMTDKz7rfgCg/7L2cj9ggDwxo44cLuaVwk4nRPcwbSw6mVHW6Kr0+rD3CvJQY8/VBpBdrAQAn04ux8Xw2ZNeSLbWN1aLcYML/9iUDAI6nFaNfa1/MHq7G2lMZ+GKv7fqHe0U67OfaXJfaxKUzmjFcHYj/7rmM9dcSQqczNfjrQq61fY5kl+ittb+S8spqdSe9uvaTWQD+s+d6G1v5uuGR3pH4aGdSi7pzHzWtzr6heOjvVdZlk1nA14MewG0h0diVecnhPiVGPVJLiwAA6eXFtZqCNj6qC0ZHxGLmwXXYePW8df2uzEuQicQAgKnR3dEjIAKP7/kJu7MqntvH89NgEsx4qdMQ/JF6Fkdyr4+KrE3sa5LjMb/naHTzC8OJ/OtF6CdEdcElTR6O5VUUkr63VSeMi4zDs/t/tY6YOZGfjssl+fjljkcwLjLOZlRPF98wTNr5PQBgf3YKRADe7DoMh3KuYNmF6/UJ92UnW9tXlaZod1X+GD7DZtlLpgQA/DbsUZv1OzIu4pMzf1d5HFdcz9o+7xxdGwGw2/5o3lV4y5V4JnaANSFVU7sMgrnOz/26MEUFw+CphEyjhdlsxqJFi7BgwYJa7SuVStG9e3d0794dzz33HDIzM63JqcOHD0Or1Vq3LSsrw86dO7Fz504AgFqttk7t69SpEyQSSRVnISIioltN9d9kyaUsSQqLvy/lI7dUj6HtAprsnFKxCIOj/bAjKc+auLD4JT4dXkoZekX6AAD2JecjJsgDgaqKofkDovywJzkf+1LyMehaoqp3pC/kUjH2JhfUKQ6JSIQR6kDsTMqzJqMqM5iFOsVqseFcts3ymSwNQr2U+PPG9ZkatPFzXLC1putS27iMZgEFZQaMiwtG93DbgtUGc+ONRahPP/15QxtPphdDLhGjlY9bo8VFLd+flZIsAHDyWtIm2tO/Uc8zOiIWedpSmx/5FpbpcEND2yK7XGNNXlj8knwKAHBHaDub9bWJ/c/Usyg16DA+6vr0ytYevugdGGkzxWpsZCwKdGV207fOFmYhrawIQ0La2p776lmbZQFAtrYU3fzCMDo8BnLx9R/0lvZVpSnaXRW1d6DNvxB3T4frQ92rL9DvqutZG46uDQDEegfhX91GYOWQafh9+KP4Y/gMjAhTI9TdC24SWa3b1dS0Yb7W/966dSvOn7ePpTZCQkIwfvx4fPrpp/jrr7/wn//8B5MmTUJ4eLjdtomJifjmm2/w2GOPYeTIkZg9ezY2bdqEwsLC+jaDiIiIWgiOkGrGMort78yXWay1FihvCt5KKRRSCdKL7JNAlnXB186/93I+gIqpeqczNQj2VGDf5XwUlhnw9qgYyCQiDGzji1KdESfSiuoWh5sU7nKJdWRXQ2O1yNTYblt8rfj3jeuLtEbIpWJ4KCQo0ZlsHqvputQlrhfXnca80bH48aFeKCg34EhqIbYkZOOPM1mNNj2mPv2UYdcfFYksX3dZI0VFt4KMctu7vRUZKp5XvvLGTWyGunnialn17zFBSk+kl9nXQcrVlUJnMiJIaVs8vjaxl5kM2Hg1AWMjYvHeyb9QbjJgfOvOMJhN+C3ltHW7cHdvKCUy/DZsOgBABFHFnecgQoBChQClyuZcaQ7ukvfBqR3wUbjh0773QG824mR+Bv7OTMKqSydQatQ7td1VuXPrUpvlYaHt8WKn23D3tm+ste4AoNhQ/V1nXXU9a8PRtekdEIlvBk/CzoyLWJxwAFnlGhgFMx6I6opH2veCUiJFuclQq3Y1NZNKAbFUArOx4nPtyy+/xOeff96gYyoUCvTv3x/9+/fHK6+8gpSUFOtd+44dOwaj8fqo2qKiImzatAmbNm2CWCxGp06dMGjQIAwaNAjt27eHyMGdY4mIiKjlYkKqGfNSSu2mR3m7VRS+biplBpP13DfydqtIRlimdiXllSGzWItBbfzgrZQi+9p0wIJyA9zlEvSM8MGAKD8cSi2EsY4jfsr0JpgFAT5uVSdA6hKrRVWls8xVrBfB/stxTdelLnEdvVqEcUsOorWvG3pG+GBoO398eFdH9I70xVub6veX6xs1Zj/xp8Kty1I4W3lDDSl/RdW3fjdXUeuusX90lhr18KkhsVBm1MNbbp/Md5PIoJBI7ZI6tY19TXI8JrTpgtERMViXcgb3tu6EnRlJyNOV2Zw7s1yDfx5e7/CY5UbbkYt6k/202GxtCR7f8xP8FO7o6R+BAUGt8WzcQNzbujPu27asyhE2TdVuR26cYtbJNwQAcLE4t051D115PWvi6No81K4n8rVleOHAOpgr/SlBKrYdhF6bdjmDVK6A0VwxbW/fvn04evQoevbs2SjHFolEiIqKQlRUFKZNm4bS0lIcOnQIe/bswd69e5Gbe/05YjabER8fj/j4eHz55ZcICgrCwIEDMXDgQPTp0wfu7lW/txAREVHLwCl7zVjvG6ZRRXgrEeqlwPE6jjaqi3KDGQnZJejbyscu+dCvtS/MgoCT6dfPvy+lAP2j/DCwjR/2JleMmMot1SMhuwT3dgqBOtAD+66trwut0Yz49GL0j/Ktsp5SXWNtLDVdl/rElVJQjl9PZeD5tafx14UcjIoNrDYGS1F6aTW1pixc1U/UsmRcGxkSqfK1Wd8rsPFv92750S+toT6SxcGcK4hQeVc7/ep4fhoiVD4Iu2G6WL+gVgCAE/lp9Yr1eH4aLhbnYkJUF9wWEo1gN0+7O6JZ4ivSa3GhONfuX11GzeTryrA1PRFzT2zFZ2d2o71XAKK9nN/upuSq61nX552Fh1SBXF2pTTJKIhJhSEi0zXa1aVd9Y6gLsUSMESNGWJe/+OILCHVIGNaFSqXC0KFD8dZbb2Hjxo344Ycf8NRTT6Fz5852ycDs7GysXbsWr7zyCoYNG4ZnnnkGK1euxJUrV5okNiIiInI9JqScSCEV44/H+mDOCHWtth/aLgBt/Sv+QuihkGDe6FiU6k1Yeex6oda6HrM2vtx7GW38VXj59raw5Dtui/bD5G7hWHc6E1crjdDadzkfASo5BrXxt07hA4A9l/Nxd8eKv45XXl+XmD/elYRgDwUWjIuDh6KiZopULMKELqGIDfKoc6yNpTbXpTZxBarkmDW0LcK8lNb9fN1kiPJ1x6W8MlQntaBiKmPMtX6oiSv6iVqWs4VZuKTJw6Pte0Elragb19k3FH0DWzX6udLKimA0mxHjXX1i1mLZhcPI1Zbio953orXH9YRZ38BWGBMRCwBYfvEIdCYj5vcYY70LXSuVD17rcgcua/LsagzVxZrkePQKiMTzHQYhq1yDv28o/r008RBytKX4vN+9iKoUn0oqx5Tobrj9hhpSjszqPBSdfUOtyzKxBJ19QytGXzmYumbRlO1uKq66nnV93lkczU1FrHeQ9bUgE0vwr+4jkX3D3fFq0676xlBX06dPh1RaMdoxPj4eu3fvbtLzARWjp2JjY/H4449j2bJl2Lp1K+bNm4dRo0bBy+uGOooGAw4dOoRPPvkE999/P+677z58/PHHOHDgAPT6qqeoEhER0c2FU/acSCkVQx3ogYTsklpt//HOJHx4VwcEeSgQ4CHH1cJyPL76JLJLrn8Zq+sxa2NTQg5mrT+LF2+LxtQe4SjTm6CSS/HzyXR8uNP2Vs/7kvNhFgSIRLAZCbUvOR+P9W2FLI0OSTckV2ob86ErhXj8p5N49Y52OPjCYGQW6+DjJsP6s1nYlJBd51gbS22uS23iKiw3IKdUj+VTusNTKUWx1oBgDwX2XM7He39dqOr0AICdSbn4OykPXz/QFWlF5TCYBbzy+xkk5Di+g6Ir+olaFgHA60c24JM+d2PvuOdQpNfiXFEWFsbvwKjwmEY9V7FBhy/P78NTsf1xT6uOKDMasPziEbuRRxb5ujJM2fkD3uo2An+OeAz5ujIoJTKcLsjE/JNbAQBXS4swffdqvN19BPbf+Tyyy0sQ5OaBPVmX8a/jW6A3mxweuzZ+SzmNlzoNQSffECw6v99mpAwAFOjLMWnH93i9yx34ffgMFBu0MJkFuEll+CP1DP5Kr/k1eCzvKt7oOgwx3oHI0ZYgUKHCJU0+ntr3i7UekiNN2e6m4qrrWdfnncXixINo4+mPZYMnIaNMAzeJFEsSDyFZU4Ae/teLfNemXfWNoa5CQkIwYcIE/PjjjwAqakkNGjQIYrHz/k7p4+ODsWPHYuzYsTAajTh9+rT1zn0XLth+BqampmLVqlVYtWoV3Nzc0KdPH+v0vuDg4CrPsWnTJqxatQojR47E1KlTWaPqFtJ22iDoCkpwdcMJV4diI2pCX5gNJlxZd8TVodTIJy4c/j3bQO7lDlQakV96JRdXfj/qwshuHn5dWyN4cCwSl2yHSWuoeQcXH5fIFURCU43TdpJ///vfWLziZxjGvgrRDYVhXSHUSwGVXIqLufaJgSFt/bH4ga6Y8O1hnMqs+i/azw1qg+cHtUHnD3dCbzIjyEMOqVjs8G5ztT2mXCJGa183ZGi0NkW6fd1kCFDJcTG31GER7RBPBeQSMTKKtVXe+S362t3oLuVfTzxJxSK08XNHmcFkV/OqtjFX5usmg6dCirQibZW1SKqL1c9dBn93OS7ccF2qar+j9XW5LrWNy8JbKYWnQorsEr11Op6Fj1KKQA8FkvJKcePuPkop/FRySEQiXCksh85ornb7+vaTm0yMCG83pBVprTWpnE0ozoZy+xd46anHMH36dJfEcLOYN28eVm36A+aXJzTJ8SNU3igzGpCvK4NEJEK0pz9ytCUo1Fe8FtwkMkSovJFWWmStPWXR3isA+boya40luViC1h6+SC8rtqv74yaRIcTNE1KxGLnaUhToq77JgYW7RIZANw9kl5eg3OT4S5qv3A3eciVytKUOz1nb2CtrpfKBQiJ12I7KZGIJQtw8oTUZkHPDCJrqzm2hEEsR7OaBPF2Z3Xmq68umand1PGUKhLh52tWWqgtXXE9Hz7vaXBt3iQz+ShUyyzUwmE3wkSsRqPRAUnGeXZKypnbV57lfG6bNhxFyIRcbf/8DBoMB99xzD8rLK479zjvvYMyYMY1ynobKysqyJqcOHToErbbqz9n27dtj0KBBGDhwIDp16mQd+QUAd955JzIzMwEA48ePx6xZsyCRSKo6lFVubi4mjn8Ag8I7Y2KvUQ1vUAunivSHb+dIuAX7QKKUwVSuh76oDEWJGShKSIdgdM5dJCtrP30IdPklLkmcRE8eAGOZzuG5o6cMgFlvQvIvB50el4VbiA+iJvTF5R/3QZvr+Hu4MsATbR8ajIwdZ1F47iosXyijJw+AoVSLlF8POzPkm5Z/9yiEDu2Ic19uqXPiyL9HGwQNUCNh8V8w623rFzbkuNQwz/z4LobfORpz5sxxdSgtBkdINbKKO7A5voPQgChfbEnIrnUSxqLyyJv6HlNvMtslGQCgoNyAgvKq38gyNdXfDQmwTURZGM2Cw/MB9euHmuIEqo81v8yA/DL7/as6bm3OV911qW1cFkVaI4q09sVyAaBQa0RhHR6rbvua4qmqn8oNjp8/dGu6Wnq95pFJEOwSDuUmQ5VJiBvX682mKrctNxlwuaRuNejKTAaklBRUu02BvrzKH/h1ib2yK6WFtYrPYDYhtYptqzu3hc5srPJc1fUl0DTtro7GoIOmhjvq1cQV19PR864216bMZEBZpWtTqNdak7SOtq2uXfV57teVn58fpk6diqVLK+6OuGjRIgwfPhwymevvphocHIz7778f999/P/R6PY4dO2ZNUKWmptpse+HCBVy4cAHLli2Dl5cX+vfvj4EDB2LAgAEYPHgwfv75ZwDAL7/8guLiYsybN69ZtLGlCBveCb6dIpF3PBmpfx6DobgcEqUMXu1CEDqkA5QBnsjc1fymBjclkVQMkdTxaMPLPx9Ao91GuZ682gXDrDNUmYwCAFWrAIhEIhScvmKTULzJxzHcVEQSMSRyqcM7CuWdTEHB6VSYXfRHYqLGxISUEy0/fNXu7mzN8ZhN7WaMmYiIqKV56KGHsGbNGhQVFSEtLQ3r1q3DhAlNM7KyvuRyOfr164d+/frh5ZdfRkpKijU5dezYMRiN179PFBcXY/Pmzdi8eTNEIhE6duyIdu3a4eLFimmxW7duRWlpKRYuXAg3N9ff8fBmF9C7Lfy6tMbVjSdQeO76jQRMWgNyj1xCUWIGPNtWPaXyVuSK0WI38mwbjOKkrGq3kaoqavM1h3jJAbMAczOcck9UH0xIOVFNU7uayzGb2s0YMxERUUvj4eGBRx55BJ9//jkA4Ouvv8add94JpVJZw56u07p1a7Ru3RpTp05FaWkpDh8+jD179mDv3r3IycmxbicIAk6fPm23/759+/D000/j888/tyumTrUnkooR2KctytILbJJRlRmKy5F/PNlmnU9cOPy6tobcVwXBaEJpWj6y91+AvuD6KGxL/afsfRcQOrQD3IK8oS8uQ+bf51CWVgCFnweCb4uFe4gPjGV6ZO1NgKaKBIvcV4XQ2zvALdgbxnI9Ck6lIu/YZZttYp4chqJz6cj823YkV8TYblD4eiBpxR7rOrdQHwT2aQdlgCdEEjF0eRrkHU+G5lJFbdOYJ+6AVKUEICDuuVHWfrj43d8Aqq4hVZd+ydqTgNDbO8A9zBcmrQH58Vfs2lQVuY87lP6eyNx5tspt4p4bBZFEbP1vAMg9nIScg1XXO6wp/qABavh2jkTC4u3AtVFW/j3bIKi/GgWnU23iaffQYJTnFCNt08lq26KK9Id/jzZwC/ICRCKUZxYie/8FaHOKax0XUPn5loiQ2+LgHuqLwoR05B2/jHYP3YaM7adh0hoQ2LcdFL4eSN1wHCXJOZCqFAjs2x4eUQGQKGUwaLQoPHO1xmvh1T4E4aO6WpfNBiN0uSXIO3YZmssVz6OQ2zvAr0vFjTJinhhm3Tb55wMozyqqsoaUIsATQX3bwT3Mt+L5mV+KvOOXUXwh07pNYJ+2COjTDucXbUNgn7bwiQuHSCpGSUouMnee5RRAcjompJqhlceuYvP5bLtaQuRavC5ERNTSTJw4EatWrUJOTg7y8vLw448/3jR1+lQqFW6//XbcfvvtEAQBiYmJ1uTU6dOnYTY7/rw+ffo07r77bqxZswYBAQFOjrplUIX7QaKQWX9A10ZQ//YI7Nse2fsTUfhnGiRuMoTe3hFtpw7EpVX7oMuvuNmNWCaBTKVEyG2xyN6fCGOJDkGDYtD6vj64vHo/ggdfW6/RImiAGq3u7IHEZTthKLaduitRyBA2tCOyD1yAvrgc3u1DEHJbHKTucmTtSbBuJ5ZJHU6xE0slEMuu1xyTebohanxfFJ1PR/KuszDpjFAGeMK/exR0eSXQF5UhcdkutJ1iW0Oq8jQ3sUxiN2WvLv0idVcg9PYOyD1yCfqiMvh2jkTo7R1gKC5H8cVM1MSzbTBMOgNKU/Oq3Cbhq20IGhiDgB5tkPDVtoo2VPPdtzbxl6UXIKhfe7iH+aAsrWK6smdUEERiETyjg6wJKZmXG5SBXsg7kVJtO3w7RyJseGcUnLqClLUJMJbr4RbsjeCBMUj57XCd+1WmUiLsjk7IPngBxhId3MJ8IRKJIJFL4REVBMFkQtrmeEiUMmuc0ZMHwKApR9qmk9AXlsE93BdhwztD7qtCxl/2yXCL4otZKEneZl2WqpTw7RKJVvf0wuU1B1B2NR9Zu8/DpNUjeEAMLny7E+ZrM0ssU/RE4orYKlMGeSF6Un+UpRci5bcjMOkM8O0UiVZ39UTGrnPIO1pxB2DLVMCQwbEozy7CpdX7oPT3RMTY7hBLxEj983i1fU/U2Jx3OxWqtfwyA+v1NEO8LkRE1NIolUo8/vjj1uXly5ejuLi4mj2aJ5FIhJiYGDz22GP48ssv8fjjj6Njx45wd3d3uH1JSQm++uorJ0fZcsi8KqY86otrV3BfqlIgoE87FJ69ipyDF2HQlEObXYyUdRXJg+DBsTbbu4X5ImPHGZRnFsFQokXmzrMQS8SIGt8H6dtOoTyjEIYSLTJ2nYUgCPDtFGl3TvdwP6RvP42y9AIYS7TIO56MvJMpCOgVDalH3UcBuof7QiKXIufQRegLy2Aq16M0NQ9Xfj8KfVFFPVXBaIIgCBAEAWaDCWaDqdppb3XtF/dwP2TsPFvRplIdcg5chDZPA7+urWrVBq+2wdBczoZQxU12gGtJj2uPW9tQxfa1jb/0ah7MRhM8WgcCqBhh5x7ui/wTKVD4qCDzrng+ebSuSBCXXMlxcLYKEqUMobd3QPGFTKRvOw1trgbGUh00l7Ktyaj69Gv69jMoSyuoKMhfadSfMtATaZvjrYm1svQChAyJg0giRsrawxXXokyH4guZyNx1Dn5dWkHuW82Ntio9N8wGE/SFpcj6+zzKs4vg37V1xSYmMwST7TWoqV5UyG1xMBvNSFl3BNqcYhiKy5G9LxFFCekIHqi2JtMs9MVlKDxzFcYSHUpScpF3/DK81KGQuMmrPQ9RY2NCioiIiOgWds899yAysuIHvUajwffff+/iiBpm/vz5WLx4Mc6cOYOysqrvDnnbbbc5MaqW5lql5VoWuVZF+kMsEaMoMcNmvVlnRElyjjURYaHNKYZBc73Eg0lrgKFUB0OJ1mYklFlnhLFEB7mPfeJRm1sMfaHt9S9OzIBILIZHpH+t4q5Ml18CQRAQekdHuIf5AiIH1abrqF79ckMSUJtTDLl3zXcalyhlcA/zrXJ6Y33UNn7BaEZZegE8oioSUqpwP4jEYuQcToJRq4dHq4r1Hq0CoC8shaGo6kSnqlUAxDIpCs9ebXBcFro8DfSFjv/orLl4Q3+JRfBsE4SSlBy76W0lKTkQiUTVP79EgF/3KERPHoDYp4Yj7rlRiHtuFNyCvCD3qd8d40USMVThftBcyoZgtE1cFSVkQCyVwD3Cr9p2aXM0EIlEkHuzvh45F6fsEREREd3CpFIpnnrqKbz55psAgFWrVmHSpEk37XQ2k8n2B5lYLEarVq3Qvn17qNVqhIWFoVevXvD3r3tSgioYSioSBjLP2o00kl4bdWEssa8jaijVVUyPk0utt7d3tJ1ZX5F8upFJb4BEYX/nRGOp/baWdRL3uo8C0WYX4+rGEwjs2w7RkwfAbDCi9Go+8uOv1DvJ0yj9ovv/9u47TKr60P/458zMttlZli2wCwsrIL2LgFIUAbGhIkYsAUFURMEkN4k3Jvndi14TNd70REQ0SiRy7YICikRQmoAgIr2XhaVs723K+f2xMrCwFdg5s8P79Tw+D98zZ873M0Xd/XDO93jOOfulOjEdkmSaUuHBms8+aqiG5C86nKWkIV1kjwxT9GWJKs3IrzzLLC1brnaJyt2apujURBWcVSKdLez7BdfPLCwvJJckuavZz7//WY/ZI8Nkc9jVrGOyuk27oepd8L4vKWv7fiUPq1wf6vgXO06XWqap1DH95XBG1Pi82tgiHDLsNnmKq3u9ldscZ5355D5rX195ZblW3b9LQGOikAIAALjEjRo1Sm+88Yb27NmjsrIyvfbaa3ryySetjnVennzySQ0YMEA2m02dO3dWhw4dgnqh9qaoJD1XPnflJVhZGw7Uuf+pM0nszghJhVUeczjD5fP65HPXfQdm8+wFmE6p5mSls38Br5w/vEoeqbLosjns5+xb3WV9+buOKX/XMTlcEXK2jld8r1RdNqa/0hZtqrNIqc7Fel/qo1nHJJUcyfaXMBdDQ/IXpWUp+Zquik5NlCs10V+MFR3OVPI13RSV3FyOqHAVpWXVOqfn+zkd0RFSDd1aQ9/X2tbIOvsxX7lHps+nvJ3pNS4OX9vx4nq2Vf6uY8rdmlZle5grstZLKWvjq/DI9JnVFlqn/j04Z7Hymqa6CGf+AQ3BJXsAAACXOJvNpmnTpvnH8+fPV3p69XdPC3bNmzfXnXfeqTvuuEPdu3enjGoEvgqPsjcfkis10X8Z1tnskWFq3r2NJKk4PUemz1RMh5ZV9jEcNrlSE1WSnlPzL8jnKaJFMzlcVX9Bj2nfUqZpquRojn9bRX6JIhJcVfZzREcoMjGmxmN7ispVsOe4Ds//WqbXJ1fq6bPtTI9Phq1+v2IF6n0x7Da5LktUwUW8XE9qWP6yk/nylFaoebcURbZopuLDpwqpLNkjw9Tiqo4yfWadhVRxWpZ8Hq9iO7e6KLkayvT6VHwkR662iVXWCjvzn9qKJcOQvGeVgpFJsYqIr/od9HlOLWBe93fJ9PhUeiJPrssSZdiqFkrNOibL9FZeMgkEIwopAAAAaMiQIerbt68kyePxsOg3anVyzW4V7Duh1NuuVMKVHSrPWFHlXcuad0tRx/uvUWTLZpIkd0GpcrakKb53qpr3aCPDYZMjOkJtbu4rW0SYTq7ZXdtU56UsI1+tR/RUWGyUDJuhZp2SlXhle+VuO+JfhFyS8rYflbNVXGV5ZhgKb+5UqxE9VJZRdXH/uF5t1XJw58oFq22GDJtR+VrsNpUcy/PvV55TpMjEmHpdFhio98X1/bpLF3P9KKnh+YuPZKvZ5Unyub3+gsRdUKryvGI1uzxJpRn5/jvK1aRyMfe9at69jVoO6lS5CLfNUFRSrFJu6H1euRrq+JfbZY8MU+ptVyoiMUYyDNnC7HK2jlObW/pWu6bZKYWHstS8W4qikmIlQ4pKjlXr4T1UcrxqYVSeXXkXwDPLztqcXLNbjugIpdzYR3ZnuAyHrfL1d0tR1qaD1V7CCgQDLtkDAACADMPQ448/7r/r3qeffqqJEyeqY8eOFidDUPKZSvv4G8V2ba24XqlKGtxJstlkur2qKChRzneHlbPtiH/348u3yV1YqpZXd1LKqF4yTan0WK4OvrtOpcfzLno8T3G5MjfsV+rt/RWZ4JKvwquc79J0YvWuKvvlbj+i8PhotRreXSmjeqk0s0DpS7coaXDVO5MV7D2huF6pSr3tysrCwZTKc4uUvnRLlQW2M9buVUS8S12njJTp86kiv1T75q6sMWcg3peYjkkqPZlf61pJ56sh+YsOZyq2cyuVHM2pchZR0aEsRfSNVtHh2s+OOiXz6/2qKChV4pUd1OKqTjK9XpVlFipj7Z7zytVQ5dlF2v9/q9VyUGe1H3e17BEO+Sq8KsssUPZ3h6sUnmc79vlWtR7RQ+3GXS3DZqj0ZL7SP9+qpKFdFB52+lfz4rQsZX93WK2v76WUG/vI9Jk69N46lZ7Mr/a4xUeydeiDr9VycGd1nTJSMirvgnli5U5lf3vogl4v0JgM06zn7TGC1F//+le9Mu89uW95Ukbk+d2ZAEDwMwsyFLl8pn726EN64IEHrI4T1J555hm9tWShfD+/y+ooAIKI97MNSt6bpU8/XqiYmJovR/rJT36iNWvWSKq8E92f/vSnQEUMCllZWbr7B+M0NKWX7u5/o9VxmhTDZtRvHRybIdWwn+GwSea56/A0ZPs52wyjfncEPGM/w26TjMrLoc7dT3Vf8mVIht0uyfQfo6bX4Hc+74vdJhnGOXdXO1OXqSOVs/mwMtfvqyP098e0GTLsNvncVY95IfkrDyDZHHaZXl/V74nNkM1uk8/jq/edGxvkPN5XqfJsv/pkqvF7f+p1uWv4bM74HtX2fTMcNhmGcfo4dR33+32qe801fbanPhufx3vRL58NJdPeflbX33qTZsyYYXWUkMElewAAAPCbPn26/88rV67Uli1bLEyDpqTeizLXsp/p8VVbDjRk+znb6ltynLGf6fVVX0ZJ9fuF3ZRMj7fKMWp6DX7n8754fbWWUVGtmissOrJB60eZPrPasuNC8lceQNWvsXRqvsY6T+I83ldJ9c5U4/e+hvfx9BPP+GMt3zfT46t6nLqO+/0+NWWt9rnmqddb+2GBi41CCgAAAH6dO3fWjTeePjNo5syZauIn1AOXrNIT+drx9yUqzyqse2cACDAKKQAAAFTx6KOPym63S5K++eYbrV+/3uJEAM6LWY+zaQDAIhRSAAAAqKJt27YaM2aMf8xZUgAA4GKjkAIAAMA5Hn74YUVEREiSdu7cqWXLllmcCAAAhBIKKQAAAJyjZcuWuvvuu/3jWbNmyePxWJgIAACEEgopAAAAVGvSpEmKjo6WJB0+fFiLFi2yOBEAAAgVFFIAAACoVvPmzTVx4kT/+NVXX1V5ebmFiQAAQKigkAIAAECN7rvvPsXHx0uSTp48qffff9/iRAAAIBRQSAEAAKBGTqdTDz74oH88Z84cFRcXW5gIAACEAgopAAAA1OrOO+9Uq1atJEl5eXmaN2+exYkAAEBTRyEFAACAWoWHh2vq1Kn+8bx585Sbm2thIgAA0NRRSAEAAKBON998szp06CBJKi4u1pw5cyxOBAAAmjIKKQAAANTJbrfrscce84/ff/99nThxwsJEAACgKaOQAgAAQL1cd9116tGjhySpoqJCr776qsWJAABAU0UhBQAAgHoxDEOPP/64f7xw4UIdOnTIukAAAKDJopACAABAvQ0YMEADBw6UJPl8Pr388ssWJwIAAE0RhRQAAAAaZPr06f4/f/7559q1a5eFaQAAQFNEIQUAAIAG6dGjh4YPH+4fz5w508I0AACgKaKQAgAAQINNmzZNNlvlj5Jr167Vxo0bLU4EAACaEgopAAAANFj79u01evRo/3jmzJkyTdPCRAAAoCmhkAIAAMB5eeSRRxQWFiZJ2rp1q1auXGlxIgAA0FRQSAEAAOC8tGrVSnfddZd//NJLL8nr9VqYCAAANBUUUgAAADhvkydPVlRUlCRp//79+uyzzyxOBAAAmgIKKQAAAJy3+Ph4jR8/3j+ePXu23G63hYkAAEBTQCEFAACACzJhwgTFxsZKktLT07VgwQJrAwEAgKBHIQUAAIAL4nK59MADD/jH//jHP1RaWmpdIAAAEPQopAAAAHDBxo0bp5YtW0qSsrOz9fbbb1ucCAAABDMKKQAAAFywyMhITZkyxT+eO3euCgoKLEwEAACCGYUUAAAALorbbrtNqampkqTCwkLNnTvX4kQAACBYUUgBAADgonA4HHr00Uf947feektZWVkWJgIAAMGKQgoAAAAXzfXXX6/OnTtLksrLy/Xaa69ZnAgAAAQjCikAAABcNDabTdOnT/ePP/zwQx09etTCRAAAIBhRSAEAAOCiGjx4sK644gpJktfr1ezZsy1OBAAAgg2FFAAAAC4qwzCqnCW1ZMkS7du3z8JEAAAg2FBIAQAA4KLr27evrrnmGkmSaZqaOXOmxYkAAEAwoZACAABAo5g2bZoMw5AkrVq1St99953FiQAAQLCgkAIAAECj6NSpk2688Ub/eObMmTJN08JEAAAgWIRQIeWzOgCAxsQvMA1m+njPAJzBNGVYMO2jjz4qu90uSdq0aZPWrVtnQQoAAM6fz/TJsOT/oqGtyRdSTqdTNsOQ3BVWRwHQmNzlshmGXC6X1UmCntPplE2GVOG2OgqAYFLulmEYcjqdAZ22TZs2uuOOO/zjmTNnyucL3r9IdDqdMgypzF1udRQAQJAoc5dLhhQdHW11lJDS5AupZs2ayW4zpNICq6MAaERmaYHsFFL10qxZs8qivqjU6igAgklRmWJcLv/ZSoH08MMPKyIiQpK0a9cuLVu2LOAZ6isqKkr2sDDllxZZHQUAECTyS4pkGIZiYmKsjhJSmnwh1bt3b0WF2WUe22V1FACNyDy2S1HhNvXu3dvqKEGvV69einKEydx3zOooAIKEWVym8JN56tenryXzt2jRQvfcc49/PGvWLHk8Hkuy1MUwDPXp20d7s9JUUkGxDwCQvju6R0aYnd9FLrImX0h17dpVHVJTZBzdKjOIT/8GcP5MT4Ucx3eqb88eat26tdVxgl7//v2VFJcg7TxsdRQAQcLclaZoe7hGjBhhWYZJkyb5z3JNS0vTokWLLMtSlxEjRsi0G9p8ZLfVUQAAQWDD4W1qnhCv/v37Wx0lpDT5QsowDF0/cqSivCUy03dYHQdAIzAPfSunzWfpL1JNSVhYmEZeN1yRuSUy0zKsjgPAYqbbI3PrAcW7YjRo0CDLcsTGxmrixIn+8auvvqry8uBcp2no0KEKd0Zq1d5NcnuD80wuAEBg7Dl5WCeKc3Td8OvkcDisjhNSmnwhJUk33nij2ibGybHxA/nSd1odB8BF5Du4SWFbP1G7Vi00fPhwq+M0GaNHj1ZyszjZFnxFKQVcwswKt3wfrFR8gVt3jrlDkZGRlua57777lJCQIEk6efKk3nvvPUvz1CQmJkY3j75FR0uy9PKKd1Xu4eY5AHAp2nPysGatfFfRzWN0yy23WB0n5BimGRr3Ut+3b5+e+M9faM+xLLm7DJOR2luGK8HqWADOg2maUkGmzMObFb5vtXpd3lZ//MMflJKSYnW0JmXLli168te/0qH8bHmGdJfRuY2MWO4MAlwKTLdH5uGT0lc7lJBXrgnj7tG0adNks1n/d5HvvPOOfv/730uqPGvqo48+CsobVni9Xv35z3/W4o8WKtXZUjf3HKIuye0VZudvxwEg1GUX5+vbtJ1auG2lnAnN9Nzzz6lXr15Wxwo5IVNISZXrETzxn7/QofQTKnF7Ve5MlJI7S1ExUlikZFj/QxiAGpheyV0uleRLx3crsixXznC7Ore/TH/8w+/VsmVLqxM2Sbt379Z/PvmkjudkqcRTofIWMTLaJUvRkVJ4mGQzrI4I4GIwJXk8Uplb5skcOQ5lKMq0yeUI1+T7J2ry5MkyjOD4993tdusHP/iBjh2rvPHClClTNHXqVItTVc80Tb388st675135avwKNy0q3ury5Ual6zI8AiF28MUHO8qAOBC+ExTpe5yFZYVa8fx/TpakCFbmEPNE+P1wv++oM6dO1sdMSSFVCElSeXl5dq0aZPWrFmjVWu+UmZ2rrymKZ9pVv6wBiA4GYZshmQ3DLVKStS1Q4dqyJAh6tu3L9dqX6CysjJt2LBBq1ev1pq1a5VdkCffqf8uAggZhiHZZCjc7lC/3n00dOhQDR48OChvBrFo0SI9/fTTkiSn06mPPvpIcXFx1oaqRXp6ulavXq3Vq1drx9Zt8vlMycd/QwEgpBiVa1THNI/V1YOu1tChQzVgwADLL3cPZSFXSJ3J6/UqLS1NhYWFKi4uVgi/VKDJs9lscrlciomJUdu2bYPispJQ5PF4lJaWpqKiIhUVFVkdB8BFFB4erpiYGCUlJal58+ZWx6mV1+vVfffdpwMHDkiqXFvq5z//ucWp6icnJ0eZmZkqLCxURQVrSwFAqHC5XHK5XEpNTeUvxAMkpAspAAAABKcvv/xSTzzxhKTKu4POnz9fycnJFqcCAACBwikIAAAACLhhw4apZ8+ekirXlXrllVcsTgQAAAKJQgoAAAABZxiGHn/8cf940aJFOnTokHWBAABAQFFIAQAAwBL9+/fXVVddJUny+XyaNWuWxYkAAECgUEgBAADAMtOnT/f/edmyZdq5c6eFaQAAQKBQSAEAAMAy3bt314gRI/zjmTNnWpgGAAAECoUUAAAALPXYY4/JZqv8sXTdunXauHGjxYkAAEBjo5ACAACApdq3b6/Ro0f7xy+++KJM07QwEQAAaGwUUgAAALDc1KlTFRYWJknatm2bVqxYYXEiAADQmCikAAAAYLnk5GTddddd/vFLL70kr9drYSIAANCYKKQAAAAQFB588EE5nU5J0oEDB7RkyRKLEwEAgMZCIQUAAICgEBcXp/Hjx/vHr7zyitxut4WJAABAY6GQAgAAQNAYP368YmNjJUnp6emaP3++xYkAAEBjMExuYQIAAIAg8uabb+ovf/mLJCkhIUELFixQVFSUpZmys7O1Zs0arV27VidPnlRBYZHKKyoszQQAuDgMw5Ar2qlmMTHq3r27hgwZoj59+sjhcFgdLaRRSAEAACColJWV6c4771RGRoYkadq0aXrwwQctybJ9+3bNnj1bW7bvUJnHlNu0KTwuSY4ol2wOh2QYluQCAFw8ps+Ut6JUnqJ8+YpyFG43FB8bo+tHDNejjz6qiIgIqyOGJAopAAAABJ0FCxbot7/9rSTJ5XLpo48+8l/KFygbN27Uf814SlklHjXv0l8tug9UQpd+ckQ6A5oDABAYpmmqOOOIsrZ/rczt6+TNOqyhA/rpN7/5jeVn6oYiCikAAAAEHY/Ho7vvvltpaWmSpEmTJulHP/pRwOb/6quvNOPpZ5TvC1PPib9WbGrngM0NALCe6fNpz8LXlPPNUg3s00PPP/+8XC6X1bFCCouaAwAAIOg4HA499thj/vHbb7+trKysgMzt9Xr157/8VflmuHo/9DRlFABcggybTZ1vf1gtBt2mDVt2aPHixVZHCjkUUgAAAAhKI0eOVJcuXSRJ5eXl+sc//hGQebdu3arjGVlqNfAGxbRqF5A5AQDBxzAMdRh1n7xhUVq+fLnVcUIOhRQAAACCks1m0/Tp0/3j+fPn6+jRo40+77Jly1TmNZXUe2ijzwUACG42R5gSul+tnXv26dChQ1bHCSkUUgAAAAhagwYNUr9+/SRVXko3e/bsRp9z1erVimiZquikto0+FwAg+CX1Gapyr6k1a9ZYHSWkUEgBAAAgaBmGUeUsqSVLlmjv3r2NNl9FRYXy8gvkbEkZBQCo5GzZVl5Tys7OtjpKSKGQAgAAQFDr06ePrrnmGkmVt+R+6aWXGm2uoqIi+UzJERndaHMAAJqWsCiXfGbl/yNw8VBIAQAAIOhNmzZNhmFIklatWqXNmzc3yjw+n0+SZNjtjXJ8AEDTY3M4JEkej8fiJKGFQgoAAABBr1OnTrrpppv845deekmmaVqYCAAAXAgKKQAAADQJU6dOlf37M5c2bdqktWvXWpwIAACcLwopAAAANAlt2rTR2LFj/eOZM2f6L7EDAABNC4UUAAAAmoyHH35YERERkqTdu3dr2bJlFicCAADng0IKAAAATUZiYqLuvfde/3jWrFksMgsAQBNEIQUAAIAmZdKkSXK5XJKktLQ0LVy40OJEAACgoSikAAAA0KQ0a9ZMkyZN8o9fffVVlZWVWZgIAAA0FIUUAAAAmpx7771XCQkJkqSMjAy9//77FicCAAANQSEFAACAJicqKkoPPfSQfzxnzhwVFRVZmAgAADQEhRQAAACapLFjxyolJUWSlJ+fr3nz5lmcCAAA1BeFFAAAAJqksLAwPfLII/7xvHnzlJuba2EiAABQXxRSAAAAaLJuuukmdejQQZJUUlKi119/3eJEAACgPiikAAAA0GTZ7XZNmzbNP37//fd14sQJCxMBAID6oJACAABAkzZs2DD16tVLkuR2uzV79myLEwEAgLpQSAEAAKBJMwxD06dP948XL16sgwcPWpgIAADUhUIKAAAATV7//v119dVXS5J8Pp9mzZplcSIAAFAbCikAAACEhDPPklq+fLl27NhhYRoAAFAbCikAAACEhG7dumnkyJH+8cyZMy1MAwAAakMhBQAAgJDx2GOPyWar/BF3/fr12rhxo8WJAABAdSikAAAAEDLatWunW2+91T9+8cUXZZqmhYkAAEB1KKQAAAAQUh555BGFhYVJkrZt26YVK1ZYnAgAAJyNQgoAAAAhJTk5WePGjfOPX3rpJXm9XgsTAQCAs1FIAQAAIORMnjxZTqdTknTgwAF9+umnFicCAABnopACAABAyImLi9P48eP941deeUVut9vCRAAA4EwUUgAAAAhJ48ePV2xsrCTp2LFj+vDDDy1OBAAATqGQAgAAQEhyuVyaPHmyf/z666+rtLTUwkQAAOAUCikAAACErHHjxikpKUmSlJ2drbfeesviRAAAQKKQAgAAQAiLiIjQlClT/OO5c+cqPz9fkmSapnw+n1XRAAC4pFFIAQAAIKTdeuutSk1NlSQVFRVp7ty5Kioq0qRJkzRmzBjt3r3b4oQAAFx6KKQAAAAQ0hwOh6ZNm+Yfv/3221qyZIl27Nih48eP66OPPrIwHQAAlyYKKQAAAIS8ESNGqGvXrpKk8vJyff755/7HioqKrIoFAMAly2F1AAAAAKCxeDwePfvss9q/f78GDhyoXbt2SZK++eYb/z5ut9uqeAAAXLIopAAAABCyDh48qIULF0qSduzYobi4OOXm5so0Tf8+Ho/HqngAAFyyuGQPAAAAIat9+/bq0qWLf5ybm3vOPhRSAAAEHoUUAAAAQpbD4dCrr76q2267rcZ9uGTPOtsWv6mlz0+vc1tN9q/+RIufmix3WUljxDtvwZqrPpY+P13bFr9pdYw6rZz5X9rwf3+tsq2pZG8Ml/JrR9NFIQUAAICQ5nQ69dRTT+n555+Xy+U65/HqzppCVd8teF2Ln5qsktzMGvfJ3L9di5+arP2rP6n3cTP3bdX+NZ/Wua0mOWl7tW/lQvk8DS8Vt3w8R/9+4ccNfl59XEguq+1f86ky922tsu3T3zyiHUveOu9jluRlafFTk5V1YMeFxvNL2/iljm1dV2VbddlDSW2fQ6i/doQmCikAAABcEkaNGqW3335bV1xxRZXtGRkZFiVqOpolt9W+lQu1c+k7Ne6zZcFr2rdqkRLad7uguXqOnqAbfzXzgo5RHxm7N+vAV0safZ5QsH/VYmXu23bez/eUlWjfyoW1FpoXw42/mqmeoyc06hxWqu1zCPXXjtBEIQUAAIBLRnJysl5++WWNHz/ev61169YWJmoa2g0cKVeL1tr+ybxqH3eXlWjPF/PVpu9QNU9pf0FztejYSx2G3HxBx8ClqcOQm9WiYy+rY1jiUn7taLq4yx4AAAAuKXa7XT/96U917bXXatOmTZo4caLVkYKeYbOp+80/1Ndz/6Bj275W654Dqzy+54sFqiguVM9b75ck7V2xUHuWf/j9kw2FO2OU1KWPuo4ap3BnTK1zbVv8po5tWasbzjpLqjj7hLZ8NEf5xw8rtnU79R7zYLXPr8/c69/4vY5sWiV3aZEWPzXZ/9xRT/7Nv4/X49beL+Yrfcs6uUuLFZvSXj1uHq9myW3PK1d1Nn/wirIP7dLIn/9J+1Yu0qGvP1dkTJyGTn1KklSUeVw7l76jnMO7ZbOHqVXPgep2w92yh4Wfnj8nQzs/e1u5R/bL5nCoRcee6nbDPQqLdEqSygpyteyPP1OP0RPUbuDIKvOv+PuvFZ2YrP73VX/pYnlRvj7//X/I53Xr4LqlKso8Jklq0amXBk74Wb1f54U6unmN9nyxQJ7yUrXpO0Tdbrin2v2WPj9drXsPqnKm0Iq//1pFWcclSTa7Xc74JF02cMQ574UkHfl2lfZ++XGVeVbNmqGouBYa8MOf+Pdb/NRkXT70FrUffJO2fjxHWQd2yJXYSr3HPHjO90OSMvdt054v5qvgxBFFxjRXav/r1GHIzTIMw79PbZ9jfT6H6l67JBVlHdeuf7+nnMN75IiIVErvQeo8fKwMm63OeYHGxhlSAAAAuCRdeeWVmjJliiIiIqyO0iT0uGWCDJut2rOktn8yT5HN4nX50NGSpIT2XdV5xFh1HjFWna69TfGpHfXt+y/r7UdHyV1aXOs81a0hlX1ot9588FodWLNErbr3V7jTpcUzHlBpXtY5z6/P3G2uGKrY1u1kDwv379t5xFjZwyq/CyV5WXrnsRu06uWnFZPUVm37XavsAzv05uShOrp5zXnlqs6JXZt0aN2/tXr2/+jw18uU3LWfygvzJEkH1n6mNyZepbRvVqhVz4FKvLyHNv7fX/Tej0erorRIkpR//LDenDxUhzcsV6vuVyq5az9lH9ylt6aeLlvc5aXat3Kh8tMPnjP/4Q3LdXz7hhrz2cMj1XnEWBk2u+LadvS/Tyl9Btfr9V0Mm96dqQ9+Okbu0mKl9B6kjD1btPzPT1S7b3XrKLW7epQ/d7urRkmSFs94QGte/U2V/Ta+9Td9+LOx8pSXKqXPYGXu36blf36i2rWq9q1cqBM7v9EnTz8o0zSV0utqHVr/ud5+9HqV5udU2XfLx3P01tQRyjt6QG37Xaswp0ufPjNFi2dMks/rlVT351ifz6G6175/9Sd64/6rdGDNErXo2FMtLu+pg2uX6rPnHqvXvEBj4wwpAAAAAHVqltRGqVdep71fLNCwx3/rP5MoJ22vjm9br753TZUjvLLQiU/tpPjUTlWe3/3m8Xrt7t7a8vEcXXnP4w2ae/mffi5HZJTufvEThUVFS5I6XXeH/m/KdefsW5+5U3oPUrPktsrct02dht1e7XwFJ4/o/jmrFZ2QLEnqcct4LX5qspb+7nE9MG+DbHZHg3LVpDQ/W2FR0f6zorrecLdKcjO15DePqN1V12v006/79+0y8k69cf9AfT33jxo69SntXvah3KVFuuOFd/1nTfXQeBXnnKz3/LVxhEeo07Db9dmzj6l5Sodq36vqrJ3zO+Uc2u0fu8tLJUnr5/5eWz/+p397ZLM4jfz5n2o8Tl76Qa2e/Yz63vmIhv3oOf/2Te/N0s6l7yqmmrORznbZgOFVxt1uvEfxqZ30xV9/oT5jH5YrsZXy0g/oq388q753TdWw6c/69/1u/ms1zrNz6bv64SvLFdu6naTK4mvOff20ZcFrumrSf0qS8o8d0oq//Updrx9X5Yy/pC5X6JOnJ2vrx/9Un7EP1fk5ns/nUJx9QkuefVSp/a7Vrb+Z6z8jqtftD6g4p3LdvMb+/gB1oZACAAAAUC89Rt+vwxuWa88XC9RzdOXledsX/0uS1POW+6vse2LHN9q/5lMVZhyV110hmaZsdruy9jfsTmvF2Sd0bOs6DZz4hL/0kSoLsssGDNee5fPPec6FzF2an6P9qz9Rnzse9pdRp1//BO1buVAnd32rZsltG5yrOl53hXqPOX3ZoCM8UtsW/Uvu0uJzijtnXAu1H3Sj9q1cqKFTn5IjPEJed4UOfLVEHa+9zX8JWHR8Ur3mbizp332l9O++Omf7sS1VzzRyJbaq9Tj7Vy2S6fOq99iHqmzvPWay1rzyTL2yeN0V2vvlAh3fvlGl+dkyfT6VFebJ9PmUfXCXXImttG9l5Tx97qg6T4/RE7Rq1n9Xe9w2fYf4yyhJimmZori2lytz/+lFx/etXCif16Mrxj1a5bmdht2mmKS22r38Q/UZ+1CjfI57vlggT1mJBtz/M38ZdUp0fEtJCtrvDy4dFFIAAAAA6qXDkJsUFddC2z+Zp56j75fX49bOf7+nVj0GKqF9V/9+X//rj1r3zxfU7YZ71abPYEW4YiXD0LFt61VRUtigOfOPp0mSmrc+d7H05ikdztl2oXPnpR+QTFPHt63Xp888LNM0Kx8wpfLifElS4cmj/u31zVWT8OgYRcUmVNmWe2SfpMrLyOwOR+Vc38fIPLBNhSePSpJ63nq/Dq5bqk+eflDO+JZq02ew2l45TF1G3FmlJAu0qx94UqX52f5xaV6WvvjLLzRw4hNK7NDdv90REVXrcfKPp0mGodhWl1XZ7giPrLPMkioX23/vx6NVkpOhHqPvV3L3/nJERCrv6AEd/XaV//tQcOKIDJtNzZJTz5onQtE1zHN2JkmKik1QSc7pu3YWnDgiqfrvQ/M2HZRzuPIsssb4HPOOHpAkxV/WucZ9gvX7g0sHhRQAAACAerE7wtT9hnv0zTsvKvvgLuWk7VVpbqaGTDl9FklFSaHWz/2Det0+WcN/8kKV5//7hR81fM6wMEmSu7zknMfcZVW3XYy5bfbKX5FadO6tywaMOOfxnrdOVFLXfirNy6x3rtqER7nOzeCozHD50FvkiIis8lin4WNOP9cZox/8aYGyD+3W0W9XKf27tfryb7/S+rl/0L2zlio6Psl/KZbXXXHOPOVFBfXO2RBt+g6pMi44UVkqpvQepNQrh9X7OPawcMk05akoO+d9OnUZYG12L/tAmXu36u6ZlWt8nbJ/9SfnzGP6fPJWlMsWVfVXZE9Z9fPYzlhY3s8wZPp8Z+xT+d31VJSdU/B4ykr8a5bV53NsqFOfu7u0pNrvWGPNCzQEhRQAAACAeusxeoK+eedFbf/kTeWk7VV4dIw6X3e6JCnJzZLP41Zi+25Vnndi56Y6FzSvTvxlXWQPi1DG7s3nPHZy97dVxg2Z27A7ZJo+nS2hfVeFRUXL53bXulZPVGx8vXM1VKtu/bVZs+WMb6nL+l9X5/4J7boooV0X9Rn7sI58u0of/mys9q1YpD5jH5KzeaLs4ZEqzEyv8pzCjHSV5GbUcMSqbHZHlaIlUFp07CVJyti9WW36DvVvLzhxRKW5mXU+/9Td9c7+PhzZtOqseXpWzrPnuyoLhRdmHlNJXt3z1KRlx96SKi8hbT/oBv/2itIiZR/arbb9rq2yf22fo9SwzyH5+wLu2NZ1da45Vde8QGPhLnsAAAAA6i2ubUel9BmsHUveUtrGL9Rl5A+qrqGUnKqImOY6sPYz/y/PZQW5Wjfnd4qKa9Hg+cIinep+8w+16/MPdHzHRv/2Pcvnqzi76uLLDZk7pmWKKooLVF6UX2W7IzxSA8b/VLs+f0+7l31Q5bGK0iJ9+/5smT5fg3I1VMdhtynx8p5a8fdfKe+su+PlHtnnX59q74qPlX3G4uHS6bOzomLj/dvaDRyhfV9+7L8DnKeiXOv++b/1/jxcLVur8OSR834956vjsFsVnZCkr/7xnMqLKy+v83rcWjfnd3LGtazz+S2/L7TOPCPq6OY156xv1XHYbZXzvPac/zI+n9ej9f98Qc7mDf/O+o977a1ytWitta8/77+E0fT5tGb2M3KXFumKu6ZKqv/n2JDP4fJrRiuhfTeteeUZ5abt9W+vKC1q8PcHaCycIQUAAACgQXqOnqDPnpsmSepxy4Qqj9nsdo36xd+09HfTNXfS1WqWnKq89IMa/pMXtHLmf53XfNc89j8qzj6hD/7jdiV17Sevu1xxbTuq+00/1NrXTt8VrSFzd7vxXm1+f7bemjpSiR26y7DZNerJvyncGaMB4/9Dhs2m5X9+Quv++YJiUzqoLD9bRZnH1Gn4HdL3iz/XN1dD2ewOjf39e1r+p5/rzclDlXh5D0XGxqvg2CHZ7A4NeujXkirXYFrym0fkcZepeev2qigpUubereozdoo6nXHW2pBHZujDn9+pf00eopYde6kw46iuffw5Hd+2vl55+o17TMv//ITe+/Gtcsa1UItOvTRwws/O+/XVV3iUS7f+9l9a/NRkvTFhgFp07KWCk2ka/ND/U8ae7+p8fochN6v7zeO19HfTtW3RXHndFTLsDg155L/10S/vPXeeGQ/onxMGqsXlPVWYcVSDHvy1jm/fKJvNfl75w6KiNeaFd7TkmSl64/6rlNSlr/KPHVZZQY5G/eLvSuk9SFL9P8eGfA52R5ju+N93tfR3j2vew9epRadeletnpR/UwPE/bdC8QGMxTP8qfQAAAMClLSsrS3eOu0euK29S51sftDpO0PJUlOng2qWyO8LUYcjN1e5TVpinjD1bJEnJ3fspPMqlwxu+ULjTpVY9BkiSMvdtVeHJo1WOUd22U7IP7lL+8UOKbdVOCe27Kjdtr7IO7lSHITfL7ghr0NyS5C4t1oldm1RemC/T9KnD4Jv8a+9Ikqe8VBl7tqisMFfRCcmKv6yzwiKd553rbCd2bVJpXrbaXz2qxn2Ks08o68BOmaZPsa3bqXlKB//d0E7JPbpfeUcPKNzpUkK7ropsFnfOcTwVZTq+7Wv5PB4ld++vCFezat+TA2s+VUxSG//lcqcUnDyq7AM75KkolzO+hVJ6XV1j5rO5y0p0aP3nSuk9SM7zOEvO667Q8e0b5CkvVVLXKxQVm6DDG79UWESUWve6qs7suUf3K+/IfjnjWyqpS1+VFebpyKaVatV9gFwtTi9a7qko14kdG+SpKFdSlysUFRuvl2/vqA6Db9INv3zRv9/eFR8rLrXTOZcCHt28RqbpU9srrqmy3TRNZe2vXIw+PLqZkrpeUe33qD6fY02fQ02vXZLyjx9WzqHdCo+OUYuOPRXujGnwvJBW/tc43XHDdZoxY4bVUUIGhRQAAADwPQopAKfkpR/QGxMG6trpz/ovr8Oli0Lq4mMNKQAAAADAJS39u6/8i6BLlXds/PLvv65ctH/EWAuTAaGLNaQAAAAAAJc2m03v/+R2RTaLU3h0jDL3bpU9PFyj/+efio6vewF1AA1HIQUAAAAAuKSl9Lpa97/xlXIO7VJhRrqimieqZec+ta4BBuDCUEgBAAAAAC55dkeYWnTsVe3C4AAuPtaQAgAAAAAAQEBRSAEAAAAAACCgKKQAAAAAAAAQUBRSAAAAAAAACCgKKQAAAAAAAAQUhRQAAAAAAAACikIKAAAAAAAAAUUhBQAAAAAAgICikAIAAAAAAEBAUUgBAAAAAAAgoCikAAAAAAAAEFAUUgAAAAAAAAgoCikAAAAAAAAEFIUUAAAAAAAAAopCCgAAAAAAAAFFIQUAAAAAAICAopACAAAAAABAQFFIAQAAAAAAIKAopAAAAAAAABBQFFIAAAAAAAAIKAopAAAAAAAABBSFFAAAAAAAAAKKQgoAAAAAAAABRSEFAAAAAACAgKKQAgAAAAAAQEBRSAEAAAAAACCgKKQAAAAAAAAQUBRSAAAAAAAACCgKKQAAAAAAAAQUhRQAAAAAAAACikIKAAAAAAAAAUUhBQAAAAAAgICikAIAAAAAAEBAUUgBAAAAAADUwDRNqyOEJAopAAAA4HsREREyDMnnrrA6CgAgSHgrymVIioyMtDpKSKGQAgAAAL7ndDplMwy5SwqtjgIACBKekkIZhhQTE2N1lJBCIQUAAAB8z263q0O7dio4vFM+r8fqOACAIJCzf6vCbIYuu+wyq6OEFAopAAAA4AwjRgyXraxQufu2WB0FABAEMrasVnSEQ9dcc43VUUIKhRQAAABwhuHDhyvSYejEtyusjgIAsFh5frYKD27T4Kuv4pK9i4xCCgAAADhD69atdUXvXsrd/pUOr1hgdRwAgEXKC/O0Ze5zcjqkG264weo4IYdCCgAAADjLjBkz1LdLBx1dNk/7l7wpT3mZ1ZEAAAFUdDJNm1+dIXvOEU175GENHTrU6kghxzBN07Q6BAAAABBsCgsL9ctf/lKbtu1ShWFXbIfeSux+lWJat5MjMlq2sAirIwIALgbTJ095qSoK85Szd7Oyd25QRXa6osMM/ewnP9aYMWOsThiSKKQAAACAGpSUlGjp0qVavXq1Nn23RaUVXnlNU6Yp8UM0AIQOQ5LNkMLshpIS4jV0yGCNGDFCffr0sTpayKKQAgAAAOqhoKBAX3/9tU6ePKmioiJVVFRYHQkAcJG4XC5FR0ere/fu6tatm+x2u9WRQh6FFAAAAAAAAAKKRc0BAAAAAAAQUBRSAAAAAAAACCgKKQAAAAAAAAQUhRQAAAAAAAACikIKAAAAAAAAAUUhBQAAAAAAgICikAIAAAAAAEBAUUgBAAAAAAAgoCikAAAAAAAAEFAUUgAAAAAAAAgoCikAAAAAAAAEFIUUAAAAAAAAAopCCgAAAAAAAAFFIQUAAAAAAICAopACAAAAAABAQFFIAQAAAAAAIKAopAAAAAAAABBQFFIAAAAAAAAIKAopAAAAAAAABBSFFAAAAAAAAAKKQgoAAAAAAAABRSEFAAAAAACAgKKQAgAAAAAAQEBRSAEAAAAAACCgKKQAAAAAAAAQUBRSAAAAAAAACCgKKQAAAAAAAAQUhRQAAAAAAAACikIKAAAAAAAAAUUhBQAAAAAAgICikAIAAAAAAEBAUUgBAAAAAAAgoCikAAAAAAAAEFAUUgAAAAAAAAio/w90u/EaB2Z1MQAAAABJRU5ErkJggg=="
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "\n",
+    "from matplotlib.patches import FancyBboxPatch\n",
+    "\n",
+    "figure, axis = plt.subplots(figsize=(10.0, 4.2))\n",
+    "axis.set_xlim(0.0, 10.0)\n",
+    "axis.set_ylim(0.0, 4.0)\n",
+    "axis.axis(\"off\")\n",
+    "\n",
+    "boxes = [\n",
+    "    (0.4, 1.4, 2.0, 1.2, \"NeqSim stream\\nT, p, flow, composition\", \"#0072B2\"),\n",
+    "    (3.2, 1.4, 2.1, 1.2, \"Python unit operation\\nunit conversion + contract\", \"#009E73\"),\n",
+    "    (6.1, 2.5, 3.2, 0.8, \"Chemistry / property model\", \"#E69F00\"),\n",
+    "    (6.1, 1.4, 3.2, 0.8, \"Combustion / flow correlation\", \"#CC79A7\"),\n",
+    "    (6.1, 0.3, 3.2, 0.8, \"Validated result + diagnostics\", \"#56B4E9\"),\n",
+    "]\n",
+    "\n",
+    "for x, y, width, height, label, color in boxes:\n",
+    "    patch = FancyBboxPatch(\n",
+    "        (x, y),\n",
+    "        width,\n",
+    "        height,\n",
+    "        boxstyle=\"round,pad=0.08\",\n",
+    "        facecolor=color,\n",
+    "        edgecolor=\"#222222\",\n",
+    "        alpha=0.85,\n",
+    "    )\n",
+    "    axis.add_patch(patch)\n",
+    "    axis.text(\n",
+    "        x + width / 2.0,\n",
+    "        y + height / 2.0,\n",
+    "        label,\n",
+    "        ha=\"center\",\n",
+    "        va=\"center\",\n",
+    "        color=\"white\" if color != \"#56B4E9\" else \"black\",\n",
+    "        fontsize=10,\n",
+    "    )\n",
+    "\n",
+    "for target_y in (2.9, 1.8, 0.7):\n",
+    "    axis.annotate(\n",
+    "        \"\",\n",
+    "        xy=(6.0, target_y),\n",
+    "        xytext=(5.35, 2.0),\n",
+    "        arrowprops={\"arrowstyle\": \"->\", \"color\": \"#333333\", \"linewidth\": 1.8},\n",
+    "    )\n",
+    "\n",
+    "axis.annotate(\n",
+    "    \"\",\n",
+    "    xy=(3.1, 2.0),\n",
+    "    xytext=(2.45, 2.0),\n",
+    "    arrowprops={\"arrowstyle\": \"->\", \"color\": \"#333333\", \"linewidth\": 1.8},\n",
+    ")\n",
+    "axis.set_title(\"Model-boundary workflow for third-party NeqSim unit operations\")\n",
+    "figure.tight_layout()\n",
+    "display(figure)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "property-sweep-explanation",
+   "metadata": {},
+   "source": [
+    "\n",
+    "The diagram is an executable overview of the data contract. It emphasizes that external\n",
+    "packages supplement a NeqSim flowsheet; they do not silently replace its process state. The\n",
+    "next comparison also illustrates why model differences should be plotted across an operating\n",
+    "range instead of judged from one number.\n",
+    "\n",
+    "## 7. Pressure sweep: NeqSim SRK versus CoolProp for pure CO2\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "property-sweep-figure",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<Figure size 960x600 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA7QAAAJMCAYAAADKcepuAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjExLjEsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvctoD+AAAAAlwSFlzAAASdAAAEnQB3mYfeAAAmTFJREFUeJzs3Xd8U/X+x/F3VpvuQfcAWjbIkiUXBcS9wK2o14t43XoVvVecd6lXr3qv9/4Er17HdV71igvcCogLERVFptIyu0sHHUmTJvn9URIJLdA0bdPxej4efZCe8805n4RD6LvnOwwej8cjAAAAAAC6GWOoCwAAAAAAoC0ItAAAAACAbolACwAAAADolgi0AAAAAIBuiUALAAAAAOiWCLQAAAAAgG6JQAsAAAAA6JYItAAAAACAbolACwAAAADolgi0AAAAAIBuiUALAAAAAOiWCLQAALRg+PDhGjJkSKjLCMjUqVM1ZMgQVVRUhLoUhEB3vGYBIFjmUBcAAN3dyJEj5XA4/LZZrValpaVpypQpmjt3rrKyskJUXftbsWKF3n77ba1Zs0bl5eVyu91KT0/XL37xC1100UXKzc1t8Xlut1tvvfWW3nnnHa1fv16VlZWKjIxUVlaWpk6dqosuukhJSUktPu+7777T0qVLtXr1ahUWFqqqqkoJCQkaM2aMLrjgAk2ePLmjXza6Abvdrm+++UYrV67UypUrtWHDBrndbt1888269NJLAzrWvffeq6efflqSdO211+q6664L6PklJSX68MMPtXz5cm3btk0lJSWKjIzU4MGDddppp+nss8+WyWQK6JjdUVs/LwCgtQwej8cT6iIAoDtrKdDuKzo6Wk8++aTGjBnTeUV1gPLycs2bN09fffXVAdsYjUb9+te/1g033OD3w3phYaGuueYabdiw4YDPjYyM1F133aVTTz3Vb/uqVat08cUXH7S2yy+/XDfddFMrX0nrDB8+XC6XS5s3b27X43akqVOnqqSkRCtXrlRiYqJv+6RJk1RVVaXVq1crNjY2hBUeXLB1/vWvf9VTTz3VbHuggfabb77RRRddJIPBIJfL1aZAO2vWLG3atOmA+ydNmqTHH39c4eHhAR33YLrSNRvM5wUABII7tADQThYtWqSRI0dKkioqKvTll1/qL3/5i8rKyjR//ny9++67Mhq750iPPXv26MILL9S2bdsUERGh2bNn66STTlJubq7CwsJ8Ieq5557Tv//9bx1//PG+96KyslIXXnihCgsLFR0drcsvv1wnnHCCMjIyVFdXp2+++Ub/+te/tG7dOv32t7+VyWTSSSed5Du3yWTS2LFjdeyxx2rChAlKT09XTEyM8vLy9PDDD+vjjz/Wv//9bx1xxBGaMmVKqN6iLuGTTz4JdQkhZbVa9Ytf/EJHHHGEJk+erEceeUTLly8P6Bg2m0233nqr+vbtq9zcXC1btqxNtWRlZWn69OmaPHmy+vfvr4SEBJWUlGjx4sV65JFHtGrVKj355JO6+uqr23T8riyYzwsACBSBFgA6QGJiok4++WTFx8frkksu0bZt27Ru3TqNGjUq1KW1yd13361t27YpLi5OzzzzjIYNG+a3Pzs7W9nZ2Tr77LP11FNPyWKx+PbdddddKiwsVHx8vJ5//nkNGjTIty8sLEzHHnuspk2bpuuvv15Lly7VHXfcoUmTJvnuMI4fP14vvfRSs5oOO+wwLVy4UOedd57WrVunt956q9cH2t7u+uuv9/u+Lb9A+tvf/qadO3fqv//9r5599tk217Jw4cJm2/r27atrr71W9fX1evLJJ/XRRx/1yEAbzOcFAASqe94qAIBu4ogjjpDVapUkbd++XZJ0yy23aMiQIXr77bdbfM6DDz6oIUOG6Mknn/Tb/vDDD2vIkCF65JFHtHPnTs2fP19HHXWUhg8frgcffNDXrr6+Xo8//rjOOussHX744Ro1apROOeUULViwQPX19QG/hl27dumtt96SJN1+++3Nfjjdl7cL4dChQyVJO3fu1LvvvitJuvXWW/3C7L4sFovuu+8+JSQkqLa2Vv/9739bVZvZbNbRRx8tSdq9e3erX5PX5s2bdc0112jixIkaPXq0Zs6cqRdeeEGHGo3Tlvd45MiRGjJkiBobG7VkyRKde+65Gjt2rMaOHauLL75YX3/9dYvP27Vrl+644w4dc8wxOuywwzRx4kSdfvrpuv/++7Vr1y6/tvtPCvXaa69pyJAhqqqqkiRNmDBBQ4YM8X3t2rVLhYWFGjZsmMaPHy+bzdZiDS6Xy3fsjRs3HvS98SopKdFTTz2liy66SEcddZQOO+wwTZkyRVdeeaVWrlzp17Y1dXaG1atX6/nnn9ecOXM0duzYDjuP99ht+ffYmdesJG3YsEFXXXWV3/mee+45eTyeFiehCubzAgDagju0ANBJDAZDuxwnLy9PZ5xxhmpqanzb3G63JKm4uFiXXnqptmzZ4vecLVu26OGHH9ZHH32k5557TjExMa0+34oVK+RyuZSYmNhsfGtrnut2u5WQkHDI58bGxuqMM87QU089peXLl+vaa69t1Tm84S3Qibe++uorXXbZZbLb7b5tmzdv1p///OeDhrZg3+MHHnjAN9mQ16pVqzRnzhw988wzGjdunG/7zp07dfbZZ/uCniRVV1erurpaGzdu1Ndff63//e9/Abzq5jIyMjRt2jQtX75c77zzjs4666xmbT7++GOVlJRo1KhRBw0o+7rhhhv07bff+m0rLy/X8uXLtXz5ct1555266KKLgqq9PdXX1+u2225T//79dcMNN3ToudavXy9JAc9I3NnX7BdffKErrrjCb46AzZs36+677z7g+YL5vACAtuAOLQB0oC+//NL3w2ffvn3b5ZhvvfWW+vTpo8cee0yrVq3S5s2bdfPNN8vj8ej666/Xli1bNHjwYC1cuFCff/65vvnmGz399NMaOnSoNm7cqHvvvTeg861bt06SNGbMmIAnbvH+4D5mzBiZzYf+Hao3zG3atOmQd5wkqaysTEuWLJHBYNDpp5/e6rrsdrt++9vfym63a+LEiXrttdf0ww8/aPny5ZozZ45eeeUVuVyuZs9rj/f4ueee09y5c/Xee+/pu+++06uvvqqRI0fK6XRqwYIFfm2ff/55VVVVafTo0XrxxRf1zTff6Ntvv9Wbb76p+fPnKzs7+6Cv88wzz9TmzZsVHx8vqekO5ObNm31f3l8CzJ49W5L08ssvt3gcb2g+99xzD3q+fWVkZOi6667TokWLtHLlSn3//fd6//33dd1118lsNuv+++/33VVvbZ0d6cEHH9SuXbt07733tutETV6NjY0qLCzUE088oSeeeEKRkZG66qqrWv38zr5m6+vrdfPNN8vhcGjKlCl644039MMPP+jjjz/WZZddpldffbXF8wXzeQEAbcEdWgDoAPtOCiVJ/fr104gRI9rl2FarVc8884zS0tL8tn/yySf67rvvlJGRoeeee84XDiRp8uTJeuqpp3TyySdr8eLFmj9/vuLi4lp1vsrKSklScnJywLV6n5uSktKq9t52jY2Nqq6u9nsN+3M4HLrxxht9E9AEMj75vffeU0lJiZKTk/Xvf/9bERERkppC2K233qrS0lK98847zZ7XHu/xJZdcot/97ne+7w877DA98MADOvHEE/X111+rsbHRF/7Ly8slNS0bc/jhh/ueM3To0HbtpnnUUUcpKytL33//vTZt2uR37OLiYn366aeKjo7WKaec0upj/u1vf2u2rX///rr22mtVXl6uF198UZ999plmzZrVLq8hGKtWrdJ///tfzZ07t927Gj/00EN69NFH/bZNmzZN8+bNC+jvsLOv2ffee09lZWVKS0vTv/71L1/IT09P129/+1uVlpbqzTffbHa+YD4vAKAtuEMLAO3k7LPP9o35mzx5subNm6eysjJFRkbq3nvvbbe7FUcffXSzMCs1dfWTpJkzZ7YYBPv06aNJkybJ6XRq7dq1AZ83mC7T7dXd2svlcunmm2/WV199pUmTJumWW24J6PmrV6+WJJ133nm+YLCvSy65pMXntcd7fPbZZzfblpOTo7i4ODkcDu3Zs8e33ftLkEWLFrVpjHBrGY1GnXfeeZKa36X13vk77bTTFBkZ2epjulwuvfLKK5ozZ44mT56sESNG+P59vPjii5KkgoKC9nsRbVRXV6fbbrtNOTk5zSaV6iibN2/WJ5984hsq0Bqdfc16x3Sfc845Ld6xPtRSWu39bx4ADoQ7tADQAcLCwpSRkaHJkyfr0ksvPWTX0EAcqOuyd+Kcf//733r88cclNXU39Hbd3bcL777hyLt26b5SU1N9S8AkJCRIkkpLSwOuNdDnetuZzeYDrkPqdDr129/+Vu+9954mTpyoxx57TGFhYQHVVVxcLKkpSLYkNze3xe1tfY/3lZmZ2eL26OhoVVdX+41XvOiii7RixQq9//77+vDDDzVkyBCNGDFCEyZM0NFHH93qu+ytcfbZZ+vhhx/W4sWLdfPNNysiIkIul0uLFi2SJF/gbQ23262rr75aH3/88UHbNTQ0BFNyu3jggQdUWFioF198sUO6Gs+bN0/z5s2T0+lUaWmpPv30Uy1YsEB///vfVVJSot///vetOk5nX7Pez4QDna9///4tbg/m8wIA2oI7tADQThYtWuQb8/fDDz/o/fff1x//+MeAw+yhxo56Z03en/duj9vtlsvlksvlktvt9vvh1cvpdLa6nsMOO0yS9P3337c4Zu5gvHcY16xZo8bGxkO2/+abbyQ1daltackVh8Oh3/zmN35htqW7Va0V6F2k9niPA1lKJiwsTM8884yef/55XXLJJYqOjtY777yj+fPna/r06Qcc89oWiYmJOuGEE1RbW+ubgXvFihUqLi4OaDIoSXr//ff18ccfKzIyUnfddZc+/PBDX3fmzZs367rrrmu3uoO1bNkyud1unXfeeX4zKw8ZMsTXhXfBggUaMmSIzjzzzDafx2KxKDMzU+eff74vWL744osB33kPxTUbiGA+LwCgLbhDCwCdzLvmYl1dXYv7d+7c2abjpqenS5Lmz5+vuXPntvp53juxBzJt2jSZTCbt3r1bb7/9tmbOnNnqY0+bNk333HOPKisr9dZbbx104qaamhq9/vrrkuRbimdfNptN1157rT777DNNmjQpqDDr7bKdn5/f4v4DbW/rexysCRMmaMKECZKaxhd//vnn+t3vfqc//elPGj9+vAYMGHDQ57c2BM2ePVtLlizRyy+/rLPPPts3GVQgd2elptl4Jemqq65qcSKpvLy8oOrs7oYNG6bY2Fjt2bNH27dvV58+fQ75nM6+ZlNTUyVJW7dubXH/tm3bWtwezOcFALQFd2gBoJN5J0tpaYxlcXGxvvjiizYdd+rUqZKa7hTX1ta2vcD9ZGVl+ZbfuPvuu7Vp06YDtvV4PHryySd9bbKzs3XSSSdJku6991799NNPLT7P6XTqlltuUWVlpaKjo3XBBRf47a+trdVll12mzz77TJMnTw76zqw3HL788sstrr36n//8p8XnddR7HAiz2axp06Zp0qRJcrlcrRoP7e2SfaBfoniNGzdOgwcP1tq1a7V8+XJ98sknio6O1sknnxxQjd5u0y39HeXn52vp0qVB1dmePvnkE78Zlff98r7ua6+9Vps3b9Zrr73WLufctGmTb6x0aydP6uxrdvz48ZKaxlC31DX82WefbfF5wXxeAEBbEGgBoJNNmjRJkvTGG2/opZdeUmVlpaqqqrR8+XJdcsklfuvLBuKYY47RyJEjlZeXpwsuuEBvv/22CgsL5XA4VFpaqu+//14LFy4MaOkVrzvuuEP9+vVTdXW1zj//fN1///1au3atamtr5XA4tHPnTv3vf//TzJkzdf/99/t1XbzjjjuUkZGhqqoqnX/++Xrssce0fft2ORwOVVVV6aOPPtLs2bP10UcfyWAw6K677lJiYqLv+TU1Nbr00ku1evVqHXnkkXr00UeDCrOSdOKJJyo1NVVlZWW64oortH79ejmdThUVFem+++5rcbZYqWPf45b85je/0X333adVq1apqKhITqdTu3fv1quvvqrPPvtMUusCUUZGhiTp1VdfPWSo8S7h87vf/U4ul0szZ84MaDIoSb7uyY8++qhWrFihuro6lZWV6a233tKcOXMOOHY2kDq7gttvv11DhgzRvHnz/LZ/+umnuvLKK/Xee+8pLy9PdXV1qq2tVX5+vp588knfndLDDz+81UMSOvuaPfHEE5WUlKTi4mJdffXV2rRpk5xOp0pKSvTggw+2OMOxVzCfFwAQKIOnNQv9AQAOaOTIkXI4HFq0aJFGjhx5yPYej0e//vWvfYFkX8nJyZo4caLefvtt3Xzzzbr00kt9+x5++GEtWLBA119/va6++uoWj11SUqLLL7/8oHc8YmJifDOYBqK8vFw33HCDb7bVlphMJv3617/W9ddf7zerc2Fhoa6++mpt3LjxgM/1jrf03t3xevPNN3XzzTcfsr5BgwbprbfeasUrabJq1SpdfvnlvnWC93XWWWfpjTfekMvl0ubNm/32tfU99l4n69evb3FN3hkzZqigoEArVqzwdS8999xz9f333x/wPFOnTtVjjz3mG5frneBr5cqVfr8U+M9//qP77ruv2fOXLl3abI3X2tpaHXXUUaqvr5fU9P4HukRQbW2tTj/99Ba7z8fExGjGjBl68803deWVV/qFwUDqbMnXX3+tCy+88JDt9v87PZB58+bpnXfe0bXXXtviuN/bb79dixYt0sknn6yHHnrIt3358uW68sorD3rsnJwcPfHEEwGtsdvZ1+znn3+uK6+80m+isn3P9/rrr8toNPrWm95XMJ8XABAIxtACQCczGAxasGCB/u///s+31mN8fLymTp2qG2644YBd+VojNTVVr7zyihYtWqR3331XmzdvVn19vRITE5WRkaEjjzwyoLVE95WUlKTnn39eK1as0JIlS/Tdd9+pvLxcHo9H6enpmjJlii666KIWZ0XNyMjQq6++qrfeekvvvvuu1q1bp6qqKkVERCg7O1tHHXWULrrook5du3LSpEl6+eWX9X//939avXq1HA6H+vbtq7PPPlu//OUv9cYbb7T4vI58j/f38MMP691339Xy5cu1bds2VVRUKDExUf369dOZZ56pU089tVWTTF188cWy2WxasmSJdu3a1WJA8YqOjtZpp52ml19+WaNHj27TerfR0dH673//q7///e9asWKFampqlJiYqClTpuiaa6454N3EQOrsyqZOnaonn3xS7777rtauXavCwkI1NDQoPj5eQ4YM0THHHKOzzz474Nm5O/uanTJlil566SU9/PDD+uabb3znO+ecc3TmmWfq1VdfPeBs5MF8XgBAILhDCwAA/Fx++eVasWKF7rnnnhbXzQW8d8NHjx7tmzwMAEKBMbQAAMBn586d+vTTTxUVFRXwZFDoPZ555hlJP08eBQChQpdjAAAgSSotLdUf//hHud1unXHGGQFPBoWe5fPPP9f777+v0047TQMGDFB0dLTy8/P1+OOP64MPPpDFYtE555wT6jIB9HIEWgAAern9J1OKiorSZZddFsKK0BU4HA69/PLLevnll1vcf8sttzAGFkDIEWgBAIAkKTw8XMOGDdP8+fN9My2j9zryyCN1991366233tK2bdu0e/duxcTEaMyYMfrVr36lI444ItQlAgCTQgEAAAAAuicmhQIAAAAAdEsEWgAAAABAt0SgBQAAAAB0S0wKFYDvv/9ebrdbYWFhoS4FAAAAAHoUh8Mho9Go0aNHt/o53KENgNvtVledQ8vj8chut3fZ+tCzcL2hs3HNoTNxvaGzcc2hM3Xl683j8cjtdgf0HO7QBsB7Z3bEiBEhrqQ5m82mDRs2aMCAAYqIiAh1OejhuN7Q2bjm0Jm43tDZuObQmbry9bZ+/fqAn8MdWgAAAABAt0SgBQAAAAB0SwRaAAAAAEC3RKAFAAAAAHRLBFoAAAAAQLdEoAUAAAAAdEsEWgAAAABAt0SgBQAAAAB0SwRaAAAAAEC3RKAFAAAAAHRLBFoAAAAAQLdEoIUfl8ul4uJilZaWNtvncDhUXFysxsbGDq3B4XCopqamxX1Op7NTajhUHd73yftVWVl50HY2m63Zvt27d6u4uFgul6td6wYAAAB6CwJtF+V0ufXxlnK9trZIH28pl9Pl7pTzFhUVadq0aZo6darWr1/vt+/LL7/UtGnTtH379g459xtvvKGTTz5Z48aN0zHHHKMjjzxSDzzwgMrLy31ttmzZomnTpik/P79DamhtHd73aebMmTr33HN1wgknaOzYsbrjjjtUW1vbrN0HH3zgd45XXnlFRx55pF544QWZTKYOey0AAABAT0ag7WKcLrfu+vBHZf/5Ix39r5U665mvdfS/VqrvXR/prg9/7LRgazab9fe//71TziVJS5cu1fz583Xuuefq22+/1VdffaXFixerT58+WrVqla+dxWJRamqqzGZzSOvwuv322/XJJ5/oq6++0pNPPqklS5bo/vvvP+g5nnnmGd15552aN2+ebrrppg55HQAAAEBv0DGpAG3idLl1+n9W652NpTLst6+kpkG/f2+zVm2v1OuXTJDF1LG/izj//PP13HPPafXq1ZowYcIh29tsNtlsNiUmJra43+PxqLKyUtHR0QoLC1NFRYUsFotiYmIkSV988YXi4+M1Z84c33MSExM1d+5cv+P069dP//vf/5SUlCSpqVtwRUWFkpOTZTKZVFNTo7CwMIWHh/ueU1tbK5PJpIiIiEO+jtbW0ZLDDz9cU6ZM0cqVKw/Y5l//+pf++c9/6s4779SFF154yGMCAAAAbbXjoZlylub5bXN7PApvaNCu8HAZDT+nDkvKAPWdt7izSwwad2i7kPuWbdE7G5vGrnr22+f9/u2Npfrrsi0dXssRRxyhyZMn629/+9tB223YsEEXXHCBr3vujBkztGLFCr82H330kaZOnaqjjz5aEydO1J133qlf/epX+r//+z9fm/79+6u6ulpLliw56JjS/bscr127VtOmTdM//vEPTZ8+XTNmzNC4ceN01113acOGDTrzzDM1ffp0jR8/XldeeaXq6+sP+npaW8eB1NfXy2hs+Z/Vgw8+qIcfflj33XcfYRYAAAAdzlmap4bCDX5fzqKNMlbky1m00X/7fsG3uyDQdhFOl1sLP9vW7M7s/gySFn6+rVO6Ht94441as2aNli9f3uL+wsJCXXzxxYqNjdXKlSv17bff6rLLLtO1116rgoICSdLOnTt1ww036LzzztM333yjL7/8UvX19frxxx/9jnXeeefp9NNP180336yJEyfql7/8pR555BHt2rWrVbWuXr1ar7zyilavXq2//OUvev7553XppZfqtttu09dff60PP/xQa9as0bPPPnvQ4wRax549e1RcXKytW7fqP//5j7788ssWw+qjjz6qp59+Wv/4xz90+umnt+o1AQAAADg4uhx3sK92VOquD39STcPBZ+WtsjlVUttwyON5JBXXNGjCPz5VfITFt93tcqmuvl5RX3wt495JhmLCzbrzuEGa2DehTbWPGjVKxx13nB566CFNnz692f7nnntOjY2NuvfeexUXFydJmj17tt544w09/fTTuv322/XCCy8oIyND11xzjQwGg8xms/7whz/oww8/9DtWWFiY7rvvPt18881avXq11q5dq1deeUWPP/64/vGPf2jatGkHrXXevHlKTk6WJJ122mm6/fbbddppp2n8+PGSpIyMDE2ePFnff//9QY8TaB0PP/ywHn/8ce3Zs0c2m01XXHGFLr744mbHrayslMlk8nWxBgAAABA8Am0H+8cnW/XWhpJ2P+73hXsOsMfh911suFkvXNS2QCtJN9xwg0477TS99dZbvtDqtWnTJuXm5qqhoUHFxcW+7bm5ub47sPn5+Ro6dKgM+/TPj42NVXZ2dovnS0xM1AknnKATTjhB11xzjS644AL96U9/0rJlyw5aZ2Zmpu+xwWBQZGSkMjIy/NpERUVp9+7drXrdra3j9ttv16xZs+RyufSvf/1Ljz76qGbMmKExY8b4tbvpppv0/vvv68orr9Rjjz2mI444olV1AAAAoOWxoAfSXceCom0ItB3shqk5qmlobNUd2gOH1OZGZ8S2fIc2MtLvDu0NU3PbVvheAwcO1MyZM/Xwww/r1ltv9dtnNBqVl5enc889t9nz+vXrJ6npjqfD4Wi2f/9tHo/HL/RKUmRkpI455hgtWLBAtbW1io6ODuq1tEZb6zCZTLr22mu1YsUK/fnPf9Zrr73mtz8sLEwLFy7U1VdfrSuvvFL//ve/NXHixA59LQAAAD2Fdyxob+TxeORx1Mttq5HLXiN3Q63cthq593/cwj7H7o5ZbrMrIdB2sIl9E7Tk0kMHF6fLrew/f6TS2oZmE0LtyyApNSZcq284ym+mY5vNpg0bNmj48OGtms03ENddd51OPPFELVq0yG/7+PHjVVJSoiVLljQLgd4JlYYPH67nnntOdrtdVqtVUtO4Wu8YW68nnnhC06dP16BBg/y279ixQ5GRkb7ndrRg6/AG1k8//VRHHXWU377w8HA98sgjuuqqq3TFFVfo8ccf93WJBgAAQM/gcbvlbqj7OWTaa1t87DrIvv2DqTwHSwi9G4G2i7CYjLrmyP76/XubD9rOI+maKf07fNmefWVlZencc8/VCy+84Lf9l7/8pd566y1df/31+uUvf6mUlBQVFhbqgw8+UGpqqq688kpddNFFeu6553TTTTfp6quvls1m07333ivPfv8oKyoqdM455+iKK67QscceK5fLpY8++khLlizRFVdc0WHrzu4v2Dq8Yfjxxx9vFmiln0PtlVdeqcsuu0xPPPGExo0b11EvBwAAAIfgcbsOHCzttXuD58HDqfexy14jT0NdyF6LwWKV0RojozVaRmuMHCU/yeOwhayezkCg7UJumTFQq7ZX6u2969DuG/m8358yLEXzZwzssBrMZrNSU1P91nGVpKuuukorVqyQ0+mUxdLU1Tk6Olovv/yynnjiCd13333as2ePsrOzdfzxx+uss86S1DRe9vnnn9ff/vY3/eY3v1F8fLxmz56t//3vf37Hv+mmmzRq1Ci9++67evvtt2UwGJSZmakFCxbomGOO8bWzWCxKTU31BcuwsDC/771SUlIUFRXlty0uLk4JCQcfT9zaOrzvU2RkpN/zDQaDrrzySj3wwAPKy8tTVFRUs3ZWq1WPPvqorr/+et155516+OGHNWDAgIPWBQAAeobesC5oqLnqKlT+9l+b7nA27A2dex+7WgijoQx8hrBIGSNiZAyPlska4xdGjS1+7//YtG+78CgZzBa/4+fdOqLHd9U2ePa/VYYDWr9+vSRpxIgRHXYOp8utvy7booWfb1Nxzc+zHqfFhOuaKf01f8bAFu/OdmSX445w7rnnavTo0br99ttDXQraoLtdb+j+uObQmbje0JECCRjhGcM14N71HVxR5/E0OuSy7ZF775fLtkdu+z6PvV/2Pc3aNez8Xp7G5vOydDZfoAzf+2fEPo/3+94Ucah2UTIYTR1ab3e73tqSt7hD28VYTEbdcdxgzZ8xUJ9vrVBFvVOJkRZNyUns1G7GAAAAgHdComZB9ABh1GXfJ5juG1rtNfI4D71EZbsyGFq+sxkeLWNEzM93N/d+f7DHJmuMDGGRMhj5ebyrIdB2URaTUdMHJoW6jA6TmJio2NjYUJcBAADQI3ncrr2TCjW/29nSXdBmYdRe49svj7vzCjcYZYyIlSkiVsaIWBmtTX/atnzRVEsrhKUNVu6f18gQFtFs4tLexpLSfFib2+NRQ0ODwlvo4t4dEWgREo8++mioSwAAAOjS3E676jatOHgXXXtNi/s6e2IigyXcFz73DaO+x3u/TNbYvXc992u797EhLLLFEJp36wg12FrXddZgNMsYHnnohr1AS2OwvcMqBvSQYRUEWgAAAASkpYmNDqQ3TWzkcTXKZauWu75arvoquW3VctVVyV1fJZetaVtjdXGrj+csy9f2e6d3XMHyjgn1D5VNYTSm6XGL+/YLqtYYGS3hhz4Z0AEItAAAAAiIszSvx82c6vF45HHam4JofZVc9dW+INr0fQvb6vaG1r3h1W2v7ZxiDUYZI+OaxoDuEzpNze6ENt/uF0at0R0+KRHQ0Qi0AAAA6PY8bvfe7rY/B1C/O6UH2OYNr676Ksnl7PhCDcZWj0k1J2Yr87Knm4XU3jg2NJDxnd11LCjahkALAACAkHM7G/YJmc3D5v4BdP+7p257jdTRq1GazDJFxMkYGd/0Z1S8TN7H+20zRsQ1/RnZ9GfTtljl3z6q1Xe3TdYYRQ2f0bGvqZvoLd3WETgCLQAAADqMq65CZUv+4h9E/QJq058ep73DazGERfqFTG/obGmbMTJepn23RcUfcMIiAKFDoAUAAECHaawuVtmi24M/kMHQqgBq3PeO6X7bDGZL8HUA6FIItAAAAOhwBkt487Dpe/zzNu/d0P3DqzE8WgajMdQvI2i9YV1QoDMRaLuIrjj9/ZdffqmvvvpKlZWVSklJ0bBhwzR16lQZ2/E/k6KiIi1YsEC/+c1vlJqaqsrKSj344IO+/REREerXr59OO+00xcfHt9t5AQBA5whLG6zcu76XMcwa6lK6hN6wLijQmbr/r7l6CO/09635am3wbavy8nJdeOGFuvHGG2Wz2TRw4EDV19fr97//vU488UTZ7e03xqWqqkqLFi1SdXW1JKmurk6LFi2SJI0ZM0aZmZl6/fXXdfzxx2vLli3tdl4AANA5DEYzYRZAh+EOLfy43W5dddVVamho0DvvvON3V/SKK67Q9ddfL4fDIau1Y/9jmjhxombNmiVJOv/883XsscfqoYce0sKFCzv0vAAAAAC6DwIt/Hz44Ydau3atnn/++WZdfKOjo/Xwww/LYmmaUMHlcun999/XmjVr5PF4dPjhh+uEE06QyfTzAt2taXMoERERGjt2rDZsaJrifunSpfr+++91wQUX6LXXXlNxcbFmz56tYcOGafPmzXr//fdVUVGhjIwMzZo1S6mpqb5j/d///Z+GDh2quLg4ffXVV6qurtaRRx6p6dOnt/1NAwAAABASdDmGn08//VTR0dEaP358i/sjIyNlsVjk8Xh02WWX6Z577lFcXJzi4+N111136fLLL5dn7xpwrWnTWk6nU+Hh4ZKkDRs26LnnntMFF1wgm82mww47TLGxsXrnnXd0xhlnaNeuXerXr5+++OILnXzyyb4gLEkffPCB7r77bv3pT3+S1WqVxWLRddddp4ceeqiN7xgAAL2PJWWAwjOGKzxjuMLShvi2m2JSfNu9X0xsBKAjcYe2g9nyvlLZ4ruaFvs+CEf5tlYf01G+Tdvune63ze1yK6y+TkXvRsloavo9hdEao+SZdypiwMRWH7uoqEhpaWmHXGPtzTff1JdffqklS5ZowICm/6iOP/54zZo1S2+++aZOP/30VrVpjYKCAq1atUqnnnqqb1t9fb0ef/xxX/Cur6/XXXfdpYsvvli33HKLJOlXv/qVfvWrX+nPf/6zXnrpJd9zbTablixZori4OEnS0KFDdfvtt+uss85S3759W/dGAQDQi+07sVHN9+9o599PkSRlXvWCokccG6qyAPRCBNoOtvuDf6j2u7fa9ZgeR73qN61ott0kaf/pmowRscoa8EKrj20ymeRyuQ7Z7osvvtCoUaN8QVWSBg8erBEjRmjlypU6/fTTW9XmQBYtWqSvvvpKdXV1+uKLLzRgwADdeOONvv1xcXF+d5E3bdqkiooKnXHGGb5tRqNRs2bN0h133CGbzeabNXDatGm+MCtJp5xyim699VZ99dVXBFoAAAJky//K9ziif8s9vACgoxBoO1if42+Q215zyDu0tvzV8jjqW3VMQ1ikInIn+G1zu9yqq69TVKT/Hdo+x98QUL39+vXTypUr5XA4FBYWdsB25eXlSkxMbLa9T58+Ki8vb3WbA+nbt6/GjBmjiIgIzZ07VyNHjvS7a7xvIPWeS1Kz8/Xp00cej0fl5eXKzs5usY3ZbFZMTMwhawIAAM3Z9wbasPQhMkXFh7YYAL0OgbaDRQyYqL7zlhyyXd6tI9RQuOGQ7SQpLKm/+t/6sd827/plA4Ncv+yEE07Qs88+qw8++MCvi6/Xrl27lJSUpMzMTH3//fct7h83bpwktarNgew7y3FrZGZm+o6dnJzsdy6z2ay0tDTftoKCAr/n1tbWqrq62ncMAADQOh6Px3eHNiKn9UOcAKC9MCkU/IwfP16nnnqq7rnnHq1du9Zv3+bNm3XJJZfI4XDolFNO0ebNm/Xxxx/79n/00UfasmWLTj75ZElqVZv2MmTIEA0cOFCPP/64r8t0TU2NXnjhBR133HG+mZklacWKFdq8ebPv+8cff1zR0dE68sgj27UmAAB6Omdpvly1uyVJEbkEWgCdjzu0aOa+++7Tgw8+qIsuukgjRoxQdna2iouLtWbNGh1//PGyWq064ogjdMUVV+jaa6/VL37xC3k8Hq1cuVJXXnmljjjiCElqVZv2Yjabdd999+mqq67SzJkzNWjQIH377beKj4/Xbbfd5td26NCh+vWvf63Ro0dr9+7d+uGHH3TvvfcqISGhXWsCAKCn8xs/S6AFEAIE2i4ikCntO3r6e4vFoltvvVVXX3211qxZo6qqKqWkpGjw4MFKSkrytbvxxht1zjnn+LoV//73v/eNU21tm/T0dN19992+tWITEhJ09913a+zYsQesb8aMGRo4cGCz7SNHjtSHH36or776SpWVlbrgggs0bty4ZmveHnHEEZo7d65++OEH7dmzRxMmTPDrkgwAAFrHG2gN5jCF9x0d4moA9EYE2i5i3+nvu4q4uDhNnz79oG2ys7ObhdhA2sTHx+ucc87xfR8VFeX3fUtGjBihESNGtLgvIiJC06ZNO+jzpaaJoVrTDgAAHJg30Ib3HSOjJTzE1QDojbp8oLXZbPrpp5+0e/duJSUladCgQbJarS229Xg82rBhg0pKSpSenq5hw4Yd8LiBtAUAAIA/T6NT9u3fSqK7MYDQ6dKB9tlnn9XChQsVHx+vfv36KT8/X7W1tbrxxht17rnn+rXdsWOHrr32WlVWVmr48OFav369UlJStHDhQqWnp7e5LXqW3/zmN3QvBgCgHdgL1snjtEsi0AIInS4baL/++mvdc889Ou+88/SnP/1JBoNBbrdbt9xyi37/+9/7dTttbGzUVVddpfDwcL333nuKiopSbW2tZs+erWuuuUaLFi2S0WgMuC16nuOPPz7UJQAA0CPY8lb5HhNoAYRKl01u3iVjZs6cKYPBIEkyGo2aNWuWPB6PfvjhB1/bpUuXasuWLbr66qsVFRUlSYqOjtZVV12l9evX67PPPmtTWwAAALTMvnf8rDEyTmGpg0JcDYDeqssG2qFDh0qS8vPz/bZv2bLFb78kffHFF5KkSZMm+bX1Lg3z+eeft6ktAAAAWuadECoiZ4IM9G4DECJdtsvxL37xC1133XX6xz/+ocLCQuXk5GjLli1atGiRfvvb32rMmDG+ttu3b1dMTIxiYmL8jpGYmKiIiAht3769TW1b4vF4ZLPZgn+B7cxut/v9CXQkrjd0Nq45dCaut0Nz22vUULhBkmTOHtslfzbqTrjm0Jm68vXm8Xh8vXNbq8sGWkkaNWqUli1bprffflv9+/fX1q1blZmZqcMOO8yvXX19/QFnPrZaraqrq2tT25Y0NDRow4YNAb6SzrP/HW2gI3G9obNxzaEzcb0dmHHX1wr3eCRJpaZUFXfhn426E645dKauer0dKKsdSJcNtJ9//rkuv/xyzZkzRzfffLOMRqPcbrf+8pe/6NJLL9Vzzz2ncePGSZIsFotcLleLx2lsbFRYWJjv+0DatiQ8PFwDBgxo46vqOHa7Xfn5+crNzQ34IgACxfWGzsY1h87E9XZoVTvfU+XexwOnniFzHKtEBINrDp2pK19veXl5AT+nywbal19+WVLTMiveWYeNRqNuuOEGPffcc3r55Zd9gTY1NVVr1qyR0+mUxWLxHaOhoUG1tbVKTU31bQukbUsMBoMiIiLa7XW2N6vV2qXrQ8/C9YbOxjWHzsT1dmDlO9dIksyJ2YpJyw1xNT0H1xw6U1e83gLtbix14UmhampqZLFYmv3WwGq1ymKxaM+ePb5to0ePlsvl0qZNm/zarlu3Th6PR6NHj25TWwAAADTnmxCK5XoAhFiXDbSjR4+Ww+HQp59+6rf9448/ltPp1NixY33bTj75ZEVERPju6nq99NJLiomJ0QknnNCmtgAAAPDnrCpSY8VOSQRaAKHXZbscz507V5988onmzZunX/7yl8rJyVFeXp6ef/55jR07VhdddJGvbXJysv7whz/o9ttvl9Fo1Pjx4/Xll1/q3Xff1QMPPKD4+Pg2tQUAAIA/7/qzEoEWQOh12UAbGxurRYsW6f3339fatWv12WefKTk5Wffff7+OPfbYZv2rzzjjDA0dOlSLFy/WihUrlJqaqtdee02DBw9uduxA2gIAAOBn3u7GMhhk7T8utMUA6PW6bKCVmiaBOumkk3TSSSe1qv2wYcM0bNiwdm8LAACAJt5AG54xXKaImBBXA6C367JjaAEAANC1eNxu2bauliRFDJgU4moAgEALAACAVnKU/CR3fbUkxs8C6BoItAAAAGgV2z4TQlkJtAC6AAItAAAAWsWWt0qSZLBYZc08LMTVAACBFgAAAK3kvUNr7Xe4DGZLiKsBAAItAAAAWsHtbJB9x3eSGD8LoOsg0AIAAOCQGnZ8L7mckgi0ALoOAi0AAAAOad8JoQi0ALoKAi0AAAAOyRtoTdF9ZEnJDXE1ANCEQAsAAIBDsm1tCrQRuRNlMBhCXA0ANCHQAgAA4KBcdZVyFG2WxPqzALoWAi0AAAAOyrb1a99jxs8C6EoItAAAADgovwmhciaEsBIA8EegBQAAwEF5A60lOUfm2OQQVwMAPyPQAgAA4IA8Ho9s+ask0d0YQNdDoAUAAMABNVbskqu6RJIUkTspxNUAgD8CLQAAAA7Ib/wsd2gBdDEEWgAAAByQL9AaTbL2GxvaYgBgPwRaAAAAHJB3/Kw1a6SM4ZEhrgYA/BFoAQAA0CKP2+Vbg9ZKd2MAXRCBFgAAAC1qKNwoT0OdJMbPAuiaCLQAAABoERNCAejqCLQAAABokX1voDWERyk8c3iIqwGA5gi0AAAAaJH3Dm1EzngZjKYQVwMAzRFoAQAA0IzbYZN951pJdDcG0HURaAEAANCMfdu3ktsliUALoOsi0AIAAKAZJoQC0B0QaAEAANCMN9Ca4lJlTswOcTUA0DICLQAAAJr5eUKoiTIYDCGuBgBaRqAFAACAn8aacjnL8iXR3RhA10agBQAAgB9b/mrf44gBk0JYCQAcHIEWAAAAfuz7TgiVMz6ElQDAwRFoAQAA4Me2tSnQhqUNlikqIcTVAMCBEWgBAADg4/F4ZMtbJYnxswC6PgItAAAAfJxlW+Wq3S2JQAug6yPQAgAAwMe2z/hZK4EWQBdHoAUAAICPL9CaLLJmjw5tMQBwCARaAAAA+HgDrbXvaBnDrCGuBgAOjkALAAAASZKn0Sn79m8lSRG5rD8LoOsj0AIAAECS1FCwXh6HTRITQgHoHgi0AAAAkCTZ8lf5HhNoAXQHBFoAAABI+nn8rDEiVmFpg0NcDQAcGoEWAAAAkn4OtBE5E2Qw8mMigK6PTyoAAADIZatRQ8F6Saw/C6D7INACAACgaXZjj0cS42cBdB8EWgAAAPi6G0tSxACW7AHQPRBoAQAA4Au05sQsWeLTQ1wNALQOgRYAAACy5TUt2UN3YwDdCYEWAACgl3NWFamxYqckAi2A7oVACwAA0MvZ81f7HhNoAXQnBFoAAIBezjchlMEga/9xoS0GAAJAoAUAAOjlvIE2PH2YTBGxIa4GAFqPQAsAANCLedxu2bY2dTm20t0YQDdDoAUAAOjFHKVb5K6vksT6swC6HwItAABAL2bL+8r3mAmhAHQ3BFoAAIBezJbftP6swRIua9bIEFcDAIEh0AIAAPRi3gmhrP0Ol8FsCXE1ABAYAi0AAEAv5XY2qGHHd5LobgygeyLQAgAA9FINO9fK0+iQRKAF0D0RaAEAAHopb3djiUALoHsi0AIAAPRS3kBrikqUJWVAiKsBgMARaAEAAHop34RQuRNlMBhCXA0ABI5ACwAA0Au56qrkKNokie7GALovAi0AAEAvZNv2te8xgRZAd0WgBQAA6IX8J4SaEMJKAKDtCLQAAAC9kH1voLUk9Zc5NiXE1QBA2xBoAQAAehmPxyNb3ipJdDcG0L0RaAEAAHqZxsoCNVYXS5IiBkwKcTUA0HYEWgAAgF7Gf/wsd2gBdF8EWgAAgF7G291YRpOs/caGthgACAKBFgAAoJfx3qENzzpMxvCoEFcDAG1HoAUAAOhFPG6X7HvXoI3IobsxgO6NQAsAANCLNBRuktteK4nxswC6PwItAABAL2JnQigAPQiBFgAAoBfxjp81hEUqPHN4iKsBgOAQaAEAAHoRb6CNyBkvg8kc4moAIDgEWgAAgF7C7bDJvmutJLobA+gZCLQAAAC9hH37GsnVKIlAC6BnINACAAD0ErZ9JoSyEmgB9AAEWgAAgF7CG2hNsSmy9Okb4moAIHgEWgAAgF7CNyFU7kQZDIYQVwMAwSPQAgAA9AKNtbvlLM2TxPhZAD0HgRYAAKAXsOev9j2OyJ0UwkoAoP0QaAEAAHqBfSeEisgZH8JKAKD9EGgBAAB6AVv+KklSWOogmaITQ1wNALQPAi0AAEAP5/F4/CaEAoCegkALAADQwznLt8lVUy6J9WcB9CwEWgAAgB7Ob/wsgRZAD0KgBQAA6OF8gdZklrXvmJDWAgDtiUALAADQw3kDrTV7tIxh1hBXAwDth0ALAADQg3lcjbJv+0aSFDGA9WcB9CwEWgAAgB6sYdc6eRw2SYyfBdDzEGgBAAB6MCaEAtCTEWgBAAB6MG+gNVpjFJY2JMTVAED7ItACAAD0YL4JoXInyGDkRz8APYs51AUcisfj0dKlS7Vy5UrV1dVp2LBhOvvssxUVFdWs7aZNm7R48WKVlJQoPT1ds2bN0qBBg1o8biBtAQAAuiO3vVYNBeslSRE5dDcG0PN06V/TVVdX66KLLtL999+v9PR0TZkyReXl5TrzzDPldrv92r755ps666yzVFtbq6lTp6qiokJnnHGG3n///WbHDaQtAABAd2Xb9q3kafqZifGzAHqiLn2H9ne/+52qq6v12muvKTo62rd9zpw5MhgMvu/Ly8v1xz/+UWeccYb+/Oc/S5JmzZolp9OpO+64Q0cccYTi4uICbgsAANCd+U0IxZI9AHqgLnuH9ttvv9WKFSt07bXX+oVZSerTp49foH377bdVX1+v8847z6/d+eefrz179vjdeQ2kLQAAQHdm3xtozQmZsiRkhLgaAGh/XTbQLlu2TJI0YsQIPfHEE/rd736nO++8U4sXL1ZjY6Nf27Vr18pkMmno0KF+2w877DAZDAZ99913bWoLAADQndnyV0miuzGAnqvLdjnetm2bzGazLrzwQg0fPlzHHHOMdu3apTvuuEOLFi3SE088obCwMElScXGx4uLiZLFY/I4RHh6u6OholZSU+LYF0rYlHo9HNputnV5l+7Hb7X5/Ah2J6w2djWsOnamnXG+N1cVy7t4hSTJnj+2SP7+gSU+55tA9dOXrzePx+PXEbY0uG2htNpsaGxs1dOhQPfroo77tgwcP1o033qjnn39ec+fOlSQ5nU6ZTKYWj2M2m+VwOHzfB9K2JQ0NDdqwYUOgL6fT5Ofnh7oE9CJcb+hsXHPoTN39ejPmf6LwvY+LDckq7MI/v6BJd7/m0L101evNarUG1L7LBlrvsjyzZs3y237yySfr1ltv1YoVK3yBNjIy8oC/YbDb7X5L/ATStiXh4eEaMGBAq19HZ7Hb7crPz1dubm7AFwEQKK43dDauOXSmnnK9VW55RVWSZDBo8NTTZYxg0suuqqdcc+geuvL1lpeXF/BzumygzcnJkSTFx8f7bTcYDIqNjVVNTY1vW79+/bRy5UrV1NQoJibGt72iokI2m039+vVrU9uWGAwGRUREBPPSOpTVau3S9aFn4XpDZ+OaQ2fq7tdb6Y41kqSw9KGKSkwLcTVoje5+zaF76YrXW6DdjaUuPCnUkUceKUnaunWr3/Y9e/Zo9+7dys7O9m2bPHmyJGnVqlV+bb/88ktJ0i9+8Ys2tQUAAOiOPB6Pb8keJoQC0JN12UA7YcIETZgwQU8//bTKysokNX04/+1vf5MkXXjhhb62xxxzjHJzc/XII4+ovr5eklRbW6t//etfGj58uI466qg2tQUAAOiOHCVb5K6vkiRF5LL+LICeq8t2OZakf/7zn7rhhht08skna+TIkSooKFBFRYXuvfdeTZz4828bLRaL/vWvf+m6667TCSecoBEjRmjdunVKTk7WggULZDQa29QWAACgO7Ll/dwTjTu0AHqyLh1o+/Tpo+eee05btmzRjh07FBUVpVGjRrXY17t///5avHix1q1bp9LSUl133XUaPnx4i/2wA2kLAADQ3di3NnU3NljCZc0eGeJqAKDjdOlA6zVw4EANHDjwkO0MBoNGjmzdh3YgbQEAALoT7/hZa9+xMpjDQlwNAHQc+tcCAAD0IJ5Gh+zbm2Y4prsxgJ6OQAsAANCD2HeulafRIYlAC6DnC7jL8S9/+cugTvjcc88F9XwAAAAcmLe7sSRZCbQAeriAA+1XXzV9SGZmZgb0vIKCgkBPBQAAgAB5A60xKkFhqYeegwQAurM2Twq1bNmygNoPGTKkracCAABAK3kDbUTuRFZwANDjBRxow8LaNlNeW58HAACA1nHVV8tRtEkS42cB9A4BB9offvihTSdq6/MAAADQOratX0sejyQCLYDegVmOAQAAegj7PhNCReRMCGElANA52jyG9kAaGxu1ceNG1dXVacSIEYqJiWnvUwAAAKAF3vGzlqR+MselhrgaAOh4bb5D+9JLL2nGjBmaNGmSbrvtNjkcDhUUFOi0007T2WefrV/96leaMmWKXnzxxfasFwAAAAfgmxAqh+7GAHqHNt2h/fzzz/WHP/xBRqNRffv21euvv664uDht2rRJO3fu1OzZs+VwOPT666/rj3/8owYNGqTx48e3d+0AAADYy1lRoMaqQkmsPwug92hToP3Pf/4jSbrpppv061//Wv/5z3+0YMEC1dXV6eabb9bcuXMlSampqXrkkUf07LPPEmgBAAA6kG3f8bMDJoWwEgDoPG3qcrx582ZJ0mmnnSZJOuWUU1RbWyuPx6OTTz7Z127mzJmSpO+++y7IMgEAAHAwtvxVTQ8MRkX0Pzy0xQBAJ2lToN2zZ48kKSEhQZKUlJTk25ecnOx7nJ6eLkmqqKhoc4EAAAA4NO8d2vCsw2QMjwpxNQDQOdoUaDMzMyVJRUVFTQcx/nwYk8nke1xfXy9Jio+Pb2t9AAAAOASP2yX71q8lsf4sgN6lTYF28uTJkqRvv/3Wt23lypVauXKlX7utW7dKkoYMGdLW+gAAAHAIjqLNcttrJBFoAfQubQq055xzjiIjI/Xmm2/6tiUmJioxMdGv3euvvy5JOuOMM4IoEQAAAAfjNyEUgRZAL9KmWY6HDh2qNWvWHLLd9OnTNXnyZB133HFtOQ0AAABawRtoDWGRCs8cEeJqAKDztCnQttaxxx7bkYcHAACAfg60Ef3HyWDq0B/vAKBLaVOXYwAAAHQNbodN9p3fS5KsdDcG0Mu026/wampqtGvXLu3evVtut7vZ/qlTp7bXqQAAALCXfcd3kqtREuNnAfQ+QQfampoa3XvvvVq8eLGcTucB223evDnYUwEAAGA/TAgFoDcLOtD+8Y9/1FtvvaXMzEzNnj1b6enpMhgM7VEbAAAADsEbaE0xybIk9QtxNQDQuYIOtMuWLZMkLViwQMOHDw+6IAAAALSe3TshVO5EbioA6HWCnhQqLCxMkpSTkxN0MQAAAGg9V22FHCVbJNHdGEDvFHSgnTFjhiRpw4YNQRcDAACA1rNtXe17TKAF0BsFHWhvvfVWjRo1Sn/84x+Z+AkAAKATMSEUgN4u6DG0sbGxuummm3Tddddp5syZioyM9HVD3teqVauCPRUAAAD2Yctr+vkqLHWgTNGJIa4GADpf0IH2jTfe0C233CKPx6MBAwYoPT29PeoCAADAQXg8Ht8dWit3ZwH0UkEH2gULFsjj8egPf/iDLrjggvaoCQAAAIfgLN8uV02ZJLobA+i9gh5DW1bW9EE6a9asoIsBAABA6zB+FgDaIdAOHTpUklRdXR10MQAAAGgdX6A1mWXtOyaktQBAqAQdaOfPny+r1ap///vf8ng87VETAAAADsHuHT+bNUrGsIgQVwMAoRH0GNoPP/xQkydP1osvvqi1a9dqzJgxCg8Pb9Zu/vz5wZ4KAAAAkjyuRtm2fSNJihgwKcTVAEDoBB1on3rqKd/j9evXa/369S22I9ACAAC0j4aC9fI46iUxfhZA7xZ0oF25cmV71AEAAIBWYkIoAGjSpkC7YcMGDR8+XJKUmMgi3gAAAJ3JG2iN1hiFpQ8JcTUAEDptCrRnnHGG0tPTdfTRR2vGjBmaNGmSwsLC2rs2AAAAtMAbaK0542UwmkJcDQCETpsC7WOPPaalS5fqww8/1H//+19FRUXpyCOP1IwZMzR9+nTFx8e3c5kAAACQJHdDnRp2rZNEd2MAaFOgnT59uqZPny6Px6MffvhBS5cu1bJlyzR//nyZTCaNHTtWM2bM0IwZM5STk9PeNQMAAPRatm3fSh63JAItAAQ1KZTBYNCoUaM0atQozZs3T7t27dKyZcu0dOlSPfTQQ7r//vuVk5PjC7eHH364jMagl74FAADotex+E0KxZA+A3i3oWY73lZWVpYsvvlgXX3yxampqtGLFCi1btkyvvPKKnnzySSUkJOjLL79sz1MCAAD0Kra8VZIkc3yGLImZIa4GAEKrXQPtvmJiYnTqqafq1FNPVWNjo1avXq2lS5d21OkAAAB6BdvWpju0dDcGgHYItBUVFQfdb7FYFBkZqcmTJ2vy5MnBng4AAKDXaqwukbN8uyQCLQBI7RBoWxNSTSaTcnJydMwxx2ju3LnMggwAANAGtq2rfY+tBFoAUNAzNM2dO1dHH320JKlv374688wzdeaZZ6pv376SpKlTp+q4445TRUWFHnvsMZ1xxhkqLi4O9rQAAAC9jm3fCaFyxoewEgDoGoIOtMcee6y++OILnXLKKXrnnXd077336t5779U777yjE088UatWrdLFF1+sDz/8UBMnTlRhYaH++c9/tkftAAAAvYo30IalD5UpMi7E1QBA6AUdaO+//341NDTo+uuvl8Vi8W23WCyaN2+eGhoa9MADDyg6Olq/+93vJEmffvppsKcFAADoVTwejy/QMn4WAJoEHWg3btwoSUpKSmq2Lzk52a/NwIEDJUl79uwJ9rQAAAC9irM0T+66SklSxADWnwUAqR0CbWxsrCTpu+++a7bv22+/9WtTXl4uqWm9WgAAALSed/1ZiTu0AOAVdKCdOXOmJOnOO+/UypUr5XQ65XQ69cUXX+gPf/iDJOn000+XJH322WeSpClTpgR7WgAAgF7F293YYA6TNXtUiKsBgK4h6GV7rr/+eu3YsUMffvih5syZI5PJJElyuVySpBNOOEHXXXedJMnhcOiyyy7TJZdcEuxpAQAAehVvoLX2GyuDOSzE1QBA1xB0oA0PD9eCBQv05ZdfatmyZdq5c6cMBoOysrJ0zDHHaNKkn8d4zJkzJ9jTAQAA9DqeRofsO9ZIorsxAOwr6EBbUVGhxMREHXHEETriiCNabLN27VqNGkXXGAAAgLaw7/xBHmeDJMmaQ6AFAK+gx9Befvnlqq+vP+D+9evX69JLLw32NAAAAL2Wt7uxJEUMINACgFfQgXbbtm36zW9+o8bGxmb7Nm3apLlz5yoxMTHY0wAAAPRa3kBrjIxXWOqgEFcDAF1H0IH2kUce0apVq3THHXf4bf/xxx81Z84cxcTE6Jlnngn2NAAAAL2WLb9pyZ6I3IkyGAwhrgYAuo6gA+3EiRN1//33680339RDDz0kScrLy9OcOXMUGRmpZ555RmlpaUEXCgAA0Bu56qvlKNokiQmhAGB/QU8KJUknnXSSysrKdM8998jj8ei1116TxWLRM888o8zMzPY4BQAAQK9k3/aN5PFIItACwP7aJdBK0sUXX6zi4mI99thjSklJ0bPPPqvs7Oz2OjwAAECv5DchVM6EEFYCAF1PwIH2r3/96wH3eTweRUVFacSIEXrppZf89s2fPz/w6gAAAHo5b6C19OkrczzDuABgXwEH2qeeeuqQbZYvX67ly5f7bSPQAgAABM4baK10NwaAZgIOtCtXruyIOgAAALAfZ0WBGisLJDF+FgBaEnCgZU1ZAACAzuE3fjZ3UggrAYCuKehlewAAANAxfIHWYFRE/8NDWwwAdEEBB9p77rlH99xzT8AnauvzAAAAeivb1qZAG545QkZrdIirAYCuJ+BA++yzz+rZZ58N+ERtfR4AAEBv5HG7Zc9fLYnxswBwIG1eh/bJJ59szzoAAACwD0fxZrntNZIItABwIG0OtPfff3971gEAAIB9+E8IRaAFgJYEHGiXLFnSEXUAAABgH95AawiLUHjWYSGuBgC6poAD7eDBgzuiDgAAAOzDG2it/cfJYGpzpzoA6NFYtgcAAKCLcTvssu/4XhLdjQHgYAi0AAAAXYx9x3eSyymJQAsAB0OgBQAA6GKYEAoAWodACwAA0MXY9wZaU0ySLEn9Q1sMAHRhBFoAAIAuxnuHNiJ3ogwGQ4irAYCui0ALAADQhbhqK+Qo+UmSFJFDd2MAOJigA+2mTZvaow4AAABIsm392vfYyvhZADiooAPtrFmzdP755+uNN95QQ0NDe9QEAADQa9nyV/keRwwg0ALAwQQdaK+++moVFhZq/vz5mjp1qv76179q27Zt7VAaAABA7+MdP2tJGSBzdJ8QVwMAXVvQgfb666/X8uXL9eijj2rcuHF69tlndeKJJ+qSSy7RBx98oMbGxvaoEwAAoMfzeDx+E0IBAA7O3B4HMZlMOvroo3X00UertLRUr732mhYtWqTrrrtOKSkpOuecc3TuuecqLS2tPU4HAADQIzl375BrT6kkAi0AtEa7z3KckpKiK6+8Ui+88IKmTJmi0tJSLVy4UEcffbQuueQSrVixor1PCQAA0CN415+VCLQA0BrtcofWy+Vy6ZNPPtH//vc/ffLJJ3K73Zo2bZrOOussbdy4Uc8884wuv/xy3Xjjjbriiiva89QAAADdnre7sYwmWfuNDW0xANANtEug3bVrlxYtWqTXXntNJSUl6tOnj+bOnavzzjtPWVlZkqQTTjhB06ZN0/nnn6+nn36aQAsAALAfb6C1Zo+SMSwixNUAQNcXdKCdO3euvvjiC3k8Hk2YMEE333yzjj/+eIWFhTVrO2bMGElSRUVFsKcFAADoUTyuRt8atBG5k0JcDQB0D0EH2rVr1+rCCy/U7NmzNXDgwIO2NRgMevTRR4M9JQAAQI/TULBBHke9JMbPAkBrBR1oP/30U0VEtL5LzNFHHx3sKQEAAHoc2z4TQlkJtADQKkHPcnzsscdqypQpB9w/ZcqUg+4HAADAz4HWaI1WeMbQEFcDAN1D0Hdoy8vLg9oPAAAAybZ174RQ/cfLYDSFuBoA6B7afR3afXnDbHR0dEeeBgAAoFtzN9SpYdc6SYyfBYBAtOkO7Z///OdDbnO5XFq7dq2kn2c3BgAAQHP27Wskt0sSgRYAAtGmQPvCCy+0altYWJgmT56s3//+9205DQAAQK+w74RQBFoAaL02Bdpvv/3W9/jwww9vtk2SjEajrFarDAZDEOUBAAD0fLa8VZIkc3y6zIlZIa4GALqPNgXaqKgo32Pvndl9twEAAKD1vHdoI3IncjMAAAIQ9KRQ48eP1/jx49ujloP65JNPNGTIEA0ZMkQ//vhjs/1Op1MLFizQMccco8MOO0zHHXecHnvsMblcrqDaAgAAdKTGPaVylm+TxPqzABCogO/QesfDeieBau342JYmkmqtqqoq3XbbbUpOTlZZWVmLbe68804tXbpU//jHPzR+/Hh9+eWXmjdvnkpKSprVGEhbAACAjmTLX+17zPhZAAhMwIH25ZdflvRzQPV+fyjBBNo//OEPSk5O1tSpU/Xoo482279+/Xq9/vrruvXWWzVlyhRJ0rRp03TllVfq73//uy688EINGDAg4LYAAAAdzW9CqP4d3+sNAHqSgLscr1+/XuvXr2/2/aG+2mrx4sX66KOPdM8998hsbjl/f/DBB5Kk4447zm/7cccdJ4/Ho/fff79NbQEAADqaN9CGpQ+RKSo+tMUAQDcTcKA1m81+wdL7/aG+2qK4uFh33XWX5s6dq+HDhx+w3ebNmxUeHq7MzEy/7f369ZPFYvEbcxtIWwAAgI7k8Xhk904IlUN3YwAIVNuS5j4aGxv1zTffyGw2a9y4cZKk0tJS/eMf/1BBQYFOPvlknXfeeQEf1+Px6LbbblNiYqKuvfbag7atqqpSTExMs+1Go1FRUVGqrKxsU9sD1WWz2Vr5KjqP3W73+xPoSFxv6Gxcc+hMnXm9OUvz5KqrkCSZ+47tkj9joOPxGYfO1JWvN4/HE/BM70EH2jfeeEO33367zj33XF+gnTdvnjZs2CC73a4vv/xS8fHxOuGEEwI67vPPP68vvvhCzz33nMLDww/Z/mAvfP99gbTdX0NDgzZs2HDIekIlPz8/1CWgF+F6Q2fjmkNn6ozrzbT5PYXtfVzg6aNdXfhnDHQ8PuPQmbrq9Wa1WgNqH3Sg/d///idJvruweXl5ysvL04oVK7R06VLdcsstev755wMKtLW1tXrwwQd1/vnna8KECYdsHx8f32LIdLvdqqurU1xcXJvatiQ8PLxLThplt9uVn5+v3NzcgC8CIFBcb+hsXHPoTJ15ve1e9x/tkSRzmIYeOVMGy6F/iY+eh884dKaufL3l5eUF/JygA6032XtD3qpVqzRlyhTFxsbqmGOOaVNhNptNdrtdL774ol588cVm+0877TTFxMTo66+/liQNHjxYy5cvV0FBgd/Y2O3bt8vpdGrIkCG+bYG0bYnBYFBERERAr6czWa3WLl0fehauN3Q2rjl0ps643pw7vm06V98xioyN79BzoevjMw6dqSteb4F2N5baMCnUgU7qdDolSevWrdOwYcMkyTcZVKDjQZKTk7V58+ZmX96xtEuWLPGFWennGYs//PBDv+N8+OGHMhgMOv7449vUFgAAoKN4Gp2yb28KtKw/CwBtE3Sgzc3NlSR99NFHqqur0yeffKKJE5s+lHfs2CFJ6tu3b7CnOaiRI0dq5syZWrhwoT7//HM5HA6tWLFCjz76qM4//3wNHDiwTW0BAAA6in3XD/I4GyQRaAGgrYLucjxnzhzdcMMNuvXWW3XXXXdp4MCBGjlypCTpk08+kSRNnz492NMc0j333KPHHntMd955p0pLS5WamqrLLrtMl112WVBtAQAAOoJ3/VmJQAsAbRV0oD3ppJNktVq1dOlSJSQk6JJLLvF1Q87Ly9PEiRN1/vnnB12oJF133XW67rrrWtwXFhZ20P1tbQsAANARvOvPGiPjFJY6KMTVAED3FHSglaSjjz5aRx99dLPtf/3rX9vj8AAAAD2OLW+VJCkiZ6IMxqBHgQFAr9QugVZqWgS3tLRUdXV18ng8zfZ3xaVuAAAAQsFl26OGoo2S6G4MAMEIOtA6nU7985//1CuvvKKqqqoDttu8eXOwpwIAAOgR7Nu+kfbeACDQAkDbBR1o//73v+upp55SZGSkLrjgAmVmZrZp/SAAAIDeYt8Joay5E0JYCQB0b0EH2jfffFOS9M9//lNTp04NuiAAAICezhtozYnZssSnh7gaAOi+gp6BoLa2VpI0YQK/XQQAAGgNb6CluzEABCfoQDt69GhJUllZWdDFAAAA9HTOykI1VuySRKAFgGAFHWhvueUWRUVF6dFHH21xdmMAAAD8bN/xsxEDJoWwEgDo/oIeQ/vWW29p0qRJevXVV7Vx40aNHTtW4eHhzdrNnz8/2FMBAAB0e75AazAqov+40BYDAN1c0IH2qaee8j3esGGDNmzY0GI7Ai0AAIBk3xtowzOHy2iNDnE1ANC9BR1oV65c2R51AAAA9Hget1u2raslMX4WANpD0IE2MTGxPeoAAADo8RzFP8pt2yOJQAsA7SHoQOtlt9u1Zs0alZSUyOl06pxzzpHL5ZLH45HZ3G6nAQAA6Lb2nRDKSqAFgKC1S9J89dVXdf/996uqqsq37ZxzztEFF1yg7777Tq+88opGjRrVHqcCAADotryB1mCxypp5WIirAYDuL+hlez766CPddtttCgsL09/+9je/fRdeeKEk6cUXXwz2NAAAAN2eLX+VJMnaf5wMZkuIqwGA7i/oQPvvf/9bknT33Xfr1FNP9ds3evRoSUwcBQAA4HbYZd/xvSTGzwJAewk60G7atEmSNH78+Gb70tPTJUnl5eXBngYAAKBbs+/8XnI5JRFoAaC9BB1oTSaTJMnlcjXbt2dP0yx+UVFRwZ4GAACgW7PvMyEUgRYA2kfQgXbYsGGSpG+//bbZvq+//lqSNHLkyGBPAwAA0K15J4QyRfeRJTknxNUAQM8QdKCdM2eOJOkvf/mL1q9f79uen5+vhx56yK8NAABAb+UNtBG5E2UwGEJcDQD0DEEH2uOPP16/+c1vtGPHDp155pm+7SeddJK2b9+um266SUceeWSwpwEAAOi2XHWVchT/KIn1ZwGgPbXLOrTXXHONjjvuOL399tvKy8uTx+NR//79ddppp2no0KHtcQoAAIBuy7b1a99jxs8CQPtpl0ArSYMHD9bgwYPb63AAAAA9hi1vle8xgRYA2k/QXY69XC6Xampq5Ha72+uQAAAAPYJ3/KwlOVfmmKQQVwMAPUdQd2iLior05JNP6pNPPtGOHTvk8XhkMBjUr18/TZ8+XXPnzlVqamp71QoAANDteDwe2bb+PCEUAKD9tDnQfv3117ryyitVU1MjSUpPT1dsbKyqq6u1bds2Pf3003rjjTf02GOPacyYMe1VLwAAQLfSWLFTruoSSQRaAGhvbepyXFNToxtuuEE1NTWaMWOGPvroI3388cdavHixVqxYoQ8++EDTp09XVVWVrr/+etXV1bV33QAAAN2Ct7uxRKAFgPbWpkC7ePFilZWVadSoUVq4cKGys7P99vfr10+PPPKIRowYoeLiYi1evLhdigUAAOhufIHWaJK139jQFgMAPUybAu2KFSskSXPmzJHR2PIhTCaTLrnkEr/2AAAAvY030FqzRsoYHhniagCgZ2lToP3xx6aFwceOPfhvGQ8//HC/9gAAAL2Jx+3yrUEbMWBSiKsBgJ6nTYG2qqpKkpSUdPBp5737Kysr23IaAACAbq2hYIM8DU1ziVgZPwsA7a5NgdZms0mSwsLCDtouPDxcklRfX9+W0wAAAHRrTAgFAB2rTYEWAAAAh+YNtIbwKIVnDAtxNQDQ87R5HVpJOvXUU9urDgAAgB7HvjfQRuSMl8FoCnE1ANDztCnQRkY2zdBXUFDQ6rYAAAC9ibuhXvZdP0iiuzEAdJQ2Bdo1a9a0dx0AAAA9in37GsntkkSgBYCOwhhaAACADmDLX+V7TKAFgI5BoAUAAOgA3gmhzHFpMidmh7gaAOiZCLQAAAAdwBtorbkTZTAYQlwNAPRMBFoAAIB21rinTM6yrZLobgwAHYlACwAA0M5sW1f7HhNoAaDjEGgBAADambe7sdS0Bi0AoGMQaAEAANqZfW+gDUsbLFNUQoirAYCei0ALAADQjjwej+8OLd2NAaBjEWgBAADakbM0X67a3ZKkiNxJIa4GAHo2Ai0AAEA78hs/yx1aAOhQBFoAAIB25Au0JovC+44ObTEA0MMRaAEAANqRN9Ba+46R0RIe4moAoGcj0AIAALQTT6NT9u3fSqK7MQB0BgItAABAO7EXrJPHaZdEoAWAzkCgBQAAaCd2JoQCgE5FoAUAAGgntrxVkiRjZJzC0gaHuBoA6PkItAAAAO3EOyFURM4EGYz8mAUAHY1PWgAAgHbgstWooXCDJLobA0BnIdACAAC0A/u2bySPRxKBFgA6C4EWAACgHdj2mRDKSqAFgE5BoAUAAGgH3kBrTsySJT49xNUAQO9AoAUAAGgHvgmhuDsLAJ2GQAsAABAkZ1WRGit2SiLQAkBnItACAAAEyb7P+NmI3EkhrAQAehcCLQAAQJB8E0IZDLL2HxfaYgCgFyHQAgAABMkbaMMzhssUERPiagCg9yDQAgAABMHjdsu2dbUkxs8CQGcj0AIAAATBUfKT3PXVklh/FgA6G4EWAAAgCDa/CaEItADQmQi0AAAAQfAGWoMlXNaskSGuBgB6FwItAABAEGx5qyRJ1n6Hy2C2hLgaAOhdCLQAAABt5HY2yL7jO0msPwsAoUCgBQAAaKOGHd9LLqckxs8CQCgQaAEAANqICaEAILTMoS4AAACgu/IGWlNUoiwpuSGuBt2R0+XWJ/kVWrvTpnJrhWYMTZfFxD2nQ3G63Pp8a4Uq6p1KjLRoSk4i71sr9MTrjUALAADQRratTYHWmjtRBoMhxNWgO3G63Lpv2RYt/GybSmobmjZ+Wqm0mHBdPaW/bpkxsNsHjY7Q4vsm8b4dQk++3gi0AAAAbeCqq5KjaLMkuhsjME6XW6f/Z7Xe2Viq/X8NUlLToN+/t1mrtlfq9UsmdNuQ0RF439qmp79v3a9iAACALsC2dbXvMYEWgbhv2Ra9s7FUkuTZb5/3+7c3luqvy7Z0al1dHe9b2/T09407tAAAAG3AhFBoC6fLrYWfbZNBzcPF/v7y0U/6sbRWRiPd2d1uj15ZW9SqtrxvP2vt+2aQtPDzbZrfDbseE2gBAADawBtoLck5Mscmh7gadBcvrSnwG/t5MLZGt577tqCDK+p5eN8C55FUXNOgz7dWaPrApFCXExACLQAAQIA8Ho9s+askcXcWB+dye7RyW4UWry/R4vXF2lxWF9Dzk6PCFBlm6qDquo96h0tldY5Wt+d9axLo+1ZR7+zAajoGgRYAACBAjRW75KoukUSgRXO1DY368McyLV5forc2lKg8gECxv/9dPK7b3THrCB9vKdfR/1rZ6va8b00Cfd8SIy0dWE3HINACAAAEiPGz2F9htV1vbSjRm+uLtfSncjU0uv32GwzS5H4JOmVYqv6+Ik8V9c6DjqE1SEqNCdeUnMQOrbu7mJKTqNTocJXWNvC+BaA3vG8EWgAAgAD5Aq3RJGu/saEtBiHh8Xj0Q1GNFq8v1uL1JVq9s6pZmwiLUccPTtbMEWk6dXiqUmLCJUkuj0e/f2/zwY8v6Zop/bvdBD0dxWIy6poj+/O+Bag3vG8EWgAAgAB5A2141mEyhkeFuBp0FqfLrU/ydmvxhqbxsNsqbM3apMaEa+aIVM0ckaZjBiUpwtJ8HOctMwZq1fZKvb13XdB975x5vz9lWIrmzxjYUS+lW+J9a5ue/r4RaAEAAALgcbtk3/a1JCkid1KIq0FHq7I59d6mUi1eX6J3Npao2t7YrM1haTG+EDshO/6Qy8VYTEa9fskE/XXZFi38fJuKa36e9Tg1JlzXTOnfLZdP6Wi8b23T0983Ai0AAEAAGgo3ym2vlcT42Z5qW0W9ryvxirzdanT7jz40GQ2ampuoWSPSdNqIVOX2CfwuvcVk1B3HDdb8GQO1bFOR1v60VaMG5WjG0PRuGyw6w77v2+dbK1RR71RipEVTchJ53w6iJ19vBFoAAIAAMCFUz+N2e/TNrmpfiF1btKdZm1irWScNTdHMEak6aWiKEiLD2uXcFpNRU3MTlWQv1vBcQllrWUxGZjFug554vRFoAQAAAmDfG2gN4VEKzxwe4mrQVnanS8u2lGvx+hItWV+iwj32Zm36JkRo5vCmrsTTBvRRmLn7//AP9DQEWgAAgAB479BG9B8ng7H5hD/ouspqG/T2hlIt3lCsDzaXqc7hatZmXFacZh2WppkjUjUqPVYGw8HHwwIILQItAABAK7kdNtl3rpVEd+PuYnNpra8r8RfbKrTfcFiFmYw6ZlCSZo5I1anDU5UVHxGaQgG0CYEWAACglezb10juprt6BNquyeX2aOW2Ci1eX6I31xfrx7K6Zm0SIy06dXiqZo5I1fGDUxRj5UdioLviXy8AAEAr2fJW+R5bCbRdRm1Doz7YXKbF64v19sZSldc5mrUZmBSlWSNSNeuwNE3ulyBzD5gMBwCBFgAAoNW842dNcamy9Okb4mp6t8Jqu5ZsaOpKvPSncjU0uv32GwzSL/olaOaIpvGwQ1KiGQ8L9EAEWgAAgFbyTQiVM5Fw1Mk8Ho9+KKrR4vXFenN9sb7eWd2sTWSYSccPTtbMEak6ZViqUmLCQ1ApgM5EoAUAAGiFxppyOcvyJTF+trM4XW6tyNutxetLtHh9sbZX2pq1SYsJ12kjUjVrRJpmDEpShIWZp4HehEALAADQCrb81b7HBNqOU2Vz6t2NpVq8vljvbipVtb2xWZuR6TG+rsTjs+JlNHK3HOitCLQAAACtYN/b3ViSInLGh7CSnmfr7nrfeNgVebvVuN/aOiajQdNy+2jmiFSdNiJVuX2iQlQpgK6GQAsAANAKtq1NgTYsdZBM0YkhrqZrcbrc+nxrhSrqnUqMtGhKTqIsB5lF2O326Jtd1XpzfbEWry/WD0U1zdrEWs06aWiKZo1I04lDk5UQGdaRLwFAN9XlA21paany8vJkNpuVk5OjpKSkA7b1eDzasGGDSkpKlJ6ermHDhrVLWwAA0Lt5PB7fkj10N/6Z0+XWfcu2aOFn21RS2+DbnhYTrqun9NctMwb6gq3N6dKyn8q1eH2xlmwoUdGehmbH65sQoVl7uxJPze2jMDNL6wA4uC4baFeuXKkFCxbo+++/1+GHH67GxkatXbtWp512mm6//XZFR0f7td+xY4euvfZaVVZWavjw4Vq/fr1SUlK0cOFCpaent7ktAACAs2yrXLW7JUkRAyaFuJquwely6/T/rNY7G0u1/wjWkpoG/f69zfo0f7fOHZ2pdzaV6P3NZap3uJodZ3x2nG887Kj0WGaPBhCQLhto3333XUVERGjp0qVKTU2VJK1du1a//OUvVVNTowULFvjaNjY26qqrrlJ4eLjee+89RUVFqba2VrNnz9Y111yjRYsWyWg0BtwWAABA+nm5HkmycodWknTfsi16Z2OpJMmz3z7v9x/+WK4Pfyz32xdmMuqYQUmadViqTh2eqsy4iI4vFkCP1WUD7cyZM3X44Yf7hctRo0bp2GOP1TvvvKPa2lrfXdqlS5dqy5YtWrhwoaKimiYJiI6O1lVXXaV58+bps88+09SpUwNuCwAAIO0TaE0WWbNHh7aYLsDpcmvhZ9tkUPMw25LECLNOG5GmmSPSdPyQZEWHd9kfQQF0M132VuT48eNbvFPqdrvldrvlcDh827744gtJ0qRJ/l2AjjjiCEnS559/3qa2AAAA0s+B1tp3tIxh1hBXE3qfb61QSW1Dq8KsJP3vV+P19OyxOnNUOmEWQLvqVp8oRUVFWr58uQYPHqzExJ9nF9y+fbtiYmIUExPj1z4xMVERERHavn17m9q2xOPxyGZrvqh3qNntdr8/gY7E9YbOxjWHzrT/9eZxOWXf9q0kydL38C75c0Bn2VVl16J1JXp81c6AnldaXd+r37dD4TMOnakrX28ejyfgcfTdJtA6nU7ddNNNstvtmj9/vt+++vp6Wa0t/7bUarWqrq6uTW1b0tDQoA0bNgRYfefJz88PdQnoRbje0Nm45tCZvNeboWyzrM6mMLY7LEOlXfjngI5QYXdp6Q673t9u03dljkM/oQV7Sgu0wVB+6Ia9HJ9x6Exd9Xo7UFY7kG4RaN1ut+bPn69vvvlGN910k4488ki//RaLRS5X81nzpKZJoMLCwtrUtiXh4eEaMGBAgK+g49ntduXn5ys3NzfgiwAIFNcbOhvXHDrT/tfbnk9XavfefTm/mKmw9KEhra8zVNmcWryhTK+sLdby/Aq59+tbPLBPhIr2OFTvdB2027FBUkp0mGZPHX3QdWl7Oz7j0Jm68vWWl5cX8HO6fKD1eDy6/fbb9fbbb+u6667T5Zdf3qxNamqq1qxZI6fTKYvF4tve0NCg2tpa3yzJgbZticFgUERE152Nz2q1dun60LNwvaGzcc2hM3mvt8qdayRJxohYxfYfLUMPXQ2hrqFRSzaU6KU1BXp3U5kcLrff/ux4q84fk6nZYzM1JjNWd3/0k37/3uaDHtMj6dojcxQbHdWBlfccfMahM3XF660ty3Z1+UD7pz/9Sa+99pquvvpqXXvttS22GT16tN5++21t2rRJI0eO9G1ft26dPB6PRo8e3aa2AAAA3gmhInIm9Lgw29Do0vubyvTimgIt3lDSbJ3YlOgwnTs6Q7PHZuqIfgkyGn/+YfOWGQO1anul3t67Du2+d2q9358yLEXzZwzsjJcCoJfq0oH23nvv1YsvvqirrrpK119//QHbnXzyyXrooYf08ssv+4XUl156STExMTrhhBPa1BYAAPRuLluNGgrWS+o56882utxavmW3XlxToNd+KFK1vdFvf3yERWeNTNf5YzM0fUAfmQ/QVdhiMur1Sybor8u2aOHn21Rc0+DblxoTrmum9Nf8GQPpagygQ3XZQPvEE0/o6aef1ujRozV06FC99957fvunTJnim6k4OTlZf/jDH3T77bfLaDRq/Pjx+vLLL/Xuu+/qgQceUHx8vO95gbQFAAC9m337t5Kn6d5jRDcOtG63R19sq9BL3xXqle8LVVrrP7lTZJhJs0akafbYDB0/JFnhZlOrjmsxGXXHcYM1f8ZAfb61QhX1TiVGWjQlJ5EgC6BTdNlAazQafXdL33nnnWb7DzvsML+ld8444wwNHTpUixcv1ooVK5SamqrXXntNgwcPbvbcQNoCAIDey9vdWOp+gdbj8ejbXdV66btCvfxdgXZW+S/REWYy6uRhKZo9NlOnDEtRVBDrw1pMRk0fmBRsyQAQsC4baOfOnRvwc4YNG6Zhw4a1e1sAANA7eQOtOSFTloSMEFfTOhtLavTimgK9tKZQP5X7L0doMhp07KAknT8mU2eMTFNchOUARwGA7qHLBloAAIBQs3snhOrid2e37q7XS981hdi1RXua7T8qN1Gzx2bqrJHpSokJD0GFANAxCLQAAAAtaKwulnP3DkldM9AWVtv1yveFenFNgVbtqGq2f3x2nGaPzdS5ozOUFd+1luYAgPZCoAUAAGhBw7avfY8jBkwKYSU/213n0Ktri/TSdwX6OG+3d74qn+Gp0Zo9NlPnj83UwCTWfgXQ8xFoAQAAWuALtAaDrP3HhayOGnuj3lhXpJe+K9QHm8vU6PZPsbl9InX+mAydPzZTI9NjQ1QlAIQGgRYAAKAFDdu+kSSFpw+TKaJzg6LN6dI7G0v04ppCvb2hRPZGt9/+9NhwnTcmQ7PHZmpCdrwMBkOn1gcAXQWBFgAAYH8etxzbmwKttZPGzzpdbn34Y5leWlOoN9YVq6ah0W9/n0iLzh6dofPHZOio3D4yGQmxAECgBQAA2I+haqfc9VWSOnZCKJfbo0/yd+ulNQVatLZIFfVOv/0x4WadMTJN54/J0LGDk2UxGTusFgDojgi0AAAA+zGWrPc9bu9A6/F49NWOKr24pkD/+75QRXsa/PZbzUadOjxVs8dm6qRhKYqwmNr1/ADQkxBoAQAA9mMsXidJMljCZc0eGfTxPB6Pfiiq8a0Vu7Wi3m+/2WjQCUOSdf7YTM0akaYYKz+iAUBr8GkJAACwH+8dWmvfsTKYw9p8nJ/KavXSd01rxW4sqfXbZzBIRw9I0vljM3TmyHT1iWr7eQCgtyLQAgCAXmvHQzPlLM3z2+Z2u2Uo2SRJchT/qLxbR0iSLCkD1Hfe4kMec2elTS9/V6iXvivQN7uqm+0/ol+CZo/N0DmjM5Qea22HVwEAvReBFgAA9FrO0jw1FG5ott07f7CrrkKuuopDHqe0pkGL1hbpxTUF+mxr8/ajM2J1/pgMnTcmUzl9IoMtGwCwF4EWAACgDapsTr3+Q1OIXfpTudwe//2DkqI0e2ymzh+boWGpMaEpEgB6OAItAABAK9U1NGrJhhK9tKZA724qk8Pl9tufHW/V+WOaQuzYzDgZDKwVCwAdiUALAADQCjurbRr1xw9U73D5bU+JDtM5ozM0e2ymJvdLkNFIiAWAzkKgBQAAvZLH7Za7seHQDffaY29UfURTmI2zmnXWqHTNHpup6QP6yGwydlSZAICDINACAIBeobGqWLb8VarPWyVb/irZ81fLba8J6BjnjcnQBWMzdcLQZIWbTR1UKQCgtQi0AACgx3E31Mu27RvZ8lbJnv+VbPmr5Ny9I+jjXjm5n6YPTGqHCgEA7YFACwAAujWP2y1H0SbZ9t55teWtkn3XD5Lb1WJ7twzaYuqrtebBmur8Winuylafq6Le2V5lAwDaAYEWAAB0K4F2HS4xJmqtebB+MA/RWvNgrTcPUL2xaS3YJVXXBhRoEyMtQdcPAGg/BFoAANBlBdp1uF5WrTMP1DrLIK3dG2BLTE1dhBMiLBqXFafrsuI1PjtO47Li5XowWo7C1tViNho0JSexPV4WAKCdEGgBAECXEEzX4R8sg7XWPFh5pr5yGUyK3xte52TFa1x2nMZlxSknMbLZurA7UgaovM6h0tpDz3YclTJAFmYzBoAuhUALAABCor26DnvD6+lZTXddx2e3HF5b0nfeYqW73DrjP6v19sZSGSR59tnv/f6UYSl6/ZIJwb5kAEA7I9ACAIAOF3jX4XCtNw/ce+f1567DcVazxmXFa3pWnH6bHa9xWXHK7dO68HogFpNRr18yQX9dtkULP9+m4pqf79amxoTrmin9NX/GQO7OAkAXRKAFAADtqr26DkdHhGtcVlNovTQrTuOy4zUgyPB6IBaTUXccN1jzZwzUsk1FWvvTVo0alKMZQ9MJsgDQhRFoAQBAUPbvOmzLXy1PK7sO/2AepHXmgbJExurwvV2Gz94bXnMTI2U0tn94PRiLyaipuYlKshdreG4iYRYAujgCLQAAaLX9uw7X561SY0VgXYdtUWk6PDNO47PjNS+racKmAX2iOj28AgC6PwItAAA9wI6HZspZmuf73iOp3uGSy+ORyWBQZJhJ3rhoSRmgvvMWH/KY+3cdrtuySg0FP8gQQNfh0shcjclO1LisOF2yd8ImwisAoL0QaAEA6AGcpXlqKNzgt82sn/+jd7TiGPt2Ha7fskr1W1fL0ODfdXjfGOrtOrzO3BRet0cN1dC+6RqXFaczs+J1T3acBhJeAQAdiEALAEAv45F/1+H6vFWq2fKlDFW7/NrtG0P37zqcFzVM2f0GalxWnI7OitNvs+I1KInwCgDoXARaAAB6mfriLdp4RawMnp+7Du8bQ/fvOrwlcpji+x2msdlJGp8dp8sIrwCALoJACwBAD+AJoK3Z7d8BudQ36/Bg/RQ5VGH9xuuwfhkalxWnc7PiNDg5mvAKAOiSCLQAAHQzHrdbzoqdchRtUkPhRlXv2CBb6VaZWvl8m8L1YsTJ+jFimNR3vAbkDtL4rHjdRHgFAHQzBFoAALoot8MuR8lPchRtUt2u9arYtl4NRZtk3p0ns8vm17a1YVaSCkwp6nvhg/rrlByZCK8AgG6MQAsAQIg11u6Wo3Cj7IUbVbl9vfbsWC936Y+y7tkpwz6diQ2SrC08v9YQIbPHJWur5jJuMio9ljALAOj2CLQAAHQCj9slZ/l2NRRtUu3O9dq9bZ1sBZtk3v2Twhsq/dqGH+AYRcYk5ZuytNWUpfKo/lLyIEVlDVNWVo5mLDlF2v1jq2oxGw2akpMY3AsCAKALINACANCO3A31aijerIaCjSrftk7VOzbIVbJJ1qqtfpMxGSVFtfB8p8zaZsrQVlOWdliyZUsYIEvaUCX2G64BGSkanRKtc5KjFR9h8Xte3gdmNbSyxsTIMFlMxja/RgAAugoCLQAAAfJ4PHLtKVVD0Sbt2bFeZfk/qL5wo0zlPymqrtCvbcQBjlFtiFa+KUv5pixVRPWXO3mwIjOHKr3fEA1Oi9es5Gj1TYjokG7BSVFh7X5MAABCgUALAMABeFyNcpTly16wUSX5P6hqx3o1Fm+WtXKLrM4aXzuzpNgWnu+WQYXGZG01ZWlnWLbq4wfKnDZE8X1HKCe7r4alRmtWcrSiw4P/79iSMqCpZknldQ5V1DvU6P55/K3ZaFBiZJiSosIUtrctAADdHYEWANCl7Hhoppyleb7vPZLqGhrV6HDox7AwRYWb5b1naUkZoL7zFgd9TpetRo7izaravk4leT+ormCjDGU/Krpmu8yeRl+76AM8364wbTNlKt+Upcro/nIlDVJExjCl5AzXoIxknZwcrcw4a4cuh7Pv+zBQktPl1udbK1RR71RipEVTchLpZgwA6HEItACALsVZmqeGwg1+2yx7vyQFMI+vP4/Ho8bKQtkKNqgw7wdVbl8vZ/FmhVf8pBh7qa9d2N6vluw2xGmrKVO7wvqqPmGAjClDFNdvuLL7DdaQtFidmBSlyLCu8V+rxWTU9IFJoS4DAIAO1TX+1wUAoA08LW1rdMhRmqfyretUvOV71RZslKH0J0XvyZfVVedrF3eAY7pkVIExRfnmbFVE9Vdjn0GyZg5VUv/DNLBvto5LiVZaTLgMBpa8AQAg1Ai0AIBuq6J6jza+/ah2b1svR9EmhVX8pLi6XTLJJalpQqYDTcpUr3BtNWWpIDxbdfEDZEgZotjs4crMHa7BGUk6OilS4WZTp70WAAAQOAItAKBLaemu64FE1+2S539X6WArqpYZErTVnK3dUf3l7DNQ4elD1SfnMOXkDNS0lFglR4dxtxUAgG6KQAsACBmP2yXn7p3avesnFW//UXsKtyi2dIfCAzxOo4zaYUpXQVhf1cblSimDFZM1XBkDRmpQ30z9ok8kEyIBANADEWgBAB3G4/HIVV2iioKfVLxtsyoLt6ihNF+q2KGI2l2KsxfLvLd7cLik5ACPX2RM0vLpT+qUKRP1i4xEJUayvioAAL0JgRYAEBRXXaWqCn5S4bbNqizYIltJvlSxXeE1uxRnK1S4p0FS0384hwqsbhnkklGWvSH3UOoMETp2yi80mdl8AQDolQi0AICDcjfUaU/hFhVu26zdu35SfclWuXdvU9ienYqtL1SUu1aSZJLUmlhZYYhVkTlN1REZaojrK2NiP0Wm5Soxc5Cy+g1S5L+my1W8sVW1mY0GTck52AhaAADQkxFoAaCX8zQ6VFu8VQXbN6t8x4+qK8mXq3ybzNU7FVNfoLjGSl/bPnu/DqbWEKFCU6qqIjJli8mSIbGfrCm5SswcqPR+QzQ0PVlTog48EVOe0dDK+7NSYmQYY2MBAOjFCLQA0EF2PDRTztI83/ceSfUOl1wej0wGgyLDTPJGOkvKAPWdt7hD6vC4XbLt3qWC/E0q2/mjaory5SzfJnP1DkXV7VK8o1wmuSVJiXu/DqZBFhWaUlVhTZctOkuexH4KT8lVfPoApfcfor4ZGZoQa+2UmYOTohgzCwBAb0agBYAO4izNU0PhBr9tZv38wetop/N4PB41VJWocNtmlWz/UXuKtshRvk3Gyh2Kqt2lhIZiWdQoSYrf+3UwjTKqxJik8vAM1UVnyZ3QV2FJ/RWXMVApfQepX98cjY6LlNHYMYHVkjKg6XVJKq9zqKLeoUb3z4v5mI0GJUaGKSkqTGF72wIAgN6JQAsAXcCh1l511lapcNsmFW//UVWFW9RQtk2Gyu2KqNmpBHuRIjx2SVLc3q9DKTUmqiwsTbVRWXLF95Ulqb+i0wYope8gZfcbpOGJ0TKHqCvvvneqB0pyutxatqlIa3/aqlGDcjRjaDrdjAEAgCQCLQB0CeW1dkX8+N3PMwWXbpUqtstas1PxtkLFuGskSTF7vw6lyhCjUkua9kRlqjE2W6a9gbVP1iBl5wzWL5ITFWbuHqHQYjJqam6ikuzFGp6bSJgFAAA+BFoA6CCHuuu6r9g9+aq+Z6yiJEW1on29rCq2pKk6MkOO2GyZEvsrMi1XfbIGKSNniA5PS5XVYmpj5QAAAN0DgRYAguSor1HRznyVFmxVVfFW1ZftlKtyl/oXb5W1rceUWSXmVFVFZKghJktK7KeI1AFKyBygjP5DNSwrS+PDLe36OgAAALobAi0AHERD3R4V7tii0oKtqi7eLlv5DjVW7pKppkgR9cWKbyhVzN51WFt7d7Uluw2x+mrkbzVqxEil9R+i3L4DNCaSGXwBAAAOhkALoNey1VSqYEeeynZtVXXJdtnKd8pdVSDTngJF2koU7yhVtLtOUuvHrnpVGmIVJZvCPM7WtTfGadysqzR9YFLgLwQAAKCXItAC6HE8Ho9qq3eraEe+ygqbwqq9fIfcVQUy1xQpsr5ECY5SRXnqJbV+ZmCvSmOsKiwpqo9MkzM6Xcb4TFmTshWb2k9JGTnKzM7RsIR45d12mBz7LdtzIGajQVNyDrUCLAAAAPZFoAVwUDsemilnaZ7ve4+kuoZGNToc+jEsTFHhZnlXI7WkDPBbcqUjeDwe1VSWN91ZLdiqPaXb1bB7pzyVu2SuLVKUrUQJjjJFemySpIS9X61VYYxXVViy6iLT1RjTFFYj9obV5MwcZWbnalhsjAyGQ6/BGsgqrYmRYczeCwAAECACLYCDcpbmqWG/u4yWvV+S5GjHc7ndblXtLlXhjjyVF21TTck2NezeJU9VgSy1RYq2lSjBWaoIT4MkKWnvV2uVGxNUHZ6i+og0NcZmyLQ3rMal9VNKRo4y++ZqeEx0O76i1kuKYrwsAABAoAi0ANrNwZapcbvd2l1WrMKdW7S7cLtqS7erYfcuqWpXU1i1lyrRWSarp0FGSSl7v1rDLYMqTAmqCkuVLSpVrpgMmRMyFZHUT/Fp/ZSSlaPMrBwNj4oM/kUGwJIyQFLT+1Je51BFvUON7p/fJbPRoMTIMCVFhSlsb1sAAAC0HoEWQLspq9qjbW88o9rS7XJU7JSqChVWV6QYW4kSnWUKl1MWSWkBHNMloypMiaoOT5EtKk3umAyZE7MUmZSt+PT+Ss3MVUZWfx0W0dYFcjrOvt2vB0pyutz6fGuFKuqdSoy0aEpOIt2MAQAAgkCgBXBAbrdbjS5Xq9vH1e9S3OtzWt2+UUZVmPtoT3iK7FHpcsdmyJyQpajkvkpI66eU7AHKzOyn8PCe0R3XYjIyizEAAEA7ItACvZDL5VZZaZFKirarsniXasp3yV5RKFd1kYy1pQqvL1VUQ7kSGnf7xqsGyilTU1i1pqohMk2euAxZErMUmdxPien9lJaVq/TMfrJYLIc+GAAAANACAi3QgzicThUX7lRZ0U5VluxUXflONVQWyb2nWKbaElltZYpxlCuhsVIWNcqiwMaqHkqRMUlbTnpMp04eq9T0bJnNfMQAAACg4/DTJnqNlpafqXe45PJ4ZDIYFBlm6tTlZwJRX1+vooLtKivaoerSXarbXSBnVZE8e4plritVhK1Msc5yxbuqZZJbEZIi2nCeOkOEqi2JqgtPliMyVZ6YVOXseEtRjopWP3/I4VOVmU23WgAAAHQ8Ai16jZaWnzHr538E7bn8TGt4PB5VVlWpuGCbdhfv1J6yXbLtLlRjdZFUU6Kw+hJF2ssV59ytOHeNJCl271egqo0x2mPpo3prspxRKVJMmiwJ6Yrsk6G45Cz1Seur9Mx+io6Nb/bcLbeOkKOwdYHWbDRoSk5iGyoEAAAAAkegBVpwsOVnDsXlcqusvFQlhdtVUbJTtWW7ZKsolKuqSMbaEoXVlyq6oVzxjRWK8tgkSX32fgV0HhlVZYpXTVgf2SKS5YpKlSE2TWEJ6Yrqk6n41Cwlp/VTWkZfhUe05X5tE8Ohm/gkRoYxay8AAAA6DYEWaEF5nUMD99vmcDaquGjX3vGpO1S7u0ANFUVyVxfJVFeicFuZYhrKldBY4VueJnXvVyCcMqvSnKDasCQ1RCbLFZ0qY1yarAmZik7KVEJqtlIy+ik5NVPmLjahUlJUz5iNGAAAAN0DgRa9RiB3XV01pfrv7WfKUleqCHuZYhy7leCqlDmI8ak2Q7iqzH1UZ02SIzJF7uhUmePSZe2ToZikTPVJ7avUzL5K6JMqo8nUhjN0DEvKAElN7195nUMV9Q41un9+N81GgxIjw5QUFaawvW0BAACAzkCgRY/j8XhUuWePyop3qaKkQNXlhbJVFiurvEhRrTxGgnuPEna93qq2NcZoVVv6qN6aJGdkihSbJkt8uiL6ZCouOVN90voqLaOfouMSZDAE0oG3a9h3cqyBkpwut5ZtKtLan7Zq1KAczRiaTjdjAAAAhASBFt1C495xqWVFu1RVXqiavSHVWV0q1ZbKVF+ucFu5ohwVinNV+camxu39aotKY5xqwpJki0hWY1TKPuNTsxSXkqnktH5Kzewna2RrY3LPYDEZNTU3UUn2Yg3PTSTMAgAAIGQItN1QS8vP1DU0qtHh0I9hYYoKN3fZ5Wf2ZbM3qKSkQLuLC1RVXqS63YWyVxXLVVMq1ZTJUl8ua8NuxTgrFe+qkkWNMktK2vvVkfJM2Yq57VudOJDlZwAAAICuikDbDbW0/Ixl75fU+cvPeHk8HlXvqVFp8S7tLi3QnvIC1VeWyFFVLNeeUhnryhVmK1dEQ4ViGysU566RUZ42j0mVJLcMqjbGqjYsUbbwRDVGJssTlSRzbKrCE9IUlZCm+JRM9UnJkO3R0+Us3tSq45pYfgYAAADo8gi0PVwwy89ITV19y8vLVFayS5WlharZXShbRZGce0rlqWnq6mu171aUo0KxjZWKboeuvg6ZVW1OUF1YohqsTSHVEJMic2yKIhLSFd0nTQkpmUpOy1JinzSZWjnTb56x9V1jWX4GAAAA6PoItD1cS8vP2B0OlRQXqrxkl6pKC1VXUdTU1XdPmVRbKrO3q6+jQvGuKoWpUSYF19W3zhChPeYE1Yf3kSMiSe6oJBljUhQWn6bIhDTFJmUoISVdqWnZio7vE/LJk1h+BgAAAOj6CLTdUCB3XT17SvTi705QuG23Ih1N41Hj3HvapavvHmOsaiwJsof3kTMySZ7oZJliU2SNT1NUYprikjKVlJappNSsLjFxEsvPAAAAAD0LgbYbqne4Wv0XF+ep0ejSD1rV1imzqs3xqrUkqiGijxojk2SI9nb1TVN0UoYSkjKUlJalPsnpre7q21W0tPzM51srVFHvVGKkRVNymLEXAAAA6E4ItN2Qy+Np9V+cWwYVmdNltybu7eqbLGNMssLi0hSRkKrYpAwlpmYqJTVLMQlJIe/q25ksJqOmM4sxAAAA0G0RaLshUwChM9+Updhbv9VxBDcAAAAAPQz9K7uhyDBTq9uaWX4GAAAAQA9FoO2GAukUzPIzAAAAAHoqkk4Px/IzAAAAAHoqxtB2Qyw/AwAAAAAE2m6ppeVnlm0q0tqftmrUoBzNGJpON2MAAAAAPR6BtgewmIyampuoJHuxhueylioAAACA3oHkAwAAAADolgi0AAAAAIBuiUALAAAAAOiWCLQAAAAAgG6JQAsAAAAA6JYItAAAAACAbolACwD4//buPCiqK20D+NPsiwRQERUXQG0BBW0lKIhFABMEA8YlQWPU0Vkso2FENJlILKOJWzQhRsdldDRlVEYRzUAEHRUnEYO4QcAoI2AwcUMWFUFoGvp8f/j1nbQNihrAyzy/Kqrsc98+/XZ76na/995zLhEREZEssaAlIiIiIiIiWWJBS0RERERERLLEgpaIiIiIiIhkiQUtERERERERyRILWiIiIiIiIpIlFrREREREREQkSwohhGjtJOQiKysLQgiYm5u3dioGhBBQq9UwNzeHQqFo7XSojeN4o5bGMUctieONWhrHHLWk53m8qdVqKBQKqFSqJj/HpBnzaXOMjIyg1WpbO40GKRQKWFhYtHYa9D+C441aGscctSSON2ppHHPUkp7n8aZQKGBk9GQXEfMMLREREREREckS59ASERERERGRLLGgJSIiIiIiIlliQUtERERERESyxIKWiIiIiIiIZImrHMtMbW0tTExMmrT6lxACVVVVaNeuXQtkRm3V/fv3YWVl1eRYc3NzGBsbN3NW1JZpNBrcu3cPxsbGsLW1bTSurq4OGo0GlpaWLZgdtQXl5eUNtltYWDxyf1dZWQlra+vn7jYXJC/V1dWwsLB47DiqqamBkZERzMzMWigzagsqKytRW1vb6HYbGxuYmpoatGu1WlRXV8Pa2ro502sWXOVYBq5cuYLdu3fjX//6F0pKSgAArq6umDFjBkaOHGkQX1FRgRUrViA1NRUAYG5ujokTJ2L27NksNKhJMjIysGPHDpw5c0a6H5iPjw9mzZoFLy8vg/iEhARs2LABZWVlqK+vx7Bhw/DBBx+ge/furZA9yV1MTAy++eYb9OjRA4cPHzbYfvnyZXz88cc4deoUjI2N4ejoiKioKLz66qutkC3JjVqthpeXFywsLAxuWzFhwgRER0frtdXW1mLNmjVISEiARqOBQqFAREQE3n333SYf7COqqanBhg0bsH//flRUVMDc3BzBwcGIjo6Gg4ODXux3332HVatWoaioCEII9O/fH7GxsfD09Gyl7ElOYmJikJ6ebtBeWVmJuro67Ny5E97e3lJ7SUkJli5dirS0NBgZGcHGxgbTp0/HtGnTWjLtZyPouffOO++IESNGiLS0NFFfXy+qq6tFXFycUCqV4ssvv9SL1Wq1YtKkSSIwMFAUFBQIIYTIyMgQAwcOFMuWLWuN9EmGoqOjxfHjx8W9e/eEEEIUFRWJCRMmiP79+4v8/Hy92ISEBKFUKsU//vEPodVqRVlZmTQGdc8naqoDBw4ILy8v4evrK0aMGGGwvbS0VPj5+Ynp06eLO3fuiPr6evHll18KpVIpDh482AoZk9zU1NQIpVIpPvvssybF/+UvfxHe3t7izJkzQggh8vLyhL+/v5gxY0ZzpkltiFqtFhMnThSjR48Wubm5Utu+ffvE/v379WIzMzOFh4eHWLVqlVCr1aKqqkrMnz9fDBo0SPz0008tnzy1CdXV1cLb21v4+/uLuro6qV2tVotRo0aJ8PBwcf36dSGEEIcOHRIeHh7ib3/7W2ul+8RY0MrAjh07GiwMxowZI3x9ffXaDh8+3OAPu7i4OOHu7i6uXr3arLlS25WdnS2USqVYu3at1KbRaMTQoUMNftgVFRWJvn37ivXr17d0miRjN2/eFD4+PmLz5s0iIiKiwYJ2xYoVwt3dXdy8eVOv/a233hJBQUFCq9W2VLokU09S0F66dEkolUqxadMmvfZ9+/YJpVIpMjMzmytNakPWrl0rBgwYIIqLix8b+8Ybb4hXXnlFb19WVVUlBg8eLObNm9ecaVIb9vXXXwulUini4uL02uPj44VSqZQO2OnExsaKAQMGyObEBBeFkoFJkyY1OA+2c+fOKCsrg0ajkdqOHj0KY2NjDB8+XC82KCgI9fX1OHbsWLPnS22Tbj6GnZ2d1JaVlYXy8nK89NJLerE9e/ZEr169GrxclKgxsbGxcHJyeuRlTmlpaXB3d4ejo6Nee3BwMK5evYq8vLzmTpPakPv376O6urrR7UePHgUABAYG6rXrHnMfR48jhMCuXbsQHByMTp06oa6uDpWVlQ3GlpaWIjs7GwEBAXrza62srODr64ujR49Cq9W2VOrUhiQmJsLIyAivv/66XvvRo0dha2uLQYMG6bUHBQWhurq6wUuXn0csaGXqzp07yMzMhIuLi97E7oKCAjg6OhrM63FxcQEAXLp0qUXzJPmqr69HeXk5iouLceLECSxZsgSenp4YM2aMFJOfnw8AcHZ2Nni+s7MzCgoKWipdkrldu3YhIyMDy5Yta3Suf21tLa5cudLoeAO4j6Om+/vf/46hQ4di4MCBCAwMxPr16/UOEAP/3cf17NlTr93Ozg729vbSdqLGXL58GWVlZbC3t8esWbOgUqkwdOhQDBs2DOvWrUN9fb0Uq/vObGwfV1VVhevXr7dU6tRG/PLLLzh16hSGDRsGJycnvW0FBQXo2bOnwQJlujEol30cVzmWqQ8//BCVlZVYtGiRXntFRUWDZ3PbtWsHhUKBioqKlkqRZK6wsBCTJ0+GWq1GdXU1PDw88Mknn+itfqcbTw2NORsbG6jVatTU1BgsvEL0a0VFRVi1ahX+8Ic/wM3NrdG4e/fuQQjR6D4OAPdx9FgKhQITJkzA1KlT4eLigqqqKuzevRuffvop8vLy8MUXX0ixusV7Glpl1sbGhuONHku3mOeOHTsQHh6O77//HhYWFkhISMDixYtx9+5dxMbGAnj8d+qvY4iaKjExEUIIREZGGmy7e/dugwdQdOPt7t27zZ3eb4JnaGVozZo1SE1Nxbhx4xAREWGwXTSwcLV4MF+6Sbf7IQIApVKJzMxMZGdn49ChQ7C3t8e4ceOQm5srxeiO6DU05nSXRXHM0aPU19fjvffeQ+fOnTFr1qxHxj5qvOnaON7occzMzLB48WK4urpCoVCgXbt2+P3vf4+33noLhw4dQnZ2thSrUCgaHG/Ag30cb99Dj6MbI7a2tliyZIl0y5Q333wTwcHB2LVrF27fvq0Xy+9U+q1otVrs378fDg4OBlMngMb3cXIbb/LIkiRbtmzB+vXrMWrUKHz00UcG2+3t7XHnzh2Ddt0RFnt7++ZOkdogZ2dnrFmzBhqNBhs3bpTadeOpoSN4FRUVsLKy4v3z6JFSUlKQnZ2NmJgYVFZWory8HOXl5dBqtdBqtSgvL0dVVRWAB0eMTUxMGhxv3MfRs9KtPZGTkyO12dvbo7a2tsF5thUVFRxv9Fjt27cHAPTt29fgntkqlQp1dXXSZZ2P+k7lPo6eRnp6Om7evImxY8fCxMTwwlx7e/tGf8PptssBC1oZ2b59O1atWoXQ0FCsWrWqwXlm7u7uKC0tNRicunkZj7qcj+hRbGxsYG9vj5s3b0ptuvHU0FzZ/Px8uLu7t1h+JE91dXWws7NDbGwsQkNDpb/CwkJcv34doaGh+OyzzwAApqam6NWrFwoLCw364T6OnpVu/uyvv1t1+7CH93HFxcWoqKjgPo4ey9nZGVZWVqirqzPYphtzurVQlEoljI2NG/xOLSgoQPv27Q0WxCN6lL1790KhUBgsBqXj7u6OoqIig/GpO8gil30cC1qZ2LNnD5YtW4aQkBCsXr260UVTQkNDIYTAwYMH9doPHDgACwsLBAcHt0S6JGONXV5XVFSEW7du6RUMnp6e6N69u8F4y8nJwdWrVxEWFtasuZL8jRkzBpmZmQZ/ffr0Qbdu3ZCZmYmFCxdK8aGhocjPz9f7wSeEQGpqKtzc3ODq6toab4NkpLF9XEpKChQKBXx8fKS2l19+GSYmJkhNTTWIBR6MR6JHMTU1RUhICC5evChdWqyTkZEBa2tr6Xv1hRdegJ+fH9LS0qQ7CwBAWVkZMjMzOd7oidy+fRtpaWnw8/ND9+7dG4wJDQ3F/fv38e233+q1p6SkwN7eHr6+vi2R6jPjolAykJycjEWLFsHPzw8LFy40WBDAzs5Ousbdx8cHo0aNwqeffooOHTqgf//+SEtLw549ezBv3jzp0heixhw9ehRJSUkYN24cXFxcIIRAbm4u1qxZg06dOunNc1QoFFi4cCFmzpyJFStWYPLkySguLkZsbCz69euHN954oxXfCbVFU6ZMQVJSEubOnYuPP/4Y9vb22Lp1KwoLC7Ft27bWTo9kYO3ataioqMCIESPQo0cPlJWVISEhAcnJyZg+fTr69OkjxTo5OeGPf/wjtmzZAldXVwwfPhxZWVlYu3YtJkyYAA8Pj1Z8JyQXc+bMQXp6OqKiojB//nzY2NggPj4ep06dwuLFi/UuRX733XcRGRmJ+fPnY86cOVCr1Vi6dCns7Ozw9ttvt+K7ILn55z//CY1G88jfYiNHjsTu3bulceji4oKkpCQcOXIEK1euhLm5eQtm/PQUorFDlfTcmDlzJs6dO9fo9uTkZHTq1El6rNFosG3bNhw4cABlZWXo1q0bJk6ciNGjR7dEuiRzQgh89913SExMxKVLl1BVVYXOnTvDz88PU6dObfCgyMmTJ7F582bk5+fDysoKAQEBmD17trRKHtGTmjx5Mqqrq7F3716DbeXl5Vi3bh1OnDiBmpoa9O3bFzNnzoRKpWqFTElu1Go1kpKSkJqaip9++gkKhQJKpRJjx47FK6+80uBzEhISkJCQgBs3bsDBwQERERGYPHlyo1dLET3sxo0bWLduHU6dOgW1Wo3evXtj6tSpCAgIMIi9dOkS1q1bh9zcXBgZGcHHxwdRUVHo0qVLK2ROcjVlyhQUFxfjm2++0bvF58Oqq6uxadMmHD58GBUVFXB2dsa0adMQFBTUgtk+Gxa0REREREREJEucQ0tERERERESyxIKWiIiIiIiIZIkFLREREREREckSC1oiIiIiIiKSJRa0REREREREJEssaImIiIiIiEiWWNASERERERGRLLGgJSIiIiIiIlliQUtERERERESyZNLaCRAREdHzR61WY9++fdLjnj17ws/PT3q8e/du9OjRA76+vq2R3mMlJSWhqqoKAGBra4uwsLBWzoiIiJqDQgghWjsJIiKi39q3336L69evS49NTEzg4OAAlUoFW1vbVsxMHsrLy/WK1bCwMMTFxUmPPTw8EBYWhtWrV7dGeo8VFBSEa9euAQBcXFxw8ODBVs6IiIiaA8/QEhFRm7R9+3akp6cbtJubm2Pu3Ln43e9+1/JJyZCbmxsGDBgAT0/P1k7liYSHh+P27ds4cuRIa6dCRETNiAUtERG1aWPHjoWpqSk0Gg3y8vJw4cIFLF++HL1794a/v39rp/fc8/Pzw3vvvdfaaTyx6OhoAEBeXh4qKipaORsiImouLGiJiKhNe//99/HCCy9Ij+Pi4rBx40YcOHAA/v7+uHv3LlJSUqBSqeDm5oaLFy8iLy8P3bt3h7e3NwCgqqoKZ86cQUlJCdq3bw8fHx+0a9fO4LUqKyuRlZWF0tJSdOrUCf369YOdnd0TxRw/fhylpaUYM2aM3vNqa2uRmJiIvn37YtCgQQCAM2fOID8/H6+//jrq6+uRkZGB4uJijBw5Urqs+ueff0ZOTg40Gg1cXV0xYMCA3+Jj1VNYWIjc3FxYW1vD19e3wc/m/v37OH/+PK5evQpbW1u8+OKLev8vOr+em/vLL78gOzsblpaWGDFixBP1Q0RE/xtY0BIR0f+UiIgIbNy4EcXFxQCA4uJifPjhh4iJicHGjRuRmpoKAHjzzTfh7e2NxMRErFixQu8sn42NDT766COEhoZKbSkpKVi4cCEqKyulNisrK0RFRWHatGlNjomPj8fZs2cNCtqamhp8+OGHmDJlilTQpqSkYOfOnejTpw+io6Nx69YtAMDAgQNhbGyMBQsW4NChQ3r9qFQqrF27Fg4ODs/2Qf6/uLg4bNq0CbolOezs7PD555/rzb9dv349tm7dinv37klt1tbWWLx4McLDw/X6W7x4McLCwnD27Fn89a9/hVarhUqlwogRI56oHyIi+t/AgpaIiP6nnDt3DgAMFobatWsXSkpK4O/vDycnJwwePBhHjhzBggULYGxsjCFDhqBr164oKSlBRkYG5s+fDxcXF7i5uUGj0WDBggWoqanBiy++iO7du6O0tBTnz59HWloapk2b1qSYpzVv3jwYGRkhLCwMNjY2sLOzw5///Gekp6ejY8eOGDx4MCwsLJCbm4usrCzMnTsXX3311TN9jsCDM8TJyckYPHgwunbtiosXL6KgoABRUVFITU1Fx44dATwovI2NjeHv7w8HBwdcu3YNZ86cwfvvvw9PT084Ozvr9Xv27FkkJydDpVKhV69e0vYn7YeIiNo+FrRERNSm7du3D+bm5qitrcV//vMfJCcnAwACAgL04kpLSxEfHw8vLy+pLSwsDHZ2dti+fTv69u0rtefk5GDSpEn46quvsHTpUty6dQvV1dX405/+hJiYGCmupqYGGRkZANCkmKfl7OyMDRs2wNLSEgBw+vRppKenIyQkBKtXr4aZmRkAQAiBJUuWYNeuXcjNzX3mhZ5u3LiB5cuXY+zYsQAArVaLJUuWID4+Hnv27MHbb78NAHjnnXcQEBAACwsL6bmnTp3C5MmT8fXXX2POnDl6/V6/fh0rV67Ea6+9ptf+pP0QEVHbx4KWiIjatOXLlxu0jR49GhEREXptYWFhesVscXExCgsLoVKpcO7cOenMro6DgwNycnIAAF26dIGzszNyc3Nx+fJluLq6AgAsLCwQGBjY5JinFRUVJRWzAHDixAkAQI8ePZCYmKgXq5tvmpOT88wFrVKplIpZADAyMsK8efOwe/dunD17VmoPCQlBeXk5Tp48idLSUmg0GimXvLy8Bvt9uJh9mn6IiKjtY0FLRERtmm6VYxMTE3Ts2BG+vr5QqVQGcboCU6e0tBQAkJWVhaysrAb77tKlC4AHhdy2bdvw+eefIzIyEmZmZvD09ERwcDBee+01mJqaNinmaT2ce1lZGQBg8+bNjT7n1/NQn1ZDl/i2a9cOHTp0wJ07d6S21atXY9u2bairqzOI//V8Yp2H38/T9kNERG0fC1oiImrTHl7luDEPF5TW1tYA/nsf1ob8eh5u165d8cknn0Cr1eLnn39GVlYWNmzYgMTEROzYsQMmJiZNijEzM4NarTZ4rZKSkifO/dVXX5X+/TB3d/dG+2sq3SJUv6bRaHDnzh2pKE1LS8PmzZthY2ODwYMHo3379lK+Bw4cQH19vUEfDRX3T9MPERG1fSxoiYiIGtCjRw906NABdXV1mD9/PmxsbPS219TU4MaNGwAenBGtq6uDo6MjjIyM4OzsDGdnZ9y+fRsrV67EhQsX4OTk9NgYLy8vdOnSBdXV1fjxxx/Rr18/6fXi4+ObnLtKpcK2bdvg6uqKWbNmGWwvKiqCo6PjU34y//XDDz/g3Llz0qrLALBz505oNBop9x9++AEAsH37dnh4eEhxV65cMbgc+nGv9Vv0Q0REbQsLWiIiogYYGRlhxowZWLZsGcLCwhASEgInJyeo1WpcuXIFaWlpmDBhAqKjo1FQUIDp06dj+PDhcHNzQ/v27XH16lXs3bsXwINb8zQlBgB8fHywdetWzJgxA5GRkTA3N8fJkyel+bpNERwcDKVSiS+++AIZGRkYMmQIbG1tcevWLVy4cAHff/89/v3vf+vNu30aVlZWmDZtGsaPHw8nJyecP38eKSkpMDU1xfjx4wEA3bp1AwAsWrQIL7/8MszMzFBUVITU1FRpsaqm+K36ISKitoUFLRERUSOmTp2KsrIybNmyxeA2N5aWltJltR07dkTHjh1x7NgxHDt2TIpRKBSYOnUqevfuDYVC8dgYAAgMDMSQIUOQmZmJdevWSa+1cuVKREVFNSlvExMTbNq0CbNnz8bp06dx+vRpve0uLi7PXMzqcq2qqsKOHTukNmNjY3zwwQfo1asXgAeXPW/fvh05OTl6RXlMTAz27dvX5Nf6rfohIqK2hQUtERG1SS+99BKcnJwee/bO1tYWkZGRjc4pnTt3LsaPH4+0tDRcu3YN1tbWcHZ2RlBQkDQ3t1evXkhLS8Px48fx448/oqKiAo6OjggICJAKu6bE6GzZsgXJycm4ePEi7O3tER4ejk6dOiEyMlLv8l5vb2/U1dU1OOe0a9eu2Lt3L06cOIGzZ8+isrISnTt3Rv/+/TFkyBAoFIomfY55eXmIj49Hz5494efnJ7VHRkaif//+GD16NA4ePIjc3FxYW1sjJCRE7xZHlpaWSExMRFJSEgoKCmBpaYnAwEB4eXlBrVZLZ6Yf7vdhT9pPUlISqqqqUFZW9kwLbhER0fNNIYQQrZ0EERERPV/Ky8vh6+srPQ4LC0NcXFwrZvRkgoKCcO3aNQAPzkgfPHiwlTMiIqLmwDO0REREZMDCwgKRkZHS42e9Z21LCw8Px+3btwE8uGcwERG1TTxDS0RERERERLJk1NoJEBERERERET0NFrREREREREQkSyxoiYiIiIiISJZY0BIREREREZEssaAlIiIiIiIiWWJBS0RERERERLLEgpaIiIiIiIhkiQUtERERERERyRILWiIiIiIiIpIlFrREREREREQkSyxoiYiIiIiISJZY0BIREREREZEssaAlIiIiIiIiWfo/B/yGWBO+EcIAAAAASUVORK5CYII="
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "\n",
+    "pressure_grid_bara = np.linspace(20.0, 70.0, 11)\n",
+    "property_rows = []\n",
+    "\n",
+    "for pressure_bara in pressure_grid_bara:\n",
+    "    comparison_fluid = fluid(\"srk\")\n",
+    "    comparison_fluid.addComponent(\"CO2\", 1.0)\n",
+    "    comparison_fluid.setMixingRule(\"classic\")\n",
+    "    comparison_fluid.setTemperature(14.3, \"C\")\n",
+    "    comparison_fluid.setPressure(float(pressure_bara), \"bara\")\n",
+    "\n",
+    "    comparison_stream = jneqsim.process.equipment.stream.Stream(\n",
+    "        f\"CO2 at {pressure_bara:.0f} bara\",\n",
+    "        comparison_fluid,\n",
+    "    )\n",
+    "    comparison_stream.setFlowRate(1_000.0, \"kg/hr\")\n",
+    "    comparison_stream.run()\n",
+    "    comparison_fluid.initPhysicalProperties(\"density\")\n",
+    "\n",
+    "    neqsim_density = comparison_fluid.getPhase(0).getDensity(\"kg/m3\")\n",
+    "    coolprop_density = PropsSI(\n",
+    "        \"Dmass\",\n",
+    "        \"T\",\n",
+    "        comparison_stream.getTemperature(\"K\"),\n",
+    "        \"P\",\n",
+    "        comparison_stream.getPressure(\"Pa\"),\n",
+    "        \"CO2\",\n",
+    "    )\n",
+    "    property_rows.append(\n",
+    "        {\n",
+    "            \"pressure [bara]\": pressure_bara,\n",
+    "            \"NeqSim SRK density [kg/m3]\": neqsim_density,\n",
+    "            \"CoolProp density [kg/m3]\": coolprop_density,\n",
+    "        }\n",
+    "    )\n",
+    "\n",
+    "property_comparison = pd.DataFrame(property_rows)\n",
+    "\n",
+    "figure, axis = plt.subplots()\n",
+    "axis.plot(\n",
+    "    property_comparison[\"pressure [bara]\"],\n",
+    "    property_comparison[\"NeqSim SRK density [kg/m3]\"],\n",
+    "    marker=\"o\",\n",
+    "    color=\"#0072B2\",\n",
+    "    label=\"NeqSim SRK\",\n",
+    ")\n",
+    "axis.plot(\n",
+    "    property_comparison[\"pressure [bara]\"],\n",
+    "    property_comparison[\"CoolProp density [kg/m3]\"],\n",
+    "    marker=\"s\",\n",
+    "    color=\"#D55E00\",\n",
+    "    label=\"CoolProp\",\n",
+    ")\n",
+    "axis.set_title(\"Pure-CO2 density at 14.3 degC\")\n",
+    "axis.set_xlabel(\"Pressure [bara]\")\n",
+    "axis.set_ylabel(\"Density [kg/m3]\")\n",
+    "axis.legend()\n",
+    "figure.tight_layout()\n",
+    "display(figure)\n",
+    "\n",
+    "assert np.isfinite(property_comparison.select_dtypes(\"number\").to_numpy()).all()\n",
+    "assert (property_comparison.filter(like=\"density\") > 0.0).all().all()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "orifice-sensitivity-explanation",
+   "metadata": {},
+   "source": [
+    "\n",
+    "The steep density rise marks the subcritical condensation region. The models need not predict\n",
+    "the transition at exactly the same pressure because SRK and CoolProp use different formulations\n",
+    "and parameterization. The comparison is therefore most useful for locating sensitive regions\n",
+    "where a project should choose and document a fit-for-purpose property method.\n",
+    "\n",
+    "## 8. Orifice-flow sensitivity\n",
+    "\n",
+    "For fixed geometry, differential pressure should rise monotonically with mass flow. The sweep\n",
+    "below reuses the repaired `Orifice` process unit and verifies that expected trend using NeqSim\n",
+    "transport properties at every point.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "orifice-sensitivity-figure",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<Figure size 960x600 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA7QAAAJMCAYAAADKcepuAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjExLjEsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvctoD+AAAAAlwSFlzAAASdAAAEnQB3mYfeAAAtNJJREFUeJzs3Wd4VNX69/HvpAdIgFBC7yT0GkF6J3QQQQUEERBQ7AjqAfUoRylWRCxIVwQRpErvvYP0GroQIKEkpE1m9vOCJ/MnJoEkM8kk8Ptcl5dk7bXXumdmEXJnlW0yDMNAREREREREJJtxcXYAIiIiIiIiIumhhFZERERERESyJSW0IiIiIiIiki0poRUREREREZFsSQmtiIiIiIiIZEtKaEVERERERCRbUkIrIiIiIiIi2ZISWhEREREREcmWlNCKiIiIiIhItqSEVkRERERERLIlJbQiIiIiIiKSLSmhFRH5lx49ehAYGMihQ4eSXAsLC+P999+nefPmVKxYkcDAQFasWEFsbCyBgYHUrFnTCRHbr1WrVgQGBnLp0qVE5Q96L65cucLbb79NvXr1qFChgu29ADAMg+nTp9O2bVuqVKlCYGAgffv2zYyXkqXs2bPHYa/dkW2JOMrJkycJDAyka9eumXpvRrYlItmLm7MDEBFJj3Xr1rF48WL+/vtvbty4gYeHB0WKFKF+/fo8//zzFC9e3OF9WiwWevXqxdmzZx3ednZjsVjo168fISEhyV6fOXMmo0ePzuSoRERE5HGjhFZEspXbt2/z5ptvsm3btkTlcXFxnDx5kpMnTzJr1iyGDh3Kiy++6NC+d+3axdmzZylcuDCTJk2ibNmyuLq6AhAbG+vQvrK6Xbt2ERISkux7ATBnzhwARowYQffu3fH29nZWqBlm27ZtvPjiizRs2JApU6Y4OxyRLOXQoUN069aN6tWrM3fu3Mc+DhHJOEpoRSTbiIuL48UXX+TIkSN4eHjQp08fOnfuTMmSJYmNjeXQoUNMmTKFrVu3MmbMGKxWK/37909zP7Nnz062PGE2snHjxgQEBCS65unpyYkTJ9L+orK49LwXhmFw7tw5XF1d6dWrV6JE93ETFBT0SI4LkQQBAQHpHuP23JuRbYlI9qI9tCKSbUyYMIEjR47g7u7O5MmTGTZsGAEBAXh6euLr60uDBg2YOnUqvXr1AuCrr77i9OnTDus/YRY2Z86cDmszu3rQe2E2m7FarXh6ej7WyayIiIhkPCW0IpItREZGMmvWLAAGDx5M3bp1U6z7/vvvU7ZsWeLj45MsBW3Tpg2BgYGcP3+eNWvW0Lt3b5544gkCAwM5duwYkPQgpL/++ovAwEDGjh0LwNSpUwkMDEz2v5QOhTKbzfz+++/07t2bunXrUrVqVYKDgxkxYgQnT55Mtv7s2bPp2bMnTzzxBFWrVqV169aMGTOG8PDwtL+BwOXLlxk+fDj169enatWqtGnThu+//564uLgU70nPe1G1alUAoqKiEpXff7BUel5faj47gLNnz/LBBx/QokULqlatSlBQEH369GH16tXJtrtmzRoCAwN5/fXXuXv3Lp9//jktWrSgSpUqNGzYkJEjRxIWFpbonv79+9uWtG/ZsiXR63zmmWds9R50kNPff//NqFGj6Ny5M0FBQVSrVo3g4GA++eQTrl69muJnklb3v75bt27xySef0LRpU6pUqULz5s0ZM2YMERERD7zvzp07jBkzhpYtW1KlSpVEKx8sFgt//vknvXv3pk6dOrZ2R40axbVr15KN6c6dO3z11Ve0b9+e6tWrU7NmTTp06MCIESM4cuRIuus2aNCAwMBA7ty5k2y/nTt3JjAwMMnfuWeeecY2Rrds2UL//v2pW7cugYGB7Ny501bv8uXLfPLJJ7Ru3Zpq1apRu3ZtevXqxZIlSx78IaRg+/btDB48mPr161OlShUaNWpEz549mTVrFpGRkUnqp7X/nTt32sZfbGws3377LcHBwVSpUoX69eszbNiwFMdaamNL7jCmt956i27dugH3xvn9fz/atGnzwHtnz55NYGAgQ4YMSfF9S7ivYcOGWCwWu+L4448/CAwMZPDgwSn2d/z4cQIDA2ncuLGtPxHJOrTkWESyhd27d3P37l3bMtYHcXd3p2fPnowaNYoNGzYkW2fatGlJltNarVZHhZvI7du3GTRoEPv3709Ufu7cOc6dO8fmzZvZtGmTrTwyMpKBAweyd+/eRPXPnz/PtGnTWLVqFb/88gtFixZNdQynT5/m+eef5+bNm7ays2fPMn78ePbu3ZupP6TZ+/oe9NmtWrWKd955J9Ge5ri4OHbu3MnOnTsZOHAgQ4cOTbbdiIgInnvuuUTJzvXr1/njjz/Yv38/f/75J56enul6zf929erVRIlvgoQx8ddffzFnzhxKly7tkP7g3jh85plnOH/+vK3s8uXLTJs2jS1btjBr1ixy586d5L47d+7QvXt3zp07ZyszDAOAmJgYhgwZwpYtWxLdc/nyZX799VdWrlzJjBkzKFu2rO1adHQ0PXr0SLJ64tSpU5w6dYrFixfbfvmRlrqOMG/ePNv+7wQJY2vLli289tprREVF2a7FxsayZ88e238ff/xxqvtaunQp77zzju29BLh27RrXrl1j7969hIeH89prr9mu2dN/TEwMffr04cCBA7aysLAwFi9ezN69e1m8eDG5cuVKd2yO1L59e0aPHs3GjRsJDw/Hz88vSZ0FCxYA0LFjR7tXgXTo0IFx48axadMmrl69SqFChZLUSRgT3bp106oTkazIEBHJBiZMmGAEBAQYHTp0SFX9Y8eOGQEBAUZAQIDxzz//2MqDg4Nt5W+++aZx7NgxIzY2NtG9zz33nBEQEGAcPHgwUfnkyZONgIAAY8yYMUn6i4mJMQICAowaNWokuTZ48GAjICDACAoKMmbNmmVcvXrViI2NNUJCQoy5c+ca/fv3T1T/jTfeMAICAoxmzZoZCxYsMK5cuWLcvXvX2L9/v/H8888bAQEBRp8+fVL1PiR46qmnjICAAKNTp07Grl27jNjYWOP69evGTz/9ZFSsWNH2nly8eDFD3wt7Xt/DPrvTp08bVatWNQICAox33nnHOHTokBEZGWlcvXrV+PXXX42aNWsaAQEBxubNmxO1u3r1alu7DRo0MBYuXGiEhoYat2/fNpYsWWK7b+7cuYnu27p1qxEQEGD069cvxfd99+7dRkBAgPHCCy8kKr969arRs2dPY8GCBcbp06eNqKgo4/bt28aePXuMgQMHGgEBAcaAAQNS1dbD3P/6goKCjIULFxoRERFGZGSksWzZMuPJJ580AgICjPfeey/F++rUqWPMnz/fuHr1aqI6H3zwge19mzt3rnH58mUjKirKOHTokPHSSy8ZAQEBxlNPPZXongULFhgBAQFG48aNjfXr1xu3bt0yYmJijNOnTxvz5883nnvuuXTVNQzDqF+/vhEQEGDcvn072feiU6dORkBAgHHixIlE5d27d7e91kGDBhmHDh0yoqOjbdcvXbpk1KpVywgICDBeffVV48CBA0ZERIRx7do1Y+7cuUadOnWMgIAAY9myZan+XNq2bWsEBAQYH3zwgXHmzBkjJibGCAsLM/bu3Wt88sknxtSpU+3uf8eOHYk+w7lz5xpXrlwxIiIijFWrVtnumzJlSrpjO3HiRLKf88GDB42AgACje/fuKb4HKd375ptvGgEBAcaMGTOS3BMfH280aNDACAgIME6ePOmQOEaNGmUEBAQY3377bZJrUVFRRu3atY0KFSoYly9fTrENEXEezdCKSLaQMLNYsGDBVNW/v154eDiFCxdOdL1+/fp8/fXXjgswBUePHmXdunW4ubkxbdo0qlSpYrtWunRpSpcuTffu3W1lp06dYvny5eTKlYsZM2YkevxQjRo1+Pnnn+ncuTM7duzg5MmTSQ5kSs6ePXs4cuQIXl5eTJo0CX9/fwDy58/PwIEDuXPnDj///LMDX3XKHPH6UvrsfvrpJ2JjY+nWrRuffvqprTxnzpz06tULHx8fhg0bxi+//ELDhg2T3O/q6soPP/xgWzIN92Zvzp07x4QJE9i5c2eiz8oe/v7+tiX0Cby9valduzbff/89DRo0YPv27cTExODl5eWQPgFGjRqVaMln27ZtyZkzJy+99BJLlixh2LBhyc6IffPNN9SrVy9R2ZUrV5g3bx6enp5MnTo10WdVpUoVJk6cyDPPPMORI0fYs2cPQUFBANy4cQOAXr160bRpU9s9ZcuWpWzZsomWjKalriNUrVqVH374AZPJlKh82rRpREZGEhwczLfffmsrz5UrF927d6dAgQIMGjSImTNn0rZt21T1FRYWhpubGx988AHu7u7AvcPl/Pz8qFWrlsP7//dn2KpVK65cucKnn37Kzp076devX7piywhdu3Zl2bJlLFiwgD59+iS6tmXLFq5fv06VKlUoX768Q/rr0aMHv/zyC/PmzeOVV15JNAv7119/ERERQdOmTSlSpIhD+hMRx9IeWhHJVv79g2Z69ezZ0yHtPEzCUsyEPYsPk7D0uGnTpsk+S9fLy4vmzZsDsG/fvlTFsGvXLuBe8pKQzN7v/h9kM5ojXl9Kn11C2//+AThBcHAwbm5uKbZ7//7f+9WoUQO4t/zYkcLCwvjiiy/o3LkztWrVokKFCgQGBlKpUiVu3ryJ2WwmNDTUYf0VKlSI4ODgJOWNGzemXLlymM3mZN+bUqVKJUlm4d7YtlgsPPnkk8n+4sHd3Z1WrVoBiT/LypUrA7BixYpEy5iTk5a6jtCjR49kv8ds3LgRSHlsNWnShJw5c3Lo0CHMZnOq+qpUqRLx8fH8+uuvD33sl739FytWLNnPMKWxnZbYMkKDBg3w9/fn6NGjHD9+PNG1hOXGjvxlRtmyZalTpw5Xr161vdcJEh71k9wWARHJGjRDKyLZQt68eQFSPGTm3+6vl9yMU3LJVEa4fPkycO8HxNS4dOkScG9WYPny5cD/7Vc0DCPRnraE2auHSTj0JaX9mH5+fuTJk4dbt26lqj17OOL1JffZRUZG2mbxn3rqqSTt3v//O3fuEBcXh4eHR6I2Utqzm7C38EGHZ6XVuXPn6NmzZ5LDpv7tYcnEnj17kt1T3q9fP959991EZaVKlUrxF0JlypTh9OnTySbQJUqUSPaehM9y06ZNtvGd0md5/+usV68ePXv25LfffiM4OJhSpUpRpUoVatWqRfPmzROtpkhLXUdI6bX+888/wP8llCmNLbg3vvLly/fQvkaMGMGAAQMYM2YM48ePp2rVqlSpUoUnn3ySBg0a4Ob2fz+i2dt/SmM74ZTyf4/ttMSWEVxcXOjcuTOTJk1i4cKFvPfee8C917Zu3Trc3d1p3769Q/vs0aMHu3bt4vfff7f9Uu348eP8/fff+Pv7J1ohICJZi2ZoRSRbSJipOX36dKKDjVKyZ88e4F6yltwPvd7e3o4N0EESDqAxDAOLxYLFYsFqtWK1WhP90AqkeiYowYNmt//ddkZxxOtL7rO7/97k2k1N2y4umfdP4pdffklYWBhVqlSxPTv58OHDnDhxghMnTlCmTBmH95nezz+lvyv2fJYfffQRS5Ys4bXXXqN48eJs3bqVTz75hBYtWjB69Oh0132Yh43z5JZ3J7wmSP/YSk65cuVYuXIlX3/9NR06dODOnTvMnDmTgQMH0rp1aw4fPuyw/tM6tlMbW0ZKmIFdsmQJ8fHxACxbtozY2FiaN29Onjx5HNpfq1atKFCgAJs2beLKlSsA/P7774AOgxLJ6jRDKyLZwhNPPEHOnDm5e/cus2bN4tVXX02xrtls5rfffgNw+m/VE2ZG7n+szIMkJN/PP/88H3zwgUNiSDi1MyQkJNnr4eHh3L592yF9PUxGvD4AHx8fcuXKRWRkJBs3bkz2pFJHs2f5e8Iy8G+//TbJ7JnZbObixYupaicoKIgTJ06kqu7Zs2cxDCPZuM+ePQuQ7JL0lCS8x506deLzzz9P9X0JAgICbEuVDcPg0KFDvPfee0yfPp0aNWok2gua2roJ+z3v3r2Lr69vkj4TVkykhYuLC/7+/ly5coWlS5c6bN8m3NuX2q5dO9q1awfcW2nw22+/8eWXX/LWW2+xevXqDO3f3tgexN7tIaVLl6ZmzZrs37+fTZs20bx583QtN05tHO7u7nTr1o0ffviBP/74w7av3MXFxWF750UkY2iGVkSyhVy5ctmWVv7000+2hCA5o0eP5syZM7i5uWXq/tDkNGrUCID169dz9OjRh9Zv3LgxcG/PoKP2T9apUweA5cuXJ9vm1KlTHdJPamTE60uQ8F7PmDHDoe2m5P7kKa0SlngmN/s5bdq0NM++p8bVq1dZuXJlkvJNmzZx+vRp3N3d03TgT6NGjXBxcWH9+vWJHgWUHiaTiWrVqtmWkf77EVeprVugQAEADh48mOS+5cuXJ/ts19RIGLfTp09P1/2plStXLgYOHEiOHDm4cOGCbdl9ZvWfnthSkrCkPz1/PxIkbB9YuHAhZ8+e5cCBAxQoUMD2dz010hLHs88+i6urK/PmzWPJkiVERETQuHFjhy9tFxHHUkIrItnGq6++SuXKlYmLi6N///588cUXnDp1iri4OCIjI9m2bRv9+/e3nR771ltvZdpsRkoqVqxIixYtiI+P58UXX2TOnDlcu3aNuLg4zp07Z5sJSFCpUiWCg4O5ceMGPXv2ZO7cuVy8eJHY2FjCw8M5fPgw06ZNo2vXrkRERKQqhqCgICpXrkxMTAwDBw5kz549xMXFERYWxqRJkzI1oc2I15fg5ZdfxsPDg6lTp/LOO+/YnpcZGxvLhQsX2LhxIyNGjOCLL75wyGtJOPH02LFjHDhwIE17bCtUqADA8OHDOXXqFLGxsYSEhPDFF18wfvx4h8SXnA8++IBFixYRGRnJ3bt3Wb58uW2vbceOHZPdb56SEiVK2D6n3r178+uvv3L+/HliYmK4efMmx44d45dffuHZZ59NNDP6xRdf8P7777NhwwYuXLhAXFwcd+7cYcOGDfzxxx/A/yWmaakLULduXQDGjh3L9u3biYqK4sqVK/zyyy+MHDky3e/bSy+9RI4cOZg3bx6vvfYaO3fu5MaNG8TFxXHx4kW2bt3KRx99xCeffJKq9iIiIujatStTpkzh8OHDhIeHExcXx4ULFxgzZgxRUVF4e3vj4+OTIf07MraUFC5cGJPJxLlz59ixY0e69qC3b98eLy8v1q1bx7Rp04C0P3s2LXEULlyYJk2aEBoayrhx44B7Sa6IZG1aciwi2YanpyfTpk3jjTfeYPv27fz888/JPm7G3d2dt99+2+mzswlGjx7NwIEDOXDgAB999BEfffRRouv/Xub52Wefcfv2bXbs2PHAZblp2fc6btw4evXqxfHjx5McItSwYUPOnj2bruWY6ZERrw/unVL89ddfM2zYMJYsWcKSJUuSreeoH1CLFClC1apVOXToUKI2q1evbjsZNSWvvvoqAwYMYPPmzWzevDnRtSeffJIbN25w+vRph8R5f7tXrlxh+PDhSa6VL1/edvBOWnz44YeEhYWxfv16Ro0alWK9fx9a9Oeff/Lnn38mW7d06dK29zMtdQFeeOEF5s+fz+XLl+nbt2+iug0bNuTq1avpel+LFy/OxIkTeeONN1i1ahWrVq1Ktl7C8tyHMQyDI0eOcOTIkRTrvPHGG3h6emZI/46MLSU+Pj7Ur1+frVu38sILL9jKS5cuzYoVK1IVS65cuWjZsiVLly617WdN6+nGaY2jR48erFu3joiICAoVKkSTJk3S1J+IZD4ltCKSreTOnZvp06ezdu1aFi9ezIEDBwgPD8fd3Z0iRYpQv359nn/++RRPK3WG3Llz88svv/DHH3+wdOlS26xy0aJFCQoKonfv3onq58qVi2nTprF06VIWL17MkSNHiIiIIE+ePBQqVIg6derQvn37ZPcIpqRcuXLMnz+f8ePHs2XLFiIjIylSpAgdOnRg0KBBDj8x9EEy4vUlaNmyJX/99RczZ85ky5YttpN4/f39KV26NK1bt7Y9SsYRvv32W7788kt27txJeHg4FoslVfc1aNCAqVOnMnHiRNsBO8WLF6dDhw68+OKLGbJnL3fu3HzzzTd88803bNiwgbCwMAoUKEBwcDCvvPJKut5vT09PfvjhB1atWsWCBQs4dOgQt2/fxtfXl0KFChEUFET79u0pVqyY7Z5hw4ZRs2ZNVq5caTtZ2dfXlyJFitC+fXu6detmO1k6LXXh3mztnDlz+Oqrr9ixYwdRUVEULVqUzp07M2DAALp165bu969+/fr89ddf/PLLL2zatIkLFy5gtVopWLAgJUuWpFWrVsk+Fik5vr6+LFiwgGXLlrF9+3YuXbpEbGwsBQsWpHLlyvTq1cv23N6M6N/RsaVk3LhxfPHFF2zbto2wsDDb4U5p8fTTT7N06VKAdD97Ni1xNGrUiKJFi3L58mUdBiWSTZiMzDraUkRERDLdmjVrGDJkCMHBwXz77bfODkckS4uKiqJhw4ZER0ezbt067Z8VyQa0h1ZEREREhHuPCbp7964OgxLJRrTkWEREREQea4ZhcOzYMSZMmADc20srItmDEloREREReWx9/fXX/Pjjj7ava9asqcOgRLIRLTkWERERkceer68vbdq0YcKECZhMJmeHIyKppEOhREREREREJFvSDK2IiIiIiIhkS0poRUREREREJFtSQisiIiIiIiLZkk45ttPff/+N1WrFw8PD2aGIiIiIiIhkW3Fxcbi4uFC9evVU36MZWjtZrVay6rlahmEQExOTZeOTR4fGmmQmjTfJLBprkpk03iSzZOWxZhgGVqs1TfdohtZOCTOzlStXdnIkSUVHR3P06FHKli2Lt7e3s8ORR5jGmmQmjTfJLBprkpk03iSzZOWxduTIkTTfoxlaERERERERyZaU0IqIiIiIiEi2pIRWREREREREsiUltCIiIiIiIpItKaEVERERERGRbEkJrYiIiIiIiGRLSmhFREREREQkW1JCKyIiIiIiItmSEloRERERERHJlpTQioiIiIiISLakhFZERERERESyJTdnByBZn8Vi4fr16+TOnRtvb+9E1+Li4oiNjcXHx+eh7cTExBAVFUXu3LlxdXVNdf+hoaEYhpGozM3Njfz58ydbPzIyksjISPLnz4+b24OH+J07d/Dy8sLDwyNReXR0NLdv3072Hi8vL/LkyZPq+NPCbDYTFhaWbOzh4eGYzWb8/f25du0aOXPmJGfOnBkSh6M86PVklXYzKkYRERERyXj66S0bMVstbA09S3hsNH6e3jTwL427S+oTw/S6cuUKLVq0YNy4cXTu3BmAhQsXMmnSJC5evIi3tzceHh507tyZF198MUmiuWbNGr7//ntOnTpFzpw5iY2NpVmzZgwdOpSiRYs+tP+WLVvi7e2Nl5eXraxMmTJMnz49Ub0tW7Ywb948Nm7cSFRUFMuWLaNs2bLJtrl8+XK++eYbrl27hqenJy1btuTdd9+1JeZbtmxh1KhRie6xWq1cv36dLl26MHbs2IfGnR6nT5+mS5cuLFmyhICAAAC2bt3K8OHDsVgs+Pj4sHr1ap566in69etH//79MyQOR0nu9Tir3ZQS14yKUUREREQynhLabMBstTDm4DomHttKaEykrbyQtw+vVKjPe9WaZ0pim2Dt2rW8++67vP/++/Tq1Qt3d3fCw8NZuHAhO3fupH379ra6v/zyC6NHj2bYsGH07NkTT09PLl++zIcffkj37t2ZM2cOJUqUeGif7733Hl27dn1gnd9//522bdvSunVr3nrrrRTrLVq0iI8++oixY8fSunVrrFYrixYt4sSJEwQFBQHQqlUrWrVqlei+ZcuW8dZbb9GmTZuHxpte7u7u+Pv7J0q4xo0bR4cOHXj//fdtZQULFszys7NZzfHjx+nWrVuSX3Qk956LiIiISPagn+CyOLPVQpe101h26Timf10LjY7gw/0r2Xn9Agta9M20pHbbtm3kyZOHvn372sr8/Pzo169fonoXL15k7NixPP/887z44ou28qJFizJx4kRatmzJRx99xLRp0xwS14QJE4B7M8IpiY6O5tNPP2XQoEEEBwcD4Orq+tBkGWDBggUUKFCAxo0bpzqmO3fuYBgGuXPnTlQeFxdHeHg4BQoUwMXFhZs3b+Lm5kbJkiWZO3cu+fPnt9W5ePEiHTt25OrVq7b7f/jhh2SXecfExGA2m1NcAh4dHU10dDR+fn6pfg0ptWu1Wrl27RoAsbGxWCwWu9uMjY3l5s2bFCpUKFHdsLAwPDw8Unxd98diMpnIly9fogTVbDYTHh5uaytnzpy4uLhQsGDBRO/5v6Xm83N1dSUyMhIvLy8lxSIiIpKlma0WNoWe5eDti9wI9aZ5icBMnRjLCDoUKosbc3Adyy4dB8D417WEr/+6dIyxB9dnWkylSpXi9u3bLFmy5IFJzKJFizCbzckui/Xy8uL5559n27Zt/PPPPw/t02q1Eh4enuak6d+2bNnC7du3ad++PfHx8dy6dStV9127do2tW7fSpUuXVO3/3bx5M23btqVBgwY0bNiQtm3bsmXLFtv1gwcP0qRJEyZNmkSDBg3o0KEDU6dO5fTp0zRp0oSQkBCOHDnCM888Q1RUFJMmTeKZZ56x/desWTPmzJlja+/IkSM8//zz1KpVi2bNmtGhQwd2795tu3706FF69uxJ7dq1adGiBc2bN2fjxo0PfR0PavfWrVu2eHr27Em/fv0YNGgQ586dS3ebmzdvpkmTJsTGxia656WXXuL7779Psc37Y3n66aepWbMmffv2tcVy/vx52wz3W2+9xTPPPGMbl/e/5wlS+/lNmTKF5s2b07x5c2rUqMGHH36I1Wp96PsqIiIikpnMVgujDqym+O+jaLN+KsPPb6HN+qmUmPs/Rh1Yjdlq38/YzpTlE9qFCxfSp08fgoOD6du3L0uXLk31vceOHePjjz/m2WefpWPHjgwcOJCFCxcSHx/v8L4ygtlqYeKxrUlmZv/NBEw8vjXTBuKzzz5Lly5dGD58OHXq1KF37958//33XLp0KVG948ePkydPHvz9/ZNtJ2G/4rFjxx7a5wcffEBwcDDVq1fnhRdeSNU9yTl58iQeHh5s3ryZJ598khYtWhAUFMT48eNTHBcAixcvxmKxpGom99KlS7z66qs0adKEvXv3snfvXho0aMCQIUO4fPlyororVqzgjz/+YNu2bbz55puJrtWsWZNNmzbh7e3NsGHD2LRpk+2/+2dYL168SJ8+ffD392f79u3s2bOHr7/+mn379gHwzz//0KdPH3x9fdm+fTv79u3jpZde4tVXX00Sz/0e1q6fn58tnjVr1vDDDz+QN29e3n777SSHeKW2zfS6P5YtW7awfft28uXLZ4ulXLly/PTTTwDMnDmTTZs2sWTJkmTbSsvnt2bNGn777Td27drFb7/9xp9//snixYvtei0iIiIijpSw4vPD/Su5dt/2Rfi/FZ9PrZ2ebZPaLL0+7ssvv2TGjBmMHDmS2rVrs3PnTt577z0uXrzIyy+//MB79+7dy1dffUWXLl3o2rUrrq6ubNmyhREjRrBy5Up++OEHh/WVVruuX2DU36uJMMc+sN6t2OhEe2ZTYgBXoyN4YvE35PH8v1OIrRYrd6OiyHllOy6u93534ePuyQfVW1GnwMP3rabEw8ODMWPGMHz4cHbv3s3Bgwf5448/+Pnnn/nmm29o0qQJAHfv3iVv3rwptpOQlEVFRT2wvxdeeIEXXniBAgUKcO3aNUaOHEnPnj1ZtGhRqvbf3i86Opq4uDh+++03lixZQuHChdm+fTsDBw7E09OTwYMHJ3vfwoULqVWrFmXKlHloH7NmzSJ37ty88847tiWow4cPZ8WKFfz666+8++67trpvvvlmqg7GepBffvkFb29vPvvsMzw9PQEoX7485cuXt12Pj49n9OjRtqWzPXr0YOHChUyfPp0RI0akq937RUZGEh0dzdNPP81LL71EaGhokmXDaW0zvRJOue7evTsvvPBCirGkJC2f39ChQ21tV6tWjerVq/P333/TpUsXh70eEREREXukZcXnyBotMzU2R8iyCW1ISAiTJ09myJAhPPPMMwCULVuWf/75h4kTJ9KpU6cHJgLVq1dn1qxZicoqVarE1atXmTVrFmfOnLEdDGNvX2n1zdHNLL2YvhnGB/n75pXkL9xN/KWvuxezmvSyuz8/Pz+Cg4MJDg5myJAh9OzZk48//ph169YBkCdPHg4cOJDi/Ql7Qh/2CJx33nnH9ueCBQvy5Zdf8uSTTzJ//vwHHv6UnBw5cgDw8ssvU7hwYQDq1atH27ZtWbBgQbIJ7cGDBzl16hSffvppqvoICQmhYsWKifZTenh4EBgYmGhZK5CqBPlhTp48ScWKFW0J4r8dP36cMmXKEBsbm2gfbpkyZTh58mS627VYLHzxxRfMnz+f2NjYRHtIr1y5kmwS+bA20+vfsdy/1zalWFKSls/v398XcuXKRURERDpfhYiIiIhj3b/iM/n1c/ckrPh8t1qzbLenNssmtMuXL8dqtdKuXbtE5R07duTnn39mxYoVD3xkSUqHsyTMCt6/vNTevtLqzUqNiDDHpGqGNsUkNRnV8xZOfoY2R45EM7RvVmqUvsD/P8MwMJkSL4TOkSMHLVq04LvvviMyMpJcuXJRs2ZNli1bxokTJwgMDEzSzv79+3Fzc6Nq1app6t/Hx4d8+fJx/fr1NMdeqlQpgCQJTuHChVm9enWy9yxcuJAcOXLQtm3bVPXh4eFBZGTSmfW4uLgkJxOn5Xm8KXF3dycuLi7F6y4uLpw5c8b2y5r7lSxZMt3tzpw5kwULFjB58mTKly/P0aNH8fb25qmnnkpxr/PD2kzJw/al3h9LtWrVADhz5gzt2rVL877rtHx+IiIiIlnZ1tCzaVrxuTX0LE0Ll8v4wBwoyya0R48exd3d3ZaAJChbtiyurq4cPXo0zW0eP36cuXPn0rBhw0QJVkb09SB1CpRgScuHJ8hmq4Xiv4/iWkzkQ3+j4u/tw+5Obyb6jUp0dDRHjx6lUqVKeHt7p9xAGk2ePJmmTZsmWSZ64cIFcuTIYXtebOfOnZk4cSLfffed7QTiBKGhocydO5dOnTo9cIbWarXi4pJ4q/eFCxe4du1aks8rNerXr4+HhwfHjx+3PaIH7u3jTW62NC4ujr/++os2bdqkOpmpVKkSU6dOtSX2cO+03KNHjzJgwIA0x/wwtWrV4ueffyYsLIx8+fLZyhPeu6CgIEJDQ1myZEmSX0Q8KNl7WLtHjx6lWrVqVKtWjejoaAB27txpV6wJv3C6fv06xYoVA+4tXT9//jz16tVLsd37Y0mwY8eORHU8PDwe+poh8z8/ERERkYwSHhudofWzgiyb0IaFheHr65skmXFzcyNXrly2R3A8zK+//srUqVO5e/cut27domvXrnz88ccO7cswDNsP9I42sFwdRh1e9+D+/3+9+Ng47j/WKCYmJtH/0yvhfrPZTHR0NNeuXaNbt27079+fZs2aYbFYWL9+PUuWLKF///6YzWbMZjMeHh589tlnvP3227zxxhv07NkTPz8/jh07xrfffkupUqV46623Hvje/fHHH5w8eZJWrVrh7+/PmTNn+PbbbylSpAidO3dOdO/NmzeJi4uzPb7ln3/+wdXVlRw5ctiWoHp6etK/f3++++47fH19KVeuHGvXrmXTpk2MHz8+SSxr1qzh1q1bdOzYMdWfcbdu3Zg1axavvfYar7zyCoZh8N133+Ht7U23bt1s+3gT3tv72014r2NjY23lhmEQFxeXqJ5hGLbP4+mnn2bBggUMGDCAV199lUKFCnHw4EH+/vtvPvroI7p168bixYt59dVX6dGjBwUKFODKlSusXbuWggULppikPazdSpUqMX78eBYvXkzJkiVZv349s2fPBrDF++/X87A2S5UqRYECBfjss894+eWXiY6O5ocffiAmJob4+Hjbe/Dvdu+PJSAgwLaH/v5Y8uXLh6enJ8uXL8fV1RV3d3cKFCiQpC17Pj+LxYLFYsmw7wdyj6O+t4k8jMaaZCaNN8kIOUnbasCcuDr155jkVoI+TJZNaA3DSJJgJjCZTKleRti5c2eaNm3KrVu32LZtG99//z3R0dF8/fXXtjfL3r5iY2MdPouboL2pAOt9irAl4p8ka98Tvm7oU4R25E8xhn/v+0ursLAw/Pz8uHHjBkePHqVVq1bkyZOHHTt2sGjRIkwmEwUKFODNN98kKCgoURx58uThs88+Y9myZYwcOdKWWDRp0oSWLVty8eLFB/ZdsWJFwsLCmDBhAtevXydPnjzUqlWLdu3aJTlVecKECZw4cQK4t7R8+PDhADRt2pRu3brZ6jVs2JC4uDh++uknIiMjKVy4MCNGjCB//qTv4V9//UX58uXx9PRM02c8cuRI5s+fz7Bhw4B7Bx+NHDmSCxcuAPdO0vXz8yMkJITbt2/b7ksoP3funC1pypMnD+Hh4Yn69/Hxsc0aAvznP/9h0aJFjBkzBovFQkBAAN27d090fenSpXz66afcvXuXggULUqdOHerUqfPA1/WgdqtUqUKHDh347rvviImJoUiRIgwYMICZM2dy6dIlPD09k309D4v17bffZu7cubz22mv4+fnRtGlToqKibCsOknufUhMLwKBBg1ixYgVz587F29ubsWPHJhtjej+/hO8XGfX9QBKz93ubSGpprElm0ngTR8pjWMnt6sFty4O3fJkAPzcv8ty4y9Ew5/4ck7DaM7VMRkrP13CyAQMGsHfvXvbv35+o3DAMqlatSrNmzZIsY02NX375hf/9739MmDCB1q1b293XkSNHMAzDdsBURjBbLXx5bDM/ndqZaA28v1cuBpWvy9CKjZLdvB0TE0NISAhlypRJ88AQSQuNNclMGm+SWTTWJDNpvElG2HHjAm3XTSPWmvLjKRN8WLUF71VumvFBPcCZM2cwmUxUrlw51fdk2RnacuXKsXnzZq5du0bBggVt5f/88w9mszndCWTCvsmTJ0/aElp7+zKZTA7do/pv3sDHQW0ZWas1W0PPEh4bjZ+nNw38S6fqFDIvL68MjU8kgcaaZCaNN8ksGmuSmTTexFFWXz5Jlw3TEyWzKa34bF+sIiNrtXb6CcdpXW4MkPw62yygWbNmAGzatClR+YYNGwBo3rx5uto9c+YMkPhxGxnVl6O5u7jStHA5upaqStPC5Zw+4EREREREJOv589whOqyZQlS8GReTiZ/rd2dUzTb4e/skqufv7cOomm1Y0KJvts0tsuwMbd26dWnYsCHffvstNWvWpGzZspw6dYrvv/+e1q1bJzrN9Pr16zz77LO0bNmS//znPwBMnTqVokWL0rhxY7y9vTEMg23btjFmzBhKly5NmzZt0tWXiIiIiIhIVjXj1G76bZ2L1TBwd3FldpNePF3qXj7zbrVmrLtwgoMhJ6lWJoDmJQKzbSKbIMsmtADffPMNn376KV27dsXHx4fIyEg6dOhgS1oTWCwWLl++nOg04saNGzNlyhRGjhyJu7s7ERER5MiRgzZt2vDGG28kWcqR2r5ERERERESyoglHt/D6zoUAeLu6s6BFX4KL/t/jSt1dXGnsX5r8YdFUSuX2xawuyx4Kdb+4uDhu3rxJ3rx5bc+SvJ/FYuHKlSvkyJHD9hzL+4WFhWEymZK9lta+/u3IkSMAadq4nFky6jm0Iv+msSaZSeNNMovGmmQmjTexh2EYfPr3Wj7YvwKA3B5e/NWyPw38Syepm5XHWnpyqyw9Q5vAw8MDf3//FK+7urpSrFixFK/ny5fPYX2JiIiIiIhkFYZhMGz3Ur48shGAAl45Wdl6IDXzFX3InY+GbJHQioiIiIiISGIWq5XB2+cz+eROAIrlyM2aNoMIzF3wIXc+OpTQioiIiIiIZDNxlnh6b5rN3HN/A1DOJz9r2gykZK6Hb7N8lCihFRERERERyUai4uPotm4myy8fB6Ba3sKsbP0ShXL4OjmyzKeEVkREREREJJu4ExdDxzVT2RQaAsCTBUqyrFV/8nrmcHJkzqGEVkREREREJBu4EXOXNqt+Zm/YJQBaFC7PwhZ9yeXu6eTInEcJrYiIiIiISBZ3+e5tWq38iWO3rwHQuURl5jR5Hi83dydH5lxKaEVERERERLKwM3du0HLlT5yLvAlA77K1mdrwGdxcXJ0cmfMpoRUREREREcmiDt+8QuuVP3Ml+g4AQyrU59snu+BicnFyZFmDEloREREREZEsaNf1C7RdPZnw2CgARlRrwahabTCZTE6OLOtQQisiIiIiIpLFrL9ymk5rphEZHwvAuKD2DKvazMlRZT1KaEVERERERLKQJReO0H3DL8Ra4jFh4sf6TzMw8Elnh5UlKaEVERERERHJImaH7KfPptnEG1bcTC7MbNyDHmVqOjusLEsJrYiIiIiISBbw0/HtvLz9TwwMvFzd+KNZHzoUr+TssLI0JbQiIiIiIiJONu7Qet7d8xcAudw8WdLyRZoWLufkqLI+JbQiIiIiIiJOYhgGI/YtZ/TBdQD4eeZgRasBPFGghJMjyx6U0IqIiIiIiDiB1bDy2o6FfH98GwCFvX1ZHTyQynkLOTmy7EMJrYiIiIiISCYzWy302/I7v57ZB0DpXH6saTOIMj75nBxZ9qKEVkREREREJBPFxJt5buOvLLpwBIBKefxZ1XogRXPmdnJk2Y8SWhERERERkUwSaY6l89pprLtyGoDa+YqxovVL5PfK6eTIsicltCIiIiIiIpkgPDaKdqsns/P6BQAa+5dhSct++Hp4OTmy7EsJrYiIiIiISAa7GnWH1qt+5tDNKwC0K1aBec1ewNvN3cmRZW9KaEVERERERDLQ+chwWq6YxOmIGwA8W7oGMxs9h4er0jF76R0UERERERHJIMdvXaPVyp+4FHUbgJcC6vJDvadxdXFxcmSPBiW0IiIiIiIiGWB/2GWCV03iesxdAN6p0oRxQR0wmUxOjuzRoYRWRERERETEwbaEnqX96incMccA8L9abfhPtRZKZh1MCa2IiIiIiIgDrbx8gqfWTifaYgZgQt0uvFqpoZOjejQpoRUREREREXGQeef+pufG3zBbLbiYTExr+Cx9ygU5O6xHlhJaERERERERB5h2ahcDtv6B1TDwcHFlTtPneapkVWeH9UhTQisiIiIiImKn8Uc28+auRQDkcHNnYfMXaVU0wMlRPfqU0IqIiIiIiKSTYRh8cmA1/z2wCoA8Ht781bI/9f1LOTewx4QSWhERERERkXQwDIO3dy3mm6ObASjolYtVwQOp7lfEyZE9PpTQioiIiIiIpJHFamXgtnlMPbULgOI587AmeBABuQs4ObLHixJaERERERGRNIizxNNr02/MO3cQgADfAqwOHkiJXHmdHNnjRwmtiIiIiIhIKkXFx/H0uhmsuHwCgOp+RVjZ+iX8vX2cHNnjSQmtiIiIiIhIKtyOi6bDmqlsCT0LQL0CJfmrVX/yeuZwcmSPLyW0IiIiIiIiD3E9JpLglT+zP/wyAK2KBLCg+QvkdPd0cmSPNyW0IiIiIiIiD3Dp7i1arZzE8dvXAHiqRBVmN30eT1elU86mT0BERERERCQFp+/coOXKnzgfeROAF8oFMblBd9xcXJ0cmYASWhERERERkWQdCr9Cq1WTCI2OAOC1ig35pm4nXEwuTo5MEiihFRERERER+Zcd187TbvVkbsZFA/BB9ZZ8XDMYk8nk5MjkfkpoRURERERE7rPun1N0WjuNu/FxAHzxRAeGVmnq3KAkWUpoRURERERE/r9F5w/z7MZfibXEY8LEpAbdGBBQ19lhSQqU0IqIiIiIiACzzuzjhc1zsBhW3Ewu/Nq4J8+WqeHssOQBlNCKiIiIiMhj7/tjW3l1x0IMDLxc3Zjf7AXaFa/o7LDkIZTQioiIiIjIY230wbX8Z+9yAHzcPVnash+NC5V1clSSGkpoRURERETksWQYBu/vXcbYQ+sByOeZgxWtXyIof3EnRyappYRWREREREQeO1bDypDtC/jxxHYAiuTwZXXwQCrlKeTkyCQtlNCKiIiIiMhjxWy10HfzHH4L2Q9AGZ98rAkeSGmffE6OTNJKCa2IiIiIiDw2ouPNPLNhJksvHgOgch5/VgUPpEiO3E6OTNJDCa2IiIiIiDwWIswxdF4zjfVXzwDwRP7iLG81gHxeOZ0cmaSXEloREREREXnkhcXcpe3qyey+cRGAJoXKsKRlP3zcvZwcmdhDCa2IiIiIiDzSrkTdofXKSRy+dRWADsUrMrdpH7zd3J0cmdhLCa2IiIiIiDyyzkaE0XLlJEIiwgDoUaYmMxo9h7uLq5MjE0dQQisiIiIiIo+ko7eu0mrlJP6JugPAoMAnmfhkV1xdXJwcmTiKEloREREREXnk7L1xieBVkwiLjQJgeJWmjAlqj8lkcnJk4khKaEVERERE5JGy6eoZOqyZSoQ5FoDParfl/WotnByVZAQltCIiIiIi8shYfukYXdfNIMYSD8DEJ5/ilYoNnByVZBQltCIiIiIi8kiYe/YAvTb+RrxhxdXkwvRGz/J82drODksykBJaERERERHJ9iaf3MnArfMwMPBwcWVu0950LlnF2WFJBlNCKyIiIiIi2dpXhzcydPcSAHK6ebCoxYu0KFLeyVFJZlBCKyIiIiIi2ZJhGHy0fyWj/l4DQB4Pb5a3GsCTBUs6OTLJLEpoRUREREQk27EaVt7auZhvj20BwN/bh1WtX6KaXxEnRyaZKUsntIZhMHfuXBYsWEBoaCiFChWiW7duPP300w+9Ny4ujjVr1rBixQpOnTqFm5sb5cqVo1+/flStWjVR3fDwcDp27JhsO/369aN///4OeT0iIiIiImK/eKuFAVv/YMbpPQCUyJmHNcGDKJ+7gJMjk8yWpRPasWPHMnv2bD7++GOCgoLYuXMn//3vf7l8+TKvv/76A+8dPXo08+fPZ8CAAbz++uvEx8czY8YMunfvzqeffpooKbZYLNy4cYMhQ4bQo0ePRO3kyJEjQ16biIiIiIikXawlnp4bZ/Hn+UMABOYuwOrWgyieK49zAxOnyLIJ7enTp5kxYwavv/46Xbp0AaBYsWJcvHiRn376iaeeeorixYuneH+BAgWYO3cuFSpUsJWNHj2aM2fOMG7cOLp06YKrq2uie3LmzEmBAvqtjoiIiIhIVnTXHMtT62aw+p+TANTwK8LK1i9R0NvHyZGJs7g4O4CUrFixAqvVStu2bROVt2/fnvj4eFasWPHA+19++eVEyWyCwMBAbt26RVhYmEPjFRERERGRjHMrNprWq362JbMNCpZifZuXlcw+5rLsDO3Ro0dxd3enZMnEJ5SVKVMGV1dXjh8//sD7TSZTkjKr1cru3bvJkSMHefPmTXL9119/ZdasWbi6ulK+fHmee+45GjdubN8LERERERERu1yLjiB41c8cCP8HgNZFAviz+QvkdPd0cmTibFk2oQ0PDyd37txJElNXV1dy5cpFeHh4mtucMmUKZ8+eZcCAAbi7uye61rBhQ3r06EH58uW5fv06M2fO5KWXXmLo0KEMHDjwge0ahkF0dHSa48loMTExif4vklE01iQzabxJZtFYk8yk8Zayi3dv0WHDdE5F3Fth2aVYJabV645LvJXo+Kz3M3hWl5XHmmEYyU5MPojJMAwjg+Kxy3PPPcelS5fYsmVLkmt169YlMDCQmTNnprq9jRs38sorrxAYGMjs2bPx9Py/3+ak9MYNGDCA7du3s3btWgoVKpRsu0eOHMmSg0FEREREJLs7H3uHV0LWE2qOAqBj3tKMKFYHN1OW3TkpdvLy8qJy5cqprp9lZ2h9fHyIjIxMUm4YBnfv3iV37typbmvnzp28/vrrlC5dmsmTJydKZiH55ckAHTp0YPPmzezdu5f27dun2L6npydly5ZNdTyZJSYmhpCQEMqUKYOXl5ezw5FHmMaaZCaNN8ksGmuSmTTekjp48wovb1jMtf+fzA4JqMfYmm1wUTJrl6w81s6cOZPme7JsQluuXDk2bdpEaGgo/v7+tvJLly5hNpspX758qtrZt28fgwcPpmjRokyfPh0/P79Ux+Dh4QGA2Wx+YD2TyYS3t3eq281sXl5eWTo+eXRorElm0niTzKKxJplJ4+2e7dfO0W79NG7F3VtS/FGNVnxUo3Wal6NKyrLiWEvP55tlf73RokUL4N5S4ftt2LAh0fUHOXToEC+99BKFChVi5syZ5M+fP00xbN26FSBNU94iIiIiIpJ+a/45ScuVP9mS2a/qdOK/NYOVzEqysmxCGxQURNOmTfn2229tJxofOXKEiRMn0q5du0RJ5rVr12jQoAGffPKJrezEiRMMGDCAggULPjSZ/fnnn1m4cCG3bt0C4O7du0yaNIn58+fTpUuXVM8Gi4iIiIhI+i04f4j2q6cQFW/GxWRiSoNneKuynjoiKcuyS44BvvrqK8aOHUuPHj1wc3PDYrHw1FNPMWzYsET1rFYrN27c4M6dO7ay77//nlu3bhEfH0+XLl2StD19+nRbohocHMyUKVMYN24csbGx3L17lxIlSvDOO+/Qt2/fjHyJIiIiIiICzDy9h35b5mIxrLi7uDKrcU+6l67u7LAki8uypxzfz2KxEBERga+vLy4uSSeVrVYrYWFheHl54eNz78HKd+7cITY2NsU28+bNi5tb0nw+MjISV1fXVK8nP3LkCJA1lyVHR0dz9OhRKlWqlOXWx8ujRWNNMpPGm2QWjTXJTI/7ePvu6BZe27kQAG9Xd/5s/gJtilVwblCPqKw81tKTW2XpGdoErq6u5MmTJ8XrLi4uFChQIFGZr69vuvrKlStXuu4TEREREZG0MQyDzw6uZeS+FQD4unuxtGU/GhUq4+TIJLvIFgmtiIiIiIg8WgzD4N09f/H54Q0A5PfMycrWL1ErfzHnBibZihJaERERERHJVBarlZe3z+fnkzsBKJojN6uDB1Ixj/9D7hRJTAmtiIiIiIhkGrPVQu9Ns/n97AEAyvrkY03wIEr5+Dk3MMmWlNCKiIiIiEimiI430339TP66dAyAKnkKsSp4IIVzpO/8GxEltCIiIiIikuHuxMXQae1UNl4NAaBO/uIsb/0Sfp45nByZZGdKaEVEREREJEPdiLlL29U/s+fGJQCaFy7HwhZ98XH3cnJkkt0poRURERERkQxz+e5tWq+axNFboQB0LF6JuU174+Xm7uTI5FGghFZERERERDJESEQYLVf8xNnIcAB6lanFtEbP4u7i6uTI5FGhhFZERERERBzuyM2rtFo5iSvRdwB4uUI9vnvyKVxMLk6OTB4lSmhFRERERMShdl+/QJvVkwmPjQLgvarN+ax2W0wmk5Mjk0eNEloREREREXGYjVfP0HHNVCLMsQCMrt2O96o1d3JU8qhSQisiIiIiIg7x18WjdFs/kxhLPCZMTKz3FC9XqO/ssOQRpoRWRERERETsNidkP703zSbesOJqcmFGo+foVbaWs8OSR5wSWhERERERSTWz1cLW0LOEx0bj5+lNA//STDu1m8Hb5mNg4Onqxh9Ne9OxRGVnhyqPASW0IiIiIiLyUGarhTEH1zHx2FZCYyJt5T5unkTE39svm8vNk8UtX6RZ4XLOClMeM0poRURERETkgcxWC13WTmPZpeP8+5zihGTW3eTCitb9aeBfJvMDlMeWHgIlIiIiIiIPNObgOpZdOg6AkUIds2Fl/ZWQzAtKBCW0IiIiIiLyAGarhYnHtiaZmf03EzDx+FbMVktmhCUCpGPJ8TvvvGNXh1988YVd94uIiIiISObZGno20Z7ZlBjA1egItoaepan20EomSXNCu2TJEgBcXV3TdJ/Fcu83NUpoRURERESyj/DY6AytL2KPdB8KdfTo0TTVDwwMTG9XIiIiIiLiJH6e3hlaX8QeOuVYRERERESSFW+1sODC4VTVNQH+3j408C+dsUGJ3CfNCe327dvT1VF67xMRERERkcwXHhvFsxt+Yc0/p1JV3wCGVGiAu0vatiaK2CPNCa2fn1+6OkrvfSIiIiIikrkO37xC57XTCYkIA6BqnkLk98rJ+qtnMJH40T0JX7cvVpF3qzVzQrTyONOSYxERERERsVlw/hC9N83mbnwcAN1KVWNaw2fxdHVj7MH1TDy+lavREbb6/t4+DKnQgHerNdPsrGQ6hyW0x44dY9euXVy7do24uLgk10eMGOGorkRERERExMGshpVRB9bw3wOrADBhYlStYP5TrQUm072n0I6s0ZJ3qzVja+hZwmOj8fP0poF/aSWy4jR2J7RxcXEMHTqUVatWPbCeEloRERERkawpwhxDn01zWPj/D4DycfdkVuOedCxROUlddxdXPWdWsgwXexuYOHEiq1atolatWomS2tWrV1O1alU6dOjA7t277e1GREREREQywJk7N6i3dIItmS3vm5+dHV5PNpkVyWrsTmiXLl0KwPvvv0/JkiVt5SVKlGDYsGEsXbqU6dOn29uNiIiIiIg42OrLJ3liyXiO3AoFoE3RQHZ1eIOKefydHJlI6tid0IaG3hv8AQEB9xp0udekxWKhcuV7v9VZuHChvd2IiIiIiIiDGIbB10c20Wb1z9yMiwZgeJWmLG3Znzye3k6OTiT17E5oCxYsCMCdO3cA8PX1BeD27du4ud3bonvjxg17uxEREREREQeIjjfzwuY5vL1rMVbDwMvVjd+a9GLsEx1wdbE7PRDJVHaP2Bo1agD3TjkGqFKlCgC7du1i586dABQrVszebkRERERExE6X7t6i8fKJ/HJmLwDFc+ZhS7tX6VGmppMjE0kfuxPanj17AjB16lQA+vbti8lkYujQoQwZMgSAF154wd5uRERERETEDttCzxG0ZDx7blwCoJF/afZ0fIPa+TX5JNmX3Y/tCQoK4uDBg7ZnUzVq1Igff/yR+fPnYzKZaNWqFR07drQ7UBERERERSZ/JJ3fyyvY/MVstALxcoR7f1OmMh6vd6YCIU9k9gj/99FMMw2DkyJG2sqZNm9K0aVN7mxYRERERETuYrRbe2rmIice3AeBmcuG7J59iUIV6To5MxDHsTmjnzJlDXFwcI0aMsM3SioiIiIiIc12PiaT7+plsvBoCQEGvXMxv/gIN/Us7OTIRx7F7D23C43ouX75sdzAiIiIiImK/A2GXeWLJeFsyWytfUfZ0fFPJrDxy7E5oX3/9dVxcXGyHQomIiIiIiPP8HnKA+n99x/nImwD0LFOTLe1epXiuPM4NTCQD2L3k+OzZs7Rs2ZJZs2Zx7NgxnnzySXLnzp2kXt++fe3tSkREREREUmCxWvlg/wpGH1wHgIvJxNja7RlapYm2Bsojy+6EdvTo0bY/79u3j3379iVbTwmtiIiIiEjGuB0XTc+Ns1h26TgAeTy8mdP0eYKLBjo5MpGMZXdCu3DhQgeEISIiIiIi6XHi9jU6r53GidvXAaiYuyCLWrxI+dwFnByZSMazO6GtWLGiI+IQEREREZE0WnbxGD02zuKOOQaATsUr80vjHvh6eDk5MpHMoScpi4iIiIhkM4ZhMPbQev6zdzkGBgAfVG/Jf2u2xsVk97mvItmGwxLaY8eOsWvXLq5du0ZcXFyS6yNGjHBUVyIiIiIij62o+Dj6bZnL72cPAJDTzYMZjZ7j6VLVnBuYiBPYndDGxcUxdOhQVq1a9cB6SmhFREREROxzPjKcLmuncyD8HwBK5crLohYvUs2viJMjE3EOu9cjTJw4kVWrVlGrVq1ESe3q1aupWrUqHTp0YPfu3fZ2IyIiIiLyWNt49QxBi8fbktnmhcuxu+ObSmblsWZ3Qrt06VIA3n//fUqWLGkrL1GiBMOGDWPp0qVMnz7d3m5ERERERB5LhmHw/bGttFzxEzdi7wLwRqVGrGz9Evm9cjo5OhHnsjuhDQ0NBSAgIOBegy73mrRYLFSuXBnQo31ERERERNIj1hLPwG3zGLJjAfGGFQ8XV6Y1fJZv6nbGzcXV2eGJOJ3dCW3BggUBuHPnDgC+vr4A3L59Gze3e1t0b9y4YW83IiIiIiKPlatRd2i+4kcmn9wJQGFvXza1e4W+5Z9wcmQiWYfdCW2NGjWAe6ccA1SpUgWAXbt2sXPnvb98xYoVs7cbEREREZHHxu7rFwhaMp5t184BULdACfZ0eoO6BUo++EaRx4zdCW3Pnj0BmDp1KgB9+/bFZDIxdOhQhgwZAsALL7xgbzciIiIiIo+FX07vpdHy77kcdRuAF8s/wYY2L1MkR24nRyaS9dj92J6goCAOHjyIyWQCoFGjRvz444/Mnz8fk8lEq1at6Nixo92BioiIiIg8yuINK+/tX863J7YB4Gpy4es6nXi1YgPbz9oikpjdCS2Ap6dnoq+bNm1K06ZNHdG0iIiIiMgjLzw2ijfObmRn5FUA8nnmYG7T3jQvUt7JkYlkbQ5JaAHOnz/P+vXruXjxIgDFixenefPmlChRwlFdiIiIiIg8co7cvErH1VM4e/cmANXyFmZhi76U9snn5MhEsj67E1rDMBg3bhzTp0/HarUmujZ27Fj69u3L8OHDtUxCRERERORfFp4/TO9Ns4mMjwXgqeKVmdmkJ7ncPR9yp4iAAxLayZMnM3XqVHLnzs3bb79N/fr1Adi2bRtfffUVU6dOJV++fAwYMMDuYEVEREREHgVWw8qoA2v474FVtrKX/avxRf1u5FAyK5Jqdie0s2fPBuC///0v7dq1s5WXKFECHx8f3n77bWbPnq2EVkREREQEiDDH8MKmOSy4cBgAH3dPpjz5NGVuG1rVKJJGdie0169fB+6dbvxvjRs3BuDatWv2diMiIiIiku2duXODzmunceRWKADlffOzqMWLlPL05ejto06OTiT7sfs5tKVKlQIgIiIiybU7d+4AUKZMGXu7ERERERHJ1tb8c5Inloy3JbNtigayq8MbVMzj7+TIRLIvuxPaN954AxcXF37++eck1yZPnoyLiwtvvvmmvd2IiIiIiGRLhmHw9ZFNBK/6mZtx0QAMr9KUpS37k8fT28nRiWRvaV5yPH369CRlLVq04LfffuPYsWPUq1cPgO3bt7N//35at27N+fPn7Q5URERERCS7iYk3M2jbPGae2QuAl6sbUxo8Q8+ytZwcmcijIc0J7ejRo1O8tn//fvbv35+obNWqVaxatYq+ffumOTgRERERkezq8t3bPLVuOrtvXASgeM48LGjel9r5izk5MpFHR5oT2oULF2ZAGMmzWq38+uuvLFiwgNDQUAoVKkS3bt3o0aPHQ0+Ai4mJYcWKFSxfvpxTp07h7u5O2bJl6devH0FBQQ7tS0RERETkfttCz/H0+hlcjb53zkxD/9LMb9aHgt4+To5M5NGS5oS2YsWKGRFHsv73v/+xYMECPvvsM4KCgti5cycjRozgypUrDB069IH3jhkzhkWLFjF48GBGjhyJ2Wxm5syZ9OrVi48//pjnnnvOYX2JiIiIiCSYcnInL2//E7PVAsDgwHqMr9sZD1e7HzAiIv+SZf9WnThxgt9++423336btm3bAtChQwfOnj3LDz/8QLdu3ShZsmSK9xcpUoR58+ZRtmxZW9l///tfjh8/zpdffkm3bt1wc3NzSF8iIiIiImarhbd3Lea7Y1sBcDO58N2TTzGoQj0nRyby6ErzKcdTpkxhypQpae4orfetXLkSwzBo06ZNovJ27dphsVhYuXLlA+8fOHBgomQ2Qfny5blz5w7h4eEO60tEREREHm/XYyJpvXKSLZkt6JWL9W1fVjIrksHSPEM7btw4APr375+h9x07dgwPDw+KFy+eqLxUqVK4ublx/PjxNPUPEB8fz86dO8mZMyd58+bN0L5ERERE5PFwIOwyXdZN53zkTQBq5SvKwuYvUjxXHucGJvIYSPeS47/++suRcSRx8+ZNfH19kxzI5OrqSq5cuRLNsKbWzz//zPnz5xk8eDDu7u4O68swDKKjo9McT0aLiYlJ9H+RjKKxJplJ400yi8aapMb8C4cYtHMBURYzAM+WrMbEJzqTw9UjTT8farxJZsnKY80wjDQfyJvuhPbtt99O762p9qAXYxhGmtpas2YN3377LdWrV2fIkCEO7Ss2NpajR4+mKZ7MFBIS4uwQ5DGhsSaZSeNNMovGmiTHYlj58eohpl2/9zOgCyZeK1yd530rcO7k6XS3q/EmmSWrjjUvL6801U9zQvvzzz+n9ZZ08fX1JSIiIkm5YRjcvXuX3Llzp7qtLVu28NZbbxEYGMikSZPw8PBwaF+enp7J7td1tpiYGEJCQihTpkyaB4ZIWmisSWbSeJPMorEmKbkdF8OLO/5gxfWTAOR292JG/WdoXbh8utvUeJPMkpXH2pkzZ9J8T5oT2saNG6e5k/QoX748Gzdu5OrVqxQqVMhWfunSJcxmM+XLp+4bxs6dOxkyZAilS5dm2rRp5MmTx+F9mUwmvL29U/fCnMDLyytLxyePDo01yUwab5JZNNbkfiduX6Pz2mmcuH0dgIq5C7KoxYuUz13AIe1rvElmyYpjLa3LjSEdpxxnlhYtWgCwbt26ROVr164FoFWrVg9tY9++fQwePJgSJUowffr0RAdBObovEREREXm0Lbt4jDpLvrUlsx2LV2JHh9cdlsyKSNpl2YS2Vq1atGrVigkTJnDw4EEA9u/fzw8//EDnzp2pUKGCrW5oaChBQUF8+OGHtrIjR44wcOBAihUrxowZM/Dz83NIXyIiIiLyeDEMgzEH19FhzVTumO8dpPNB9ZYsbNEXX4+stWRT5HGT7kOhMsPnn3/OV199Rf/+/YmNjcXb25uuXbvy1ltvJapnGAYRERFERUXZyn766SciIiKIj4+ndevWSdqeNWsWgYGBae5LRERERB4fUfFx9Nsyl9/PHgAgh5s7Mxo9R7dS1Z0bmIgAYDLSelywk0RHR6e4xjshoXV3d7fViY6Oxmw2p9hezpw5cXV1TXNf/3bkyBEAKleunKr6mSk6OpqjR49SqVKlLLc+Xh4tGmuSmTTeJLNorMn5yHCeWjuD/eGXASiVKy+LWrxINb8iDu9L400yS1Yea+nJrbL0DO39HvRmm0wmfH19k9RP7weU1T5YEREREclcG6+eodu6mdyIvQtA88Ll+L1pb/J75XRyZCJyv2yT0IqIiIiIZDTDMPjh+Dbe2LmIeMMKwBuVGvHFEx1wc0l+dZ+IOI9DE9qzZ89y9epVzGZzpj3eR0RERETEEeIs8by6YwE/n9wJgIeLKz/V70bf8k84OTIRSYlDEtpNmzbx6aefcu7cOVvZiRMn6NevHydOnGD69Ompfm6siIiIiEhmuxp1h6fXz2TbtXMAFPb25c/mL/BkwZLODUxEHsjux/bs2rWLl19+mRs3bjBs2LBE19q0acONGzeYM2eOvd2IiIiIiGSIPTcuErRkvC2ZrVugBHs6vaFkViQbsDuhnTBhAvHx8YwaNYoBAwYkula7dm0ANm7caG83IiIiIiIO9+uZvTRcNpHLUbcB6FsuiA1tXqZIjtxOjkxEUsPuJceHDh0CoFGjRkmuFStWDICrV6/a242IiIiIiMPEWy28t2cZXx65N/HianLhqzodea1iQ0wmk5OjE5HUsjuhTXiMbXJ/8e/evXfMuZeXl73diIiIiIg4RHhsFM9t+JXV/5wEwM8zB3807U3zIjrzRSS7sXvJccJhTwkPwb1fwuxtxYoV7e1GRERERMRuR25epc6S8bZktlrewuzp+IaSWZFsyu6E9tlnnwVg7NixXLt2zVZ+69Ytxo8fD0DPnj3t7UZERERExC6Lzh/myaUTOBMRBsDTJauytf2rlPbJ5+TIRCS97F5y3L17dw4dOsTvv/9O06ZNbeWNGjUiLi6O3r1707ZtW3u7ERERERFJF6th5X9/r+Gj/atsZaNqtmFE9RbaLyuSzTnkObSffPIJrVu3ZsmSJZw5cwbDMChVqhSdO3emcePGjuhCRERERCTNIswxvLBpDgsuHAbAx92TXxv3pFOJyk6OTEQcwe6EtmrVqhiGweHDh2nYsKEjYhIRERERsVtIRBid10zj8K17T9wo55OfxS1fpGIefydHJiKOYndCmyNHDm7dukVMTIxOMxYRERGRLGHNPyd5dsOvhMdGARBcNJDZTXqR1zOHkyMTEUey+1CohOfPJpxoLCIiIiLiLIZh8PWRTQSv+tmWzA6r0pS/WvZXMivyCLI7of3Pf/5D5cqV+e9//8uJEyccEZOIiIiISJrFxJvpu3kOb+9ajNUw8HJ1Y1bjnox7ogOuLnb/2CsiWZDdS4579uyJxWLhwoULdOrUCT8/P3Lnzp2k3ooVK+ztSkREREQkWZfv3qbruunsunERgGI5crOwxYvUzl/MyZGJSEayO6H19fUFIG/evHYHIyIiIiKSVtuvnaPruhlcjY4AoKF/aeY164O/t4+TIxORjGZ3Qjt37lxHxCEiIiIikmZTTu7kle1/Eme1ADA4sB7j63bGw9UhT6cUkSxOf9NFREREJNsxWy28vWsx3x3bCoCbyYUJT3ZhcIX6To5MRDKT3QntokWLUlWvc+fO9nYlIiIiIsKNmLt0Xz+TDVfPAFDAKyfzm71Ao0JlnByZiGQ2uxPa4cOHp6qeEloRERERsdeBsMt0WTed85E3AaiVrygLmvelRC6d5yLyOLI7oZ02bVqSspiYGHbv3s3MmTNp3749Xbp0sbcbEREREXnM/XH2b/pumUNUvBmAnmVq8nOD7uRw83ByZCLiLHYntPXrJ79PoXnz5hQqVIjPPvuMhg0b2tuNiIiIiDymrIaVD/at5LODawEwYWJsUDveqdIUk8nk5OhExJky9AnT7du3B+CHH37IyG5ERERE5BF1Oy6azmun2ZLZ3B5eLGvVn2FVmymZFZGMPeXYw+Pe8o+LFy9mZDciIiIi8gg6cfsanddO48Tt6wBUzF2QRS1epHzuAk6OTESyigxNaH/77TcAihUrlpHdiIiIiMgjZvmlY/TYOIvbcTEAdCxeiV8b98TXw8vJkYlIVmJ3Qtu/f/9kyy9dusS5c+cAeOWVV+ztRkREREQeA4ZhMO7Qet7fuxwDA4CR1Vvycc3WuJgydLeciGRDdie0p06dSlLm4uKCn58fHTp0oE+fPlSvXt3ebkRERETkEWK2Wtgaepbw2Gj8PL1p4F8as9VC/y1zmXP2AAA53NyZ0eg5upXSz5Iikjy7E9pNmzY5Ig4REREReQyYrRbGHFzHxGNbCY2JtJUX8MqJm8mFK9ERAJTKlZdFLV6kml8RZ4UqItlAhu6hjY6OxtvbOyO7EBEREZFswmy10GXtNJZdOs6/zye+HnPX9ucm/mWY1/wF8nvlzNwARSTbsXsjws2bNxk7diyTJk2ylW3fvp0GDRpQo0YNBg8eTExMjL3diIiIiEg2N+bgOpZdOg7w/3fHJq9Z4XJKZkUkVexOaKdMmcLUqVNxc7s32RsfH897771HxYoVKVasGOvXr2fmzJl2ByoiIiIi2ZfZamHisa1JZmb/zQT8eGI7ZqslM8ISkWzO7oR23bp1ADRv3hyA/fv3kyNHDiZPnsznn38OwJIlS+ztRkRERESysa2hZwmNiXzgzCzcm7m9Gh3B1tCzmRGWiGRzdie0ly5dAqBIkXsb9vfv30/dunUBqFSpEgCXL1+2txsRERERycbCY6MztL6IPJ7sTmh9fX0BCAsLA+DAgQO2RDYqKgoADw8Pe7sRERERkWzsjjltCaqfpw4WFZGHszuhrVmzJgDfffcd69atY+vWrTRo0ACAkJAQAMqXL29vNyIiIiKSDVkNK18f2cSgbfNTVd8EFPL2oYF/6YwNTEQeCXY/tufVV19l9+7dzJs3j3nz5tG7d2+KFi0KwOLFiwHo1KmTvd2IiIiISDZzLiKcvlvmsPHqvUkOEw8+3Zj/f31IhQa4u7hmdHgi8giwO6ENDAxk2bJl7Nu3j7x581K7dm3btYoVKzJ8+HA6dOhgbzciIiIikk0YhsH007t5Y+ciIsyxAJT1yceUBt35/PBG/rp0LElym/B1+2IVebdaMydELSLZkd0JLYCfnx8tW7ZMUt6lSxe8vbX/QURERORxERodwcCt81h88YitbHBgPT5/ogO53D2p71+asQfXM/H4Vq5GR9jq+Hv7MKRCA96t1kyzsyKSanYntDdv3mTSpEnkzZuXgQMHArB9+3beeecdbty4QbNmzfjmm2/w8vKyO1gRERERyboWnD/EoG3zuB5zF4DC3r5MadidtsUq2uq4u7gyskZL3q3WjK2hZwmPjcbP05sG/qWVyIpImtl9KNSUKVOYOnUqbm73cuP4+Hjee+89KlasSLFixVi/fj0zZ860O1ARERERyZpux0XTd/Mcuq6bYUtmny1dg8NPvZMomb2fu4srTQuXo2upqjQtXE7JrIiki90J7bp16wBo3rw5cO85tDly5GDy5Ml8/vnnACxZssTebkREREQkC1r3zymqLvySGaf3AJDXw5vZTXoxp+nz+HnmcHJ0IvKos3vJ8aVLlwAoUqQIcC+hrVu3LoDtebSXL1+2txsRERERyUKi4828v3cZ449utpUFFw1kSoNnKJoztxMjE5HHid0Jra+vL9evXycsLIzChQtz4MABmjZtCkBUVBQAHh4e9nYjIiIiIlnEnhsX6b1pNsdvXwMgh5s7Xz7RkUGB9TCZTE6OTkQeJ3YvOa5ZsyYA3333HevWrWPr1q00aNAAgJCQe88cK1++vL3diIiIiIiTma0WPt6/iieXTrAls/UKlOTvzkMZXKG+klkRyXR2z9C++uqr7N69m3nz5jFv3jx69+5N0aJFAVi8eDEAnTp1srcbEREREXGi47eu0Xvzb+y5cW+7mbuLKx/XbM2wKk1x04FOIuIkdie0gYGBLFu2jH379pE3b15q165tu1axYkWGDx9Ohw4d7O1GRERERJzAaliZcHQr7+39ixhLPABV8hTil8Y9qJGvqJOjE5HHnd0JLYCfnx8tW7ZMUt6jRw9HNC8iIiIiTnAh8iYvbvmddVdOA2DCxLAqTfikVhs8XR3yY6SIiF0c9p1o+/btbNiwgatXr2I2m/n+++/ZuHEjZrOZJk2a4O7u7qiuRERERCQDGYbBzNN7eH3nIu6YYwAoncuPGY2eo1GhMk6OTkTk/9id0JrNZoYOHcrKlStxdXXFYrHYri1evJilS5fyzTff0LZtW3u7EhEREZEMdi06gkHb5rPwwmFb2UsBdfmyTkd83L2cGJmISFJ2n3L8008/sXLlSurVq8eOHTsSXXv66acBmD9/vr3diIiIiEgGW3T+MFUXfmlLZv29fVjash+TGnRXMisiWZLdM7SLFi0C4L333sPX1zfRtbJlywJw8OBBe7sRERERkQxyJy6GN3ctYtqp3baybqWq8UO9p8nvldOJkYmIPJjdCe2VK1cAKFMm6X6KvHnzAhAVFWVvNyIiIiKSATZcOU3fLb9zPvImAHk8vJn45FP0KFNTz5UVkSzP7oTWx8eH8PBwbt68ib+/f6JroaGhABQoUMDebkRERETEgWLizfxn33K+PrLJVtaySHmmNXyWYjnzOC8wEZE0sHsPbd26dQFYuXJlkmurV68GoH79+vZ2IyIiIiIOsvfGJWov+caWzHq7uvPdk0+xsvVLSmZFJFuxe4Z2yJAhbNiwgc8//5w7d+7YyqdNm8Y333xDrly5GDRokL3diIiIiIid4q0WRh9cxycHVhNvWAGoW6AEMxv1ICC3VtSJSPZj9wxt+fLlmTx5MoULF2bChAm28jFjxuDv78+UKVMoUaKEvd2IiIiIiB1O3L5Gg7++48P9K4k3rLiZXPhfrTZsaTdEyayIZFt2z9D++eefWK1WVqxYwd9//82ZM2cwDIPSpUtTo0YN3Nzs7kJERERE0slqWJl4bBvv7vmLaIsZgEp5/PmlUQ9q5S/m5OhEROxjd7b5wQcfEB8fT7du3ahZsyY1a9Z0RFwiIiIiYqeLkbfot/V31vxzCgATJt6u3Jj/1WqDl5u7k6MTEbGf3QltsWLFOHfuHNevX9dpxiIiIiJZgGEYzArZx6s7FnA7LgaAkrnyMqPRczQpVNbJ0YmIOI7de2j79u0LwNKlS+1tSkRERETsdCPmLt3Xz6T3ptm2ZLZ/+Toc7DxUyayIPHLsnqEtU6YMbdq04YsvvuDChQvUq1eP3LlzJ6mX8HgfEREREckYSy8eZcDWPwiNjgCgoFcufm7QnU4lKjs5MhGRjGF3QtunTx/bn3/77Td+++23ZOudOHEizW1bLBZmzpzJn3/+ybVr1yhUqBDdunXj+eefx2QyPfT+CxcusHz5cpYvX8758+fp1q0bI0aMSFIvLCyMli1bJtvGoEGDGDx4cJpjFxEREcksEeYY3t61hMknd9rKnipRhZ8adKOAVy4nRiYikrHsTmhHjx7tiDiS9cknn7B48WLGjRtH7dq12blzJ++//z5Xrlxh+PDhD7w3KiqK/v3706ZNG95991369u1LbGxssnWtVitRUVG89dZb9O7dO9E1d3cdmCAiIiJZ16arZ3hh8xzORd4EwNfdi++efIrny9ZK1QSAiEh2ZndC27VrV0fEkcTx48f5/fffGTp0KK1atQKgbdu2hISEMHHiRJ555hlKlSqV4v05cuRg9erVAISHh6eqT3d3d3LmzGl37CIiIiIZLSbezAf7V/Dl4U0YGAA0L1yOaQ2fpUSuvE6OTkQkc9h9KFSCuLg4duzYwR9//MEff/zBjh07iIuLS3d7K1euxDAM2rRpk6i8TZs2WCwWVq5caW/IIiIiItnS/rDLBC35hi8Ob8TAwMvVjfF1O7M6eKCSWRF5rNg9QwuwaNEixowZk2Qm1M/Pj/fff59OnTqluc1jx47h4eFBsWKJH/hdqlQp3NzcOH78uF0xJ2fatGlMmjQJNzc3ypcvT48ePQgODnZ4PyIiIiLpEW+1MO7QBv57YBVmqwWAoPzF+KVRTyrkKejc4EREnMDuhHbZsmUMHz4cV1dXnnvuOerXrw/Atm3b+OOPPxg2bBhubm60a9cuTe3eunULX1/fJHs/XF1dyZUrFzdv3rQ3dBuTyUSrVq3o1asX5cqV48aNG8ycOZPXX3+dIUOG8Prrrz/wfsMwiI6Odlg8jhITE5Po/yIZRWNNMpPGm2SWrDbWTkeEMWDHfHaFXQTA1eTC+5WbMqxSY9xdXLPkzyKSelltvMmjKyuPNcMw0rz33+6E9ocffgBg2LBhvPjii7by4OBgSpYsydixY/nhhx/SnNACD3wxhmGkPdgU5M+fn++++872dYECBRg9ejS3b9/mxx9/5Omnn6Zo0aIp3h8bG8vRo0cdFo+jhYSEODsEeUxorElm0niTzOLssWYYBvPCTjP+yn5ijHuzsqU8ffmk+JNUcsnHqeNpf5KEZF3OHm/y+MiqY83LyytN9e1OaM+ePQuQ7LLizp07M3bsWM6dO5fmdn19fYmIiEhSbhgGd+/eTfZZt44WHBzM2rVr2bdv3wMTWk9PT8qWzXoPKo+JiSEkJIQyZcqkeWCIpIXGmmQmjTfJLFlhrF2OusPLuxaw5uppW9mrAfX4uForvN30JIZHSVYYb/J4yMpj7cyZM2m+x+6E1t/fn0uXLj20TloFBASwceNGrly5QuHChW3lFy9exGw2ExAQkOY208rN7d7bY7FYHljPZDLh7e2d4fGkl5eXV5aOTx4dGmuSmTTeJLM4Y6wZhsGcswd4Zfuf3Iq7t5S4RM48TG/0HM0Kl8vUWCRz6XubZJasONbS86gxu0857tOnDwCLFy9Ocm3RokUA9O3bN83ttmjRAoB169YlKl+7di0ALVu2THObabVx40YAqlWrluF9iYiIiACExdzluQ2/0nPjLFsy27dcEAe7DFUyKyLyL3bP0FaoUIHg4GA+//xzzp8/n+hQqLlz5xIcHEz58uXZuXNnovvq1q37wHZr1qxJcHAwEyZMoFKlStSsWZM9e/bwww8/0LVrVypUqGCrGxoaSps2bWjXrh2ffvppml/DxIkTyZMnD82aNaNw4cKEh4czc+ZMFi1axHPPPUeZMmXS3KaIiIhIWi27eIz+W+dyNfretqsCXjmZVL87XUpWcXJkIiJZk90JbcIMLcDs2bOZPXt2ousrV65M9pmxJ048/ACDcePGMX78eAYPHkxkZCS+vr48++yzvPbaa4nqGYZBVFQUsbGxicqfe+65RP3Mnz+fJUuWAPD555/bZnmffvppZsyYQZ8+fbh69SpWq5WAgAA++ugjnnvuuYfGKSIiImKPSHMsQ3ctYdLJHbayziUqM6l+Nwp6+zgxMhGRrM3uhHb06NGOiCNZXl5evPvuu7z77rvExcXh4eGRbD1/f3/27duHu3viwxGmT5+e4v7X+zdAFypUyNaP2WzGzc0tXeu3RURERNJqa+hZ+myeQ0hEGAA+7p58W7cLL5QL0s8jIiIPYXdC27VrV0fE8VApJbNwb/Nwzpw5k5Sn59SufyfFIiIiIhkh1hLPR/tXMu7QBgzuPY6waaGyTG/0LCVz+Tk3OBGRbMLuhFZERERE0ubv8H/ovWk2h25eAcDT1Y0xtdvxeqWGuJjsPrNTROSxoYRWREREJJNYrFY+P7yBD/evxGy9ty2qdr5izGz8HJXyFHJydCIi2Y8SWhEREZFMcObODfpsnsO2a+cAcDW5MLJ6C0ZUb4m7i6tzgxMRyaaU0IqIiIhkIMMwmHRiB0N3L+FufBwAgbkL8EujHjxRoISToxMRyd6U0IqIiIhkkH+ibtN/y1xWXP6/xwi+XrEho4PakcMt5QMvRUQkdZTQioiIiGSA30MO8PL2+dyMiwagWI7cTG/0HC2KlHdyZCIijw4ltCIiIiIOFB4bxZDtfzLn7AFbWZ+ytRlftwt5PL2dF5iIyCMozQnt+vXr09VRs2bN0nWfiIiISHax4tJx+m2Zy5XoOwDk98zJT/W70bVUVSdHJiLyaEpzQjt48OB0dXTixImHVxIRERHJhu6aY3ln91J+PLHdVtaxeCUm1e9GoRy+ToxMROTRluaEduLEiRkRh4iIiEi2tC30HH02z+ZMRBgAudw8GV+3My+WfwKTyeTk6EREHm1pTmhbtmyZEXGIiIiIZCtxlnj+e2AVYw+tx2oYADT2L8P0Rs9S2iefk6MTEXk86FAoERERkTQ6FH6F3ptn83f4PwB4uLjyWe22vFW5MS4mFydHJyLy+HBYQhsVFcXhw4e5du0acXFxSa537drVUV2JiIiIOIXFauXLIxv5YN8K4qwWAGr6FWVm4+eokrewk6MTEXn8OCShnThxIpMnTyYqKirFOkpoRUREJDsLiQjjhc1z2BJ6FgAXk4n/VGvBB9Vb4uGqRW8iIs5g95qYWbNm8e233+Ln58f48eNt5d9++y2FChWiQ4cOzJo1y95uRERERJzCMAx+PrGDagu/tCWz5X3zs7Xdq4yq1UbJrIiIE9n9HXjOnDkAfPzxxzRs2NBWHhwcjMlk4rXXXuPJJ58kKCjI3q5EREREMtUNczRdN/3KyisnbWVDKtRnbFB7crp7OjEyEREBB8zQnjt3DoAaNWoA2I6nt1qtPPHEEwBMnz7d3m5EREREMtWfFw7z7MlltmS2aI7crGz9Et/V66pkVkQki7B7htbX15cbN25gsdw7GCFnzpxERkYSGRlJzpw5Abh48aK93YiIiIhkipuxUby2YyGzQvbZynqVqcWEJ7uQ1zOHEyMTEZF/s3uGtmLFigCcOnUKgPLlywNw7NgxTpw4AUD+/Pnt7UZEREQkw62+fJKqC7+0JbO5XT34tf6z/Nqkp5JZEZEsyO6E9tlnnwVg9uzZADz99NMADB06lNdeew2ATp062duNiIiISIa5a47l1e1/0nrVJC5H3QYguHAAvwe0o2uJKk6OTkREUmL3kuMWLVrw+++/4+rqCkD37t0JCwtj3rx5mEwm+vfvzyuvvGJ3oCIiIiIZYce18/TZPJtTd24AkNPNg6/rdKJX8WocO3bMydGJiMiD2J3Quri42A6ESjB48GAGDx5sb9MiIiIiGSbOEs+ov9fw2cG1WA0DgIb+pZnR6DnK+OQjOjrayRGKiMjD6MFpIiIi8tg5cvMqvTfNZn/4ZQA8XFz5X602vF25Ca4udu/IEhGRTJLmhHb9+vUANGvWLNHXD5NQX0RERMRZLFYr3xzdxIh9K4i1xANQ3a8IvzTqQVW/wk6OTkRE0irNCW3CUuKEE4xTu7Q4ob6IiIiIM5yLCOeFzXPYFBoCgIvJxLtVm/FRjdZ4umrRmohIdpTm794TJ0584NciIiIiWYlhGEw7tZs3di4iMj4WgLI++ZjZqAf1/Us5NzgREbFLmhPali1bPvBrERERkawiNDqCl7b+wZKLR21lL1eox7igDuRy93RiZCIi4gh2r68ZMWIEAJ9++mm6rouIiIikl9lqYWvoWcJjo/Hz9KaBf2ncXe49SvDPc4cYtG0eN2LvAlDY25epDZ+hTbEKzgxZREQcyO6Edt68eUDKCevDrouIiIikldlqYczBdUw8tpXQmEhbeSFvH/qVe4Lzd28xK2Sfrfy50jWYWK8rfp45nBGuiIhkkAw9ASHh+W3u7u4Z2Y2IiIg8RsxWC13WTmPZpeOY/nXtanQEnx1aZ/s6r4c339frynNlamZukCIikinSldBu2rTpoWVWq5WtW7cCUKZMmfR0IyIiIpLEmIPrWHbpOADGA+qV98nPhnYvUyRH7swJTEREMl26EtqXXnopVWUAnp6evPbaa+npRkRERCQRs9XCxGNbMfHgZBYgIj6WAl65MiMsERFxknQltF999ZXtz2+//XaSMgCTyUTu3LmpUqUKuXPrN6MiIiJiv62hZxPtmX2Qq9ERbA09S9PC5TI4KhERcZZ0JbTt27e3/fnYsWNJykREREQyQnhsdIbWFxGR7MXuQ6HeeecdR8QhIiIi8kCGYXDo5j9pusfP0zuDohERkazAIacc79mzh99//51Tp04RFRWFYSTd1bJ69WpHdCUiIiKPob03LvHWrkVsDj2bqvomwN/bhwb+pTM2MBERcSq7E9qlS5fyzjvvYBgGRYsWpUiRIphM/z5EX0RERCTt/om6zX/2LmfG6T22Mm9Xd6It5gfeZwBDKjTA3cU1gyMUERFnsjuh/e677zAMg9dee41XX33VETGJiIjIYy4qPo4vD29kzKF1RMXfS17dXVx5vWJD3q3ajBe3/M5fl44lOe044ev2xSrybrVmTohcREQyk90J7aVLlwDo06eP3cGIiIjI481qWJkdcoD39vzFpajbtvIuJaowLqg95XMXAGBBi76MPbieice3cjU6wlbP39uHIRUa8G61ZpqdFRF5DNid0BYtWpRz584RHx/viHhERETkMbX92jne2rWYndcv2Mqq+xXh6zqdaPavR++4u7gyskZL3q3WjK2hZwmPjcbP05sG/qWVyIqIPEbsTmgHDRrE+++/z4oVK+jZs6cjYhIREZHHyPnIcN7bs4w5Zw/Yyvy9ffi0Vhv6lnsCVxeXFO91d3HVc2ZFRB5jDpmh7dSpE6NHjyY0NJTatWvj6emZpF7dunXt7UpEREQeIZHmWMYcXMeXRzYSY7m30svT1Y23Kzfm/WrN8XH3cnKEIiKS1dmd0N6/d/bHH39Msd6JEyfs7UpEREQeAVbDyozTexixdwVXou/Yyp8pVZ2xQe0p5ePnxOhERCQ7sTuhHT16tCPiEBERkcfApqtneGvXYvaFXbaVBeUvxtd1OtNQz4wVEZE0sjuh7dq1qyPiEBERkUfYmTs3GL7nL/48f8hWVjRHbkbXbkevsjVxMaW8T1ZERCQldie097Nardy5cwez2UyBAgUc2bSIiIhkQ7fjovn077WMP7qZOKsFAG9Xd4ZXbcqwKk3J6Z703A0REZHUckhCe+7cOb766is2b95MVFQUcG/P7MiRI7ly5QqfffYZ/v7+juhKREREsoF4q4UpJ3fxwf4VXI+5ayt/vmwtRtduR7GceZwXnIiIPDLsXt8TEhJC9+7dWb16Nc2bN090rXjx4mzZsoW5c+fa242IiIhkE6svn6Tmoq8ZvH2+LZmtX7AUOzu8zi+NeyqZFRERh7E7of3666+5c+cO77zzDl9++WWia02aNAFg5cqV9nYjIiIiWdyJ29fouGYKrVdN4vCtqwCUzJWXOU2eZ0u7IdQpUMLJEYqIyKPG7iXHO3bsAKBLly5JrhUvXhyA8+fP29uNiIiIZFHhsVF8cmA1E49tJd6wApDLzZP/VG/Om5Ua4+3m7uQIRUTkUWV3QhsdHQ1Azpw5k1yzWO4d/uDm5tCzp0RERCQLMFst/Hh8O/89sIrw2HtnaJgw8WL5J/hfrTYUzuHr5AhFRORRZ3emWaJECc6cOUNISAiVKlVKdO306dMAlC6t58qJiIg8KgzDYNmlY7yzeynHb1+zlTctVJav6nSiZr6iToxOREQeJ3bvoW3fvj0A3333nW1GFu79Yzd58mQAOnXqZG83IiIikgUcvnmFNqt+psOaqbZktqxPPhY078u6NoOVzIqISKaye4Z2wIABbNu2jbVr19KiRQtbeZs2bTh37hz16tXj+eeft7cbERERcaLrMZF8tH8lP53YgdUwAPB19+KD6i15rVJDPF21vUhERDKf3f/6eHp6Mm3aNGbMmMGSJUu4cePGvYbd3Bg6dCh9+/bVHloREZFsKtYSz4SjW/jfwTXcjosBwMVkYlDgk3xcM5gCXrmcHKGIiDzO7M40n3nmGaxWK/PmzeOll15yREwiIiLiZIZhsPDCYYbtXsqZiDBbeesiAXxZpyNV8hZ2YnQiIiL32J3Qnj59mrt372I2m3F317H8IiIi2d3+sMu8vWsxG66esZUF5i7AV090om2xCphMJidGJyIi8n/sTmhr1qzJli1bCAkJITAw0BExiYiIiBNcjbrDiH0rmHZqNwb39snm9fDm45rBDK5QD3cXVydHKCIikpjdpxy///775M2bl7FjxxIREeGImERERCQTRceb+ezvtZSfP5app3ZhYOBmcuGNSo043e19XqvUUMmsiIhkSXbP0E6cOJHy5cuzdetWWrZsSeXKlcmdO3eSel9//bW9XYmIiIgDGYbB3LN/8+7evzgfedNW3qF4Rb54oiOBuQs6MToREZGHszuhXbNmDQAeHh5ERUWxe/duu4MSERGRjLXr+gXe2rWYbdfO2cqq5CnEV3U60apogPMCExERSQO7E9pDhw45Ig4RERHJBJfu3uL9vcv49cw+W1kBr5yMqtmG/gF1cNPSYhERyUay9ANi4+PjmTx5MgsWLCA0NJRChQrRrVs3+vXrh4vLw7f/njp1iuXLl7N8+XLOnz/Ps88+y0cffZQhfYmIiGRld82xfH54A+MObSDaYgbAw8WVNyo1YkT1FuT28HZugCIiIungsIT22rVrbNu2jatXr2I2m3nttde4fPkyhmFQrFixdLX54YcfsmrVKr788kuCgoLYuXMnQ4cO5erVq4wcOfKB90ZFRfHmm2/Stm1bRo0aRa9evbBYLBnSl4iISFZlNazMOrOf9/cu43LUbVv50yWrMjaoPWV98zsxOhEREfs4JKH9/vvv+f777zGbzbay1157jZEjR7Jt2zZmzJjBk08+maY2jx49yvz583nvvfdo0qQJAM2bN2fQoEGMHz+enj17UqZMmRTvz5EjB3/99RcA4eHhGdqXiIhIVrQ19Cxv7lrEnhuXbGU1/Yrydd1ONClU1omRiYiIOIbda2nnzZvH+PHjKV68OLNmzUp0rUePHgD8/vvvaW535cqVALRq1SpReevWrbFarbbrjpCZfYmIiGS0cxHhPLv+Fxoum2hLZgt5+zC14TPs7viGklkREXlk2D1DO3PmTAA+/vhjgoKCEl2rWLEiQLpOPj5x4gSenp5JliuXKlUKNzc3Tpw4kc6InduXiIhIRokwxzD64Dq+OrKJWEs8AF6ubgyt3IT3qjUnl7unkyMUERFxLLsT2pCQEACqVq2a5Jq/vz8AN2/eTHLtYW7duoWPj0+SchcXF3LlysWtW7fS3GZG9WUYBtHR0Q6Lx1FiYmIS/V8ko2isSWbSeEvKYrUy8+w+Pj60lmsxkbbyZ0pUZVT11hTPmQfirUTHZ71/q7IyjTXJTBpvklmy8lgzDAOTyZSme+xOaL28vDCbzcTExODtnfiExIRENnfu3Olq+0EvxjCMdLWZEX3FxsZy9OhRh8bjSAm/dBDJaBprkpk03u7ZExnKV//s42TMLVtZlRz5eLtwLarlzE/E+X84yj/OC/ARoLEmmUnjTTJLVh1rXl5eaapvd0JbrVo1tm7dyvbt22nXrl2ia9u3bwegdu3aaW43d+7cySaJVquVu3fvkidPnnTFmxF9eXp6UrZs1tuPFBMTQ0hICGXKlEnzwBBJC401yUwab/eciQjjPwdWsuTyMVtZUW9fRlVvzTMlq+Ji0iPn7KWxJplJ400yS1Yea2fOnEnzPXYntC+99BLbtm3j008/xdPz//bmbN++nS+++AJXV1f69++f5nYDAgLYsGEDly9fpmjRorbyCxcuYDabCQgIsDd0h/VlMpmSzE5nJV5eXlk6Pnl0aKxJZnpcx9ut2Gj+9/cavj22BbP13uPocri5817V5gyt0oQcbh5OjvDR87iONXEOjTfJLFlxrKV1uTE44JTjevXqMWrUKCIiInjllVds5X379iUiIoLPPvuMGjVqpLndhBOH165dm6h89erVmEwmWrdubVfczupLREQkPeKtFr4/tpXy88fw5ZGNtmT2hXJBnOz6Hh/UaKVkVkREHjtpnqE9f/48ACVLlrSVde/enWbNmrFq1SpCQkIwDINSpUoRHBxMwYIF0xVYtWrV6NChA9999x0BAQEEBQWxc+dOfvzxR5555hnKly9vqxsaGkqzZs3o2LEjY8eOzdC+REREMtvKyyd4e9dijt4KtZU19C/N13U6EZS/uBMjExERca40J7QJs5UJj7IZNGgQAD/99BM9e/Z0YGgwevRoJk6cyPDhw7lx4wYFCxbkxRdfZPDgwYnqGYaBxWLBYrEkKu/atSvHjx+3fT137lzmzZsHwDfffJNo5jW1fYmIiGSWY7dCeWf3EpZd+r9/y0rlysvnT3Tg6ZLV0rU0S0RE5FGS5oTW3d0ds9lMfHw8bm5ubNiwIQPCusfDw4O33nqLt95664H1ChUqxJEjR3BxSbyC+o8//kjxhGJXV9d09SUiIpLRwmLu8t8Dq/jh+HYshhUAH3dPRlRrwRuVGuHl5u7kCEVERLKGNCe0xYsXJyQkhNWrV9OoUSNb+d27dx94X86cOdMeXRq4uSV9Kf9OWkVERLKyOEs83x/fxscHVnMr7t4zY11MJvqXr8OoWm3w9076zHQREZHHWZoT2n79+jFy5EjefPPNROW1atV64H0JS5RFREQkMcMwWHrxKEN3L+HUnRu28uaFy/FVnU5U9yvixOhERESyrjQntN27dycwMJBt27Zx48YNfvnlFwB69erl8OBEREQedQfD/+HtXUtYe+WUray8b36+eKIjHYtX0j5ZERGRB0hzQhseHk6xYsVshyUlJLQffvihYyMTERF5hF2LjuCDfSuZfGon1v9/3kMeD28+rNGKIRXq4+Fq96PiRUREHnlp/teyXr16gJYQi4iIpEesJZ7xRzfzv7/XEGGOBcDV5MLLFerxUY3W5PfK2DMnREREHiVpTmjd3NyIj4/HYrHo0CUREZFUMgyDP88fYtjupZyNDLeVty1agS/qdKBSnkJOjE5ERCR7SnNCW7RoUc6fP8+OHTto0KBBRsQkIiLySNl74xJv71rMptAQW1nF3AX5qk4n2hSr4MTIREREsrc0J7Q9e/Zk9OjR9OvXL9EMbaVKlR5439GjR9MenYiISDb2T9RtRuxdzozTezG4t082n2cOPq4ZzKDAJ3Fz0UonERERe6Q5oe3bty+lS5e2nXK8dOlSAIKDgx0enIiISHYUFR/Hl4c3MvbQeu7GxwHg7uLKaxUbMLJ6S/J65nByhCIiIo+GdB2h2KRJE5o0aQJgS2i//vprx0UlIiKSDRmGwZyzB3h3z19cvHvLVt65RGU+D+pA+dwFnBeciIjII8juZwLMmzfPEXGIiIhkazuuneetXYvZcf28raxa3sJ8XacTzYuUd2JkIiIijy67E9qqVas6Ig4REZFs6ULkTd7fu4zfQvbbygp65eLT2m15sdwTuLq4ODE6ERGRR1uaE9pBgwYB8NNPPyX6+mES6ouIiDwKIs2xjD20ni8ObyDGEg+Ap6sbb1VqzPvVmuPr4eXkCEVERB59aU5oDx8+/MCvRUREHmVWw8rM03v5z97lXIm+YyvvXqoaY4PaU9onnxOjExERebykOaHdunXrA78WERF5VG2+GsJbuxazN+ySrax2vmJ8XacTjQqVcWJkIiIijye799CKiIhkd2arha2hZwmPjcbP05sG/qVxv+8ZsSERYQzfvZT55w/Zyork8GV07XY8X7YWLibtkxUREXEGhyS08fHxXL9+ncjISHx8fChQoACurnpYvIiIZG1mq4UxB9cx8dhWQmMibeWFvH14pUJ9XqlQn3GH1vPN0c3EWS0AeLu6M6xqU4ZXaUpOd09nhS4iIiLYmdAeO3aM77//ni1bthAVFWUrz5kzJ40aNeKVV14hMDDQ7iBFREQczWy10GXtNJZdOo7pX9dCoyP4cP9K/vf3GlsiC9CrTC1G125H8Vx5MjVWERERSV66E9o1a9bw5ptvYjab8fT0pGbNmvj6+nL79m2OHj3KihUrWL9+PRMmTKBJkyaOjFlERMRuYw6uY9ml4wAY/7qW8HVCMluvQEm+rtuJugVKZl6AIiIi8lDpSmjDwsJ4//33MZvNPPvsswwbNgwfHx/b9Tt37jBu3Dj++OMPhg8fzooVK8ibN6/DghYREbGH2Wph4rGtmEiazP5bbncvNrR9GQ9XHTshIiKS1aTrFIs///yTO3fuUL9+fT755JNEySyAr68v//vf/6hbty63bt1iwYIFDglWRETEEbaGniU0JvKhySzAbXMM266dy+iQREREJB3SldBu374dgF69ej2wXu/evQE92kdERLKWG7F301Q/PDY6gyIRERERe6Rr/dSpU6cAqFq16gPrVatWDYDTp0+npxsRERGHioqPY8bpPXz695o03efn6Z1BEYmIiIg90pXQ3r59GwA/P78H1kvYN5tQX0RExBlCoyOYeGwr3x/fRlhs1MNv+P9MgL+3Dw38S2dccCIiIpJu6UpoY2NjAXB3d39gPQ8PDwCio7VUS0REMt/RW1f56vAmfg3ZR6wl3lZeKldeKub2Z/nl4w+83wCGVGiAu4uerS4iIpIV6chGERF5pBiGwforp/ni8MYkCWud/MV5p0pTnipZBQN4au10/rp0LMlpxwlfty9WkXerNcu84EVERCRN7Epog4KCHBWHiIiIXcxWC7+fPcCXhzdyIPwfW7kJE51LVGZolSY0KFgKk8lku7agRV/GHlzPxONbuRodYSv39/ZhSIUGvFutmWZnRUREsrB0JbSlS6d+L1H+/PnT04WIiEiq3IqN5ueTOxh/dAuXo/7vzAZvV3f6lg/irUqNKZ+7QLL3uru4MrJGS96t1oytoWcJj43Gz9ObBv6llciKiMj/a+/O46qq9v/xv85hDkRUEAcGQTnKECJOKCaKs1nXNKLSPtebZjn1rbQyK29Zn1uaaN3S5usnzZ8DmpZhzogjqFcDERQnZJJBkHk8nPX7g9h5OoAchDPxej4e93HvWfu99lnHux4HXuy91iYj0KJAu2/fvtYeBxERkVZuld7F1wkH8F3KGZQqq6R2Z5sOWNgvGC/1GwZHa9tmnctCboZR3fu01VCJiIiojXANLRERGZVz+Rn44NZJHL6YDpX4c+Wrj4MzFvuG4FnPAbA2b3rTQiIiIjINDLRERGTwVEKFPWlJiLgUg+M5N9WOjenuhcV+IzGxZz+19bFERERk+hhoiYjIYJUrq7Hx2jmsuXQMV4vvSO1mkOEpd3+80T8UAV166nGEREREpE8MtEREZHByKkqwLvkk1l8+hfyqcqm9o6U1ZnsOwhh0weiAQbCxsdHjKImIiEjfGGiJiMhgJBVmY03iMfx44zyqapVSu7tdJ7zqMxLPKwbDXCmQlJSkx1ESERGRoWCgJSIivRJCIPr2NURcisHejMtqx4Y4umKxXwimuT8M8z8eo1OhrNDHMImIiMgAMdASEZFe1Khqsf1mPCISY3ChIFNql0GGx918sMRvFIK79uJGT0RERNQoBloiItKpouoKfHMlFv9OOoGM8iKp3cbMArO8BuEVn5FQdHTS4wiJiIjIWDDQEhGRTqSWFOCzpOP4LuUMSpVVUntXazss9A7GvH7D4Whtq8cREhERkbFhoCUiojZ1Ni8NEZeOYUdqAmqFSmr3cXDGa74jMcMzENbmFnocIRERERkrBloiImp1KqHCr+nJiEiMwbGcG2rHxnT3wmK/kZjQsy/kMrmeRkhERESmgIGWiIhaTbmyGhuvncPaS8eRUpwntZvL5HjaMwCLfUMQ0KWnHkdIREREpoSBloiIHlhORQnWJZ/E+sunkF9VLrV3tLTGXEUQXvYZARdbB/0NkIiIiEwSAy0REbVYcmEO1lw6hk3X/4uqWqXU7m7XCa/4PILZiiHoYGGtxxESERGRKWOgJSIirQghcDT7OiISYxCVkax2bLCjK5b4hWCa+8Mwl5vpaYRERETUXjDQEhFRs9SoarH9ZjwiEmNwoSBTapdBhsfdfLDYNwQjnD0gk8n0OEoiIiJqTxhoiYioSUXVFfjmSiz+nXQCGeVFUru1mTlm9RmMV31HQtHRSY8jJCIiovaKgZaIiBp0q7QAnyWdwHcpcSipqZLau1rbYaF3MOb1Gw5Ha1s9jpCIiIjaOwZaIiJSc+5OOiISYxCZmoBaoZLavTt2xWK/EMzwDIS1uYUeR0hERERUh4GWiIigEir8mp6MiMQYHMu5oXYstHsfLPYNwUSXvpDL5HoaIREREZEmBloionasQlmDjdfOYc2lY0gpzpPazWVyPO0ZgNd8QzCgS089jpCIiIiocQy0RETtUG5FCdZdPoX1yadwp6pMare3sMaLfYPwss8IuNg66G+ARERERM3AQEtE1I5cLszFmksx2Hj9v6iqVUrt7nad8IrPI5itGIIOFtZ6HCERERFR8zHQEhGZOCEEjmZfR0RiDKIyktWODXZ0xWLfEEzv9TDM5WZ6GiERERFRyzDQEhGZqBpVLSJvxiPiUgzO52dK7TLI8LibDxb7hmCEswdkMpkeR0lERETUcgy0REQmpqi6At9eicNnSceRUV4ktVubmWNWn8F41XckFB2d9DhCIiIiotbBQEtEZCLSSu/is6Tj+DYlDiU1VVJ7V2s7LPQOxrx+w+FobavHERIRERG1LgZaIiIjd+5OOiISYxCZmoBaoZLavTt2xWt+IZjpGQhrcws9jpCIiIiobTDQEhEZIZVQISo9GasTY3As54basdDufbDYNwQTXfpCLpPraYREREREbY+BlojIiFQoa7Dx2jmsTTqGK0V5Uru5TI5wjwAs9gvBgC499ThCIiIiIt1hoCUiMgK5FSVYf/kU1iWfwp2qMqnd3sIaL/YNwiLvEXC1c9DfAImIiIj0gIGWiMiAXS7MxZpLMdh4/b+oqlVK7W62DnjFdyRmew2BvaW1HkdIREREpD8MtEREBkYIgZjs61idGIOojGS1Y4MdXbHYNwTTez0Mc7mZnkZIREREZBgYaP+gVCobbJfL5ZDLuakKEbW9GlUtIm/GI+JSDM7nZ0rtMsjwmKsPFvuNxCPOnpDJZHocJREREZHhMOhAW11djS+//BK7du1Cbm4uunXrhunTp+PFF1+Eufn9h97c/nl5eRgxYgTkcrnGL4rz58/HwoULW/2zERHVK6quwHcpcfgs6QTSywqldmszc/y9zyC86jsSfTt21d8AiYiIiAyUQQfat99+GzExMfj3v/+NQYMGIS4uDi+//DJyc3Px/vvvt3r/JUuWYPbs2W3xUYiINKSV3sVnScfxbUocSmqqpHYna1ss9A7GvH7D4WRtp8cREhERERk2gw20Fy9exC+//IK3334bQUFBAIDg4GC89NJLiIiIwHPPPYc+ffq0WX8iIm3VqGpxMucmCqoq0NnKBsHOHrBoYJ3rf+9kIOJSDLbfjEetUEnt3h274jW/EMz0DIS1uYUuh05ERERklAw20B48eBAAMGbMGLX2cePGYfXq1Thw4ECTgfRB+xMRNVeNqhYfJxzBuuSTyKksldq72XTA/H7DsdQ/FGYyGaLSkxFxKQYx2TfU+o/u1huL/UIwyaUf5DKu2SciIiJqLoMNtCkpKbCyskLPnj3V2t3c3GBhYYErV660ev8vv/wSa9asgVwuh5eXF5555hmEhYU9+IchIpNVo6rF1MMbsDfjMv66VVNORQmWX9iPyNR4VNUqkVJ8RzpmJpPjaY8AvOY7EoGOLrodNBEREZGJMNhAW1hYCHt7e412uVwOW1tbFBYWtlp/uVyOadOmYcaMGfDy8kJeXh42btyId955B1evXsWyZcuafC8hBCoqKpr1uXSpsrJS7b+J2kp7nmsfJUZjb8ZlAID4y7H61xfvZktt9hZWeL73IMz3GgYX244AYJDfH4asPc830i3ONdIlzjfSFUOea0IIrZ/mYLCBFqj7QI1pzgdtbv8uXbrgo48+kl67uLhg2bJlUrCdMWMG3N3dGz1XVVUVkpKS7jsefblx48b9i4haQXuba0qhwrrLpyCDZpj9KzmAhd0CMK1LH9iZWaD4ViaSkHmfXtSU9jbfSH8410iXON9IVwx1rllbW2tVb7CB1sHBocGQqFKpUFpaCgcHhzbtD9Stv927dy9+//33JgOtlZUVevfufd/z6VplZSVu3LgBT09PrScGkTba61w7lnMTBcrm/XVTBWCydyCGOHu07aDagfY630j3ONdIlzjfSFcMea5dv35d6z4GG2j79u2L6OhoZGRkwMXlz/VlqampUCqV6Nu3b5v2B+rCL3D/q8EymQw2Njb3PZ++WFtbG/T4yHS0p7l2tSgPG1MvaNWnDLXt5t9HF9rTfCP94lwjXeJ8I10xxLmm7e3GQN1dcAZp/PjxAP7crbjegQMHIJPJpOP1lEqlFEBb0r8hhw4dglwux4ABA1r0GYjItFwtysO/4g9jwM9roPhpJf6/m9oF2s5WhvVDg4iIiMjYGewVWl9fXzzxxBNYt24dPD09MXjwYMTGxuLrr7/Gs88+q3aLb3Z2NkJCQvDYY49h9erVWvePiIiAra0tRo0aBRcXF+Tl5WHTpk3Yv38/Zs+eDVdXV51/fiIyDClFeYhMjUdkagLiC7I0jpvJ5GrPkm2IDICzTQcE83ZjIiIiolZlsIEWAD744AO4ubnhww8/RG5uLrp164Z58+Zh9uzZanUymQxmZmYwMzNrUf/nn38eW7duxbJly5CamgoLCwsoFApERERgypQpbf45iciw3C/E+jo44ymP/gjr1R87UhOw/ML+Js8nACzoFwwLuVmTdURERESkHYMOtBYWFpg/fz7mz5/fZJ2zs3ODG0A1t3+nTp0wb948zJs374HGS0TGqz7Ebr8Zj4S7tzWO+zl0Q5iHP8J69Ye3g7PUvtQ/FHF5aYjKSNbY7bj+9aMu3njTf3RbfwQiIiKidsegAy0RUVu6UpSLyJsJiEzVLsTey0Juhl1jZmFlQjTWXT6J7IoS6ZizTQcs6BeMN/1H8+osERERURtgoCWidqU+xG5PjcfFBkLsw526I6xXXYjt59C1Wee0kJvhnYCxeNN/NE7m3ERBVQU6W9kg2NmDQZaIiIioDTHQEpHJu1yYK62Jba0Q2xALuRlGde/zIEMlIiIiIi0w0BKRSbpfiPXv1B1hvfojzMMffTu2PMQSERERkf4w0BKRyUguzKkLsTcTkFiYrXGcIZaIiIjItDDQEpFRa06IrX/EjqKjkx5GSERERERthYGWiIxOUmG2tDvxpcIcjeP9O/eQ1sQyxBIRERGZLgZaIjIKzQmxT/Xqjyd7+TPEEhEREbUTDLREZLDqQ+z21HgkNRBiAzr3qFsT28sfXgyxRERERO0OAy0RGZRLd7Ol3YkZYomIiIioKQy0RKR39wuxAzr3RJhH3ZrYPvaOehghERERERkiBloi0otLd7OxPTUekTfjkVyUq3GcIZaIiIiI7oeBloh0QgiBS4XZiExNaDTEBnbpibA/NnZiiCUiIiKi+2GgJaI2Ux9it9+su534chMhNqyXP3ozxBIRERGRFhhoiahVCSGQeM+a2MZCbP0jdhhiiYiIiKilGGiJ6IEJIXCtohA7Lh7GroxLuFKUp1EzsIsLwnr5M8QSERERUathoCWiFhFC4OLd24hMTcD2G78jpeSORs3ALi54yqPuSqxnhy56GCURERERmTIGWiJqNrUQezMeKcWaV2IHObpIGzsxxBIRERFRW2KgJaIm1YfY+o2dGgqxgZ17ItjSES8NCoWPU089jJKIiIiI2iMGWiLSIIRAwt3biGwixA52dJXWxHYzfwhJSUnwsOush9ESERERUXvFQEtEAP4MsXVXYuNxtVhzTey9IdbjntuJKyoqdDlUIiIiIiIADLRE7ZoQAvEFWYhMTWg0xA5xdJXWxPbqwCuwRERERGQ4GGiJ2pl7Q+z2m/G41sDuxAyxRERERGQMGGiJ2gEhBH4vyEJkajwibyY0GmLrH7HjzrWwRERERGQEGGiJTFRzQuxQJzdpTSxDLBEREREZGwZaIhNSH2LrN3a6XpKvUTPUyQ1P/XE7sZtdJz2MkoiIiIiodTDQEhmYGlUtTubcREFVBTpb2SDY2QMWcrNG64UQuJCfKW3s1FCIDXJyl67EMsQSERERkalgoCUyEDWqWnyccATrkk8ip7JUau9m0wHz+w3HUv9QKdjWh9jtqXXPib3BEEtERERE7RADLZEBqFHVYurhDdibcRmyvxzLqSjB8gv7EZeXhnf7j8WutMRGQ+wwJ3eEefTHk+7+cLVz0MnYiYiIiIj0hYGWyAB8nHAEezMuAwDEX47Vv47KSEZURrJGX4ZYIiIiImqvGGiJ9KxGVYt1ySchg2aYbczwrr0Q1ssf0xliiYiIiKgdY6Al0rPdty6qrZm9n20hM/GUZ0DbDYiIiIiIyEgw0BLpUFlNFf6bn4G4vDTE5qUhNu8WssqLtTqHeRM7HhMRERERtScMtERtRCVUuFp8B7G5txCbl4a4vDQk3L2NWqF6oPN2trJppRESERERERk3BlqiVlJQVY4zf1x1jc1Lw5m8NNytrmi03s3WAUOd3DC4iys+vngEd6srmlxDKwPgbNMBwc4erT52IiIiIiJjxEBL1AI1qlpcLLiNuDtp0hXYlOK8RusfMrfAYEdXDHV0Q1BXdwx1ckOPhzpKxytVSiy/sL/J9xQAFvQLlp5FS0RERETU3jHQEjVDZlkRYvNu/bH29RbO3clARW1No/X9OnZFkJMbgpzqwqtfp25Nrn1d6h+KuLw0RGUka+x2XP/6URdvvOk/urU+EhERERGR0WOgJfqLcmU1zudn/nHltS7EZpQXNVrfydIGQU7uCOpaF2AHO7qik9VDWr2nhdwMu8bMwsqEaKy7fBLZFSXSMWebDljQLxhv+o/m1VkiIiIionsw0FK7JoTA1eI70pXX2LxbSCi4DWUjGzeZy+To37kHhv5x9TXIyQ197B0hk8keeCwWcjO8EzAWb/qPxsmcmyioqkBnKxsEO3swyBIRERERNYCBltqVu1XlOHMnHXF5txCbm4a4O2koqCpvtN7loY51a17/WPsa2KUnHjK3bNMxWsjNMKp7nzZ9DyIiIiIiU8BASyZLqapF4t1sadfhuLw0XC7KbbTexswCgxxdpHWvQ53c4GLroLsBExERERGRVhhoyWRklRfV3Tr8x67D5/LTUa5sfOMmhb1T3cZNXd0R5OQOv07deGsvEREREZERYaAlo1ShrMH5/Ix71r6mIb2ssNF6B0sbBP1x1TXIyR1DnNzQWcuNm4iIiIiIyLAw0JLBE0Lgekm+2mNzfs/PanTjJjOZHP6duiOoq5u09tXL3hFymVzHIyciIiIiorbEQEsGp6i6Amfy0qVdh+Py0pDfxMZNPR6yl3YcDnKq27jJ1sJKhyMmIiIiIiJ9YKAlvVKqanGpMOfPW4dzb+FyUR4ERIP11mbmGNjFRe25r9y4iYiIiIiofWKgJZ3KLi+WdhyOzbuFs3fSUaasbrTey95R2nU4yMkd/p27c+MmIiIiIiICwEBLbahSWYMLBZlqAfZW6d1G6ztaWktrXoc6umGIkxscrW11OGIiIiIiIjImDLTUKoQQuFlaID0yJzbvFn4vyEKNqrbBerlMhoc7dZfWvQ51ckPfjk7cuImIiIiIiJqNgZZapKi6AmfvpN+z9jUNd6rKGq3vZtPhz42burpjYBcX2HHjJiIiIiIiegAMtCaqRlWLYzk3kVCUjjs5Ngh169vitae1KhWSCnPUHpuTVJjb6MZNVtLGTX8+99XV1gEymexBPhIREREREZEaBloTU6OqxccJR7Au+SRyKkvrGm+dQDebDpjfbziW+ofeN9jmVJSo7Tp89k4GSpVVjdb37tBFuvo61MkN/Tv3gKUZpxYREREREbUtpg4TUqOqxdTDG7A34zL+ei00p6IEyy/sR1xeGnaNmSWF2qpaJX4vyERsbpr03NfUJjZusrewxhAnVynADnFyg5O1XRt+KiIiIiIiooYx0JqQjxOOYG/GZQDQuBm4/nVURjJmxGxGj4c6IjbvFi7kZ6K6iY2b/By6SbcNB3V1Q7+OXblxExERERERGQQGWhNRo6rFuuSTkEEzzP5VZGpCg+3ONh3Udh0e5OiCDhbWrT5WIiIiIiKi1sBAayJO5tz8c81sM5jL5Bjk6KoWYN3tOnHjJiIiIiIiMhoMtCaioKpCq/ofRz6LcM+AthkMERERERGRDnAxpInobGWjVb2zDTdyIiIiIiIi48ZAayKCnT3gbG2nsbvxX8kAdLPpgGBnD10Mi4iIiIiIqM0w0JoIC7kZFngH33dDKAFgQb/g+z6LloiIiIiIyNAx0JqQpf6heNTFGwA0rtTWv37UxRtv+o/W6biIiIiIiIjaAgOtCbGQm2HXmFn4YMBEONt0UDvmbNMBHwyYiF1jZvHqLBERERERmQSj2eVYpVJBLm95/tam/4O+lz5ZyM3wTsBYvOk/GkfSriDhRgr8PRUIdevLIEtERERERCbFoFNbdXU11qxZgxEjRsDX1xcjR47Ev//9byiVylbv/6DvZWgs5GYY6eyB0I6uGOnswTBLREREREQmx6Cv0L711ls4ceIE1q1bh8DAQJw5cwYLFy5EXl4ePvjgg1bt/6DvRURERERERLplsFdoExIS8Ouvv2LRokUYNGgQ5HI5goKCMG/ePERGRiIlJaXV+j/oexEREREREZHuGWygPXjwIAAgNDRUrX3s2LEQQkjHW6P/g74XERERERER6Z7BBtqUlBRYW1ujR48eau2urq6wsLC471VTbfo/6HsRERERERGR7hnsGtqioiJ06NBBo10ul8PW1haFhYWt1v9B30sIgYqKiiZr9KGyslLtv4naCuca6RLnG+kK5xrpEucb6YohzzUhBGQymVZ9DDbQAnUfqDHN+aDa9H+Q96qqqkJSUtJ9x6MvN27c0PcQqJ3gXCNd4nwjXeFcI13ifCNdMdS5Zm1trVW9wQZaBwcHXLp0SSOl19bWorS0FA4ODq3W/0Hfy8rKCr1799bq8+lCZWUlbty4AU9PT60nBpE2ONdIlzjfSFc410iXON9IVwx5rl2/fl3rPgYbaPv27Yvo6GhkZGTA1dVVak9NTYVSqUS/fv1arf+DvpdMJoONjY22H1FnrK2tDXp8ZDo410iXON9IVzjXSJc430hXDHGuaXu7MWDAm0JNmDABAHDgwAG19gMHDkAul2P8+PFq7VVVVaipqWlRf23fi4iIiIiIiPTPYAOtj48PnnzySaxfvx5HjhxBSUkJDh48iG+++QYzZ86Ep6enVJudnQ1/f3+89dZbLeqvTS0REREREREZBoO95RgA3n//fbi7u2PVqlXIzc1Ft27dsGjRIsyaNUutTiaTwdLSEhYWFi3qr20tERERERER6Z9BB1pzc3PMnTsXc+fObbLO2dkZFy9ebHF/bWuJiIiIiIhI/wz2lmMiIiIiIiKipshEUw9gpfu6cOEChBCwsrLS91A0CCFQVVUFKyurFu0YRtRcnGukS5xvpCuca6RLnG+kK4Y816qqqiCTyTBgwIBm9zHoW46NgVwuh0ql0vcwGiSTyQzu2VJkmjjXSJc430hXONdIlzjfSFcMea7JZDLI5drdRMwrtERERERERGSUuIaWiIiIiIiIjBIDLRERERERERklBloiIiIiIiIySgy0REREREREZJS4y7ERKCwsbHAnZUtLS9jZ2TXar6ysDDY2Ns3aKUybWjI9d+/ehbm5OTp06HDf2raaV5yD7UN5eTkqKythb28Pc3PNH0GVlZUoLy9vsK+Dg0Oj86OmpgZKpRI2Njb3HYM2tWS8lEolhBCwsLBoVn1paSlsbW2b9QiLtqol41VRUdHkd0pFRQUqKioaPNapU6dG50d1dXWzHw+pTS0ZL5VKherq6mbvUtwevtsYaI3Ao48+iuLiYjz00ENq7SEhIVi1apVamxAC3333HX744QeUlpZCpVJh3LhxePvtt9G5c+cW15LpuXTpEqKiorBv3z5kZWVhwIAB2LJlS4O1Qgh888032LhxI8rKyiCEwLhx47Bs2bIG51Vb1JLxKikpwf79+/Hbb7/hzJkzqK6uxubNmzFo0CCN2s2bN2PVqlVwcHDQOLZjxw64urqqtV25cgUffvghLly4ALlcjh49emDx4sUYN26cRn9task4FRQUYMeOHdizZw/S0tIghICzszOee+45PPvssxp/RFEqlfjiiy+wdetWVFVVAQAmT56MpUuXavyBr61qyXgdO3YMkZGROHPmDCorK2FpaYlhw4bhlVdegaenp1rtV199ha+++qrB77b9+/drtCckJOBf//oXEhMTIZPJ0KtXL7zxxht45JFHNPprU0vGqbq6GlFRUdi2bRtSUlJQU1MDW1tbTJgwAfPnz4ezs7NG/dq1a7Fjxw4olUrIZDI88cQTWLJkicYfXtqqVqcEGbzhw4eLxYsXN6v2888/F76+vuLgwYNCCCEyMzPFlClTxNSpU0VNTU2La8n0LFy4UHzzzTciPT1dDB8+XDz99NON1q5du1b4+vqKw4cPCyGESE9PF5MnTxbTpk0TSqVSJ7VkvH799VexdOlSERMTI7777juhUCjE2bNnG6ytP56bm3vf82ZlZYkhQ4aI+fPni+LiYqFUKsWXX34p+vXrJ44ePdriWjJe69atE4MHDxbbt28XlZWVoqamRuzatUv4+PiIpUuXatSvWLFCBAQEiFOnTgkhhLh+/boIDQ0V//M//6OzWjJONTU1QqFQiEWLFonr168LIYRIS0sTzzzzjAgMDBQ3btxQq1+zZo1QKBSisrLyvue+fv26CAgIEEuWLBFlZWWiqqpKfPLJJ8LX11fju1ObWjJely9fFu+//75ISEgQVVVVQqVSiTNnzohhw4aJcePGiaqqKrX6JUuWiMGDB4sLFy4IIYRITk4WwcHBYsGCBRrnbqtaXWKgNQLNDbR3794Vfn5+Yvny5WrtcXFxQqFQiJ9++qlFtWT6mgq0+fn5wtfXV6xYsUKt/dSpU0KhUIiff/65zWvJdGzYsKHVAu3y5cuFn5+fKCgoUGufNm2aePTRR1tcS8YrKipKpKWlabQvW7ZMKBQKkZ2dLbWlpaWJfv36ibVr16rV7tu3TygUChEdHd3mtWS8lEql+PbbbzXaU1NThUKhEB988IFauzaB9tVXXxUDBw4UZWVlUptKpRLjx48XzzzzTItryfR8/fXXQqFQiLi4OKktOTlZKBQK8f3336vVbt++XSgUCnHu3Lk2r9U1LlYzIpWVlSgrK2v0+PHjx1FdXY3Ro0ertQ8aNAj29vY4ePBgi2qpfTt27BhqamowatQotfYhQ4bA1tYWhw4davNaan9UKhVKSkpQW1vbaM3hw4cREBCATp06qbWHhobi6tWruHXrVotqyXhNnjxZ47Z0AOjWrRsAICcnR2qLjo6GSqXS+Dk4cuRImJubq/0cbKtaMl5mZmaYM2eORnv9rZ/3zrV71dbWoqSkpMG9UYC6777o6GgMHTpUbamZTCbD6NGjcf78eRQUFGhdS6apuroaANRuWa///emvv1+NGTNG7Xhb1uoaA62R2LdvH4YMGYKBAwciODgYH3/8sUa4vXbtGgCgV69eau1yuRxubm64evVqi2qpfaufC3+dK2ZmZnBzc0NKSkqb11L7M3bsWAQHB6N///547rnncO7cObXjRUVFyMvLg4eHh0bf+rb6OaZNLZkelUqFAwcOwNLSUm0ONPZz0MbGBs7Ozs36mfmgtWR69u3bBwBQKBQNHh86dCiGDx+O/v37Y/bs2UhISFA7npmZifLyco35A9TNKSGENIe0qSXTUFVVhYKCAmRkZGD37t3YsGEDnnnmGbX5du3aNen3+Xt17twZ9vb2ar9ftVWtrjHQGoGJEyciMjISFy5cwIULF/Daa69h27ZteP7556FUKqW6oqIiAGhw5+MOHTqguLi4RbXUvtXPhebMlbaqpfaja9euWLlyJU6ePIn4+Hjs3r0bAPD3v/8dp06dkurq54etra3GOernVP33nDa1ZHq++eYbpKSkYObMmWobMt3v5+C9c6Ktasm05Obm4pNPPoGDgwNmzJihdszFxQWffvopTp8+jfj4eGzfvh0lJSWYMWMG4uPjpbr7/Wy8t0abWjINu3btwqRJkzBx4kS8+eabGDVqFBYvXqxWU1xcDGtr6wafJNDQ72JtUatrDLRG4N1334W3tzfMzMxgY2OD6dOn45VXXsHvv/+O/fv3S3X122YLITTOoVKp1LbV1qaW2rf7zZV7H6PSVrXUfjz22GOYOnUq7O3tIZPJ0KdPH6xbtw4dOnTA6tWrm3WO+jnVnDmkTS0Zn99++w2fffYZBgwYgFdffVXtGL/bqDWVlpbipZdeQmFhIVatWqWxU39YWBgmTZoEOzs7yOVyeHt7Y926dTA3N8fatWuluvvNn3trtKkl0/D0008jLi4O8fHx+PHHH/H777/jySefRGlpqVTT1P/njX1ftXatrvFb1UjVb8V+760q9WvDGvrrb3FxsdraMW1qqX1rq3nFOUjNZW9vj4CAACQlJUlrauvnR2FhoUZ9/Zyqr9GmlkzH0aNH8frrr8PHxwfffvstLC0t1Y7zu41aS0VFBV588UVcvnwZq1evRkhISLP6OTk5wdvbW6vf5e6t0aaWTIuZmRkGDx6M5cuXIzU1FTt37pSOOTg4oKKiQlpfe6+ioiK1OdFWtbrGQGukampqANRN6Hre3t4A/ly/c29tamqqdFzbWmrf+vXrBwC4fv26Wnt1dTVu3bolHW/LWqKamhqYmZlJfyG2s7ODq6urxvwB/vxeq59D2tSSaTh58iQWLVoEhUKBDRs2NPjs18Z+DhYXFyM3N7dZPzMftJaMX1VVFebNm4cLFy5g1apVmDRpklb9a2pq1G7h7N69OxwcHDTmD1C31t/c3FxaL6lNLZkmd3d3AEB2drbU5u3tDSGExs+8rKwslJeXq/28a6taXWOgNXAN3UYCAHv37gVQt7lAveDgYNjb2+O3335Tq42OjkZFRQUmT57colpq3x555BHY2dlpzJVDhw6hqqpKba60VS21Hw1952VnZ+P8+fMYOHCg2i1NkyZNQmJiIjIyMqS22tpa7N+/H4GBgdLOttrWknE7e/YsFixYAC8vL2zYsAH29vYN1oWGhsLKykrjO+i3336DSqVSCyZtVUvGrbq6GgsXLsSZM2ewcuVKTJkypdHahr7bbt68ieTkZAwZMkStfeLEiTh79izy8/PV3uvQoUMYMWKE2h9otKkl49VYHjh79iwA9T/KTpgwAWZmZhrfQVFRUZDJZGrfQW1Vq3M6fUgQaW3btm3ijTfeEMePHxfp6ekiOTlZrFmzRvj4+IhFixZp1Nc/C+rrr78WWVlZ4sSJE2LEiBFizpw5D1RLpqe0tFTk5+eL/Px8MWzYMBEWFia9Li8vV6vdsmWL6Nu3r/j2229FVlaWOHbsmAgODhYvvviixnnbqpaMl1KplObW+vXrpWdx5ufnazwX9oknnhDbt28XSUlJIiMjQxw8eFBMnDhRDBw4UCQlJanVFhYWitDQUDF9+nRx8eJFcevWLbF06VLh7+8v4uPjW1xLxis+Pl4MGDBAjB8/Xty8eVOad/X/qa6uVqv/+uuvhbe3t/jxxx/F7du3xaFDh8SQIUPEkiVLNM7dVrVknJRKpVi4cKFQKBTihx9+0JhrxcXFUm1VVZX429/+Jn766SeRnJws0tLSRFRUlAgNDRVBQUHixo0baufOyckRwcHBYubMmSI5OVncuHFD/L//9/9EYGCguHr1aotryXitXr1afPzxxyIuLk5kZmaKK1euiO+++04EBASImTNnipqaGo16Pz8/sXPnTnH79m0RFRUlAgICxIoVKxo8d1vU6pJMiEYiPxmE+isIP//8M65fvw6lUgkPDw88+uijmDZtWoMLsA8ePIiNGzciNTUVDg4OGD9+PObOnQsrK6sHqiXT8s9//lN6vMBfzZkzBy+88IJa2/79+7Fp0ybcunULDg4OmDBhAubOnauxLq0ta8k4Xb9+Hc8++2yDx6ysrHDs2DHp9a1bt7Bp0yacP38eubm56NSpE4YOHYp//OMf6Nmzp0b/vLw8fP755zh9+jRqamrg7e2NhQsXwtfX94FqyTitXbsWW7dubfR4REQERowYoda2e/dubN26FRkZGejSpQumTJmCWbNmwcLCQqN/W9WS8cnPz2/yTqKAgAB8/fXX0utr165h06ZNiI+Px507d+Do6IigoCA8//zz6Nq1q0b/rKwsfP755zhz5gxUKhUefvhhLFq0CF5eXg9US8apsrISP//8M/bv34/U1FQIIeDu7o7x48cjLCxM43tFCIHt27djx44dyM7OhpOTE6ZOnYqZM2dqZIe2qtUlBloiIiIiIiIySlxDS0REREREREaJgZaIiIiIiIiMEgMtERERERERGSUGWiIiIiIiIjJKDLRERERERERklBhoiYiIiIiIyCgx0BIREREREZFRYqAlIiIiIiIio8RAS0REREREREbJXN8DICIioj/dvn0bFy9eREFBAYQQUnvv3r0xZMgQPY7sTxcvXkRiYqL0euzYsXBycgIAXLt2DWfPnsX48ePRpUuXNh1Ha71XVlYWYmJipNeDBg2Cl5dXawyRiIjaGAMtEREZrdu3b+Po0aMAgMDAQPTt21ejRqVSITIyEiqVCj169EBISIiOR9l8UVFRWLp0KaqrqzWOPfnkkwYTaI8ePYovvvhCeu3l5SUF2rNnz+K9996Dt7d3mwTa+Ph4pKSkICwsrNXe68qVK3jvvfek1++++y4DLRGRkWCgJSIio3X16lUpiIwYMQLff/+9Rs3x48exfPlyqcaQA+0nn3wCIQQmTJgABwcHqX3btm36G1QTpkyZAltbW3Tt2lVn77l69WrI5XKEhYW12jl79OiB8PBw3L17FwcOHGi18xIRUdtjoCUiIqPn6emJU6dOISMjAy4uLmrHtm/fDk9PT9y4cUNPo2ue8vJy3L59G9OnT8e//vUvqV2pVBpsoH311Vc1/r3bUlFREc6fP4833nijVc/bt29frFixAhcvXmSgJSIyMtwUioiIjN6UKVNgbW2NyMhItfbc3FwcPXoU4eHhTfZPT0/HoUOHsGvXLvz+++9qa1fvVV1djdjYWOzevRvR0dHIzs5uUc1fnT59Gps3bwZQdxv1li1bsGXLFhQUFDTZr6SkBEeOHMGOHTsQExODsrIyteO5ubnYsmWLRpg/duwYtmzZgvT0dLX2w4cPY8+ePfcdb0vcvXsXW7duxZ49e9T+fW/fvo1ffvkFe/fulT7vL7/8gsOHD2uc4+jRo1AqlQgNDdU4plKpcPr0aezcuRPnzp3TOH7t2jVs2bIF+fn5UKlUiI2NRWRkJNLS0lrxUxIRka7xCi0RERk9W1tbTJ48GTt37sSiRYtgbl73423nzp2Qy+X429/+ho8++kij3+3bt7Fs2TKcOnVKrd3f3x/r16+X1oUCQEJCAhYsWIDc3FypzczMDGFhYXj//febXdOQnTt3SkHy1KlT0nj8/Pxgb2/fYJ/IyEh89NFHaiHWwcEBK1aswIQJEwAAlpaWWLFiBZ577jksW7ZMqnvvvfeQmZmJhQsXYtGiRQDqAuGyZcswcOBAPPbYY42OtSUyMzMxZ84clJSU4JtvvoFMJgMA/Oc//0FERASUSiUAwNraGhEREfj000/Rs2dPjBkzRu08R44cgUKhgKurq1r73bt38dRTT+HixYtSW0hICNavXy/Nhfr1to6Ojli3bh2Sk5MBABEREXBzc2vVz0tERLrDK7RERGQSwsPDkZeXJ20SVb8Z1IQJE9CpU6cG+6SlpeHUqVNQKBSYNGkSHn30UfTs2RMJCQl499131WqXL1+O3Nxc+Pj4YOrUqRg7diycnZ2xb98+rWoaMmzYMEydOhUA0K9fP4SHhyM8PLzRjY5Onz6Nd999F2VlZfD398fjjz8Ob29vFBYW4rXXXsOlS5cA1AXcvn374vTp02qfOTMzE05OToiNjZXak5OTUVhYiKCgoCbHqq3Lly8jPDwcKpUKW7ZsgY+PD4C6tc0rV66EUqnEkCFD8Nhjj6Fnz5544403UFxcrHGempoanDhxosGrsx988AHS09Mxfvx4TJo0Cba2toiJicHOnTs1av/3f/8XWVlZGDt2LMLDwxlmiYiMHK/QEhGRSfD394ePjw+2bt2KsWPH4sSJE8jMzMTKlSsb7dOjRw9s2bIFgYGBUptKpcLixYvx22+/IS8vT7pKe+vWLYwePRpfffWVWu2hQ4ek182pacj06dMxcuRI7N69G8OHD8ebb74pHau/enmv7777DkIIvPvuu5g5c6bU/tlnn2H9+vX4/vvvsWbNGgBAUFAQ/u///g8FBQXo3LkzYmNjYWFhgdmzZyMiIgLl5eV46KGHEBcXJ9W3ltOnT2PhwoXo3bs3vvrqK3Tu3Fk6tmHDBgDAp59+ikmTJgGo+7f65z//ie3bt2ucKy4uDqWlpRg9erTGMTs7O/z000/SRlopKSmYOnUqoqOjNW43t7S0xI4dO+Do6NhaH5OIiPSIV2iJiMhkhIWF4eTJk8jMzJQ2gxo8eHCj9a6urggMDMTly5fx66+/Ytu2bdi2bRvs7e0hhMCVK1ek2qCgIKSmpiIhIUFaAyqXyzF+/HitalrD+fPn4eHhoRZmAWDBggXo3Lkz/vvf/6qNSQghXY2NjY2Fv78/QkNDUVNTI603jY2NRZcuXaBQKFpljFFRUXjhhRcwaNAg/PDDD2phtv4z+Pv7S2EWqPu3ev3116Vbku915MgRODo6on///hrH5s6dq7YrtEKhQK9evZCTk6NRO3v2bIZZIiITwiu0RERkMh5//HF88skn+PLLLxEdHY0lS5Y0WZ+eno6XX34ZSUlJDR4vKSmR/veqVavwxRdfYMGCBaioqICPjw9GjhyJp59+GnZ2ds2ueVDV1dUoLy+Hh4eHxjFzc3O4u7urfZ5BgwbB3NwcsbGxmDx5MuLi4hAeHg53d3f06NEDsbGxGD58OM6dO9eqjzTasWMHamtrsWDBAtjY2Kgdq6qqQkVFRYO3+9rb2zd4i3h0dDRGjRrVYNjt2bOnRpudnR3Ky8s12j09PbX5GEREZOB4hZaIiEyGnZ0dJk+ejMjISMjlcmldamPee+89JCUloU+fPpg8eTLCwsIQHh4uBTuVSiXVdujQAW+99RaOHz+OPXv2YMaMGTh06BAee+wxaXfe5tQ8KEtLS1hYWDR49RGo29n43vBsZ2cHPz8/xMXF4erVq7hz5450W/HQoUMRGxuLxMRElJWVtertxh999BFcXV0xe/ZsJCQkNPgZ7ty5o9GvuroaRUVFam3JycnIyspqcP0sgAZDbmMsLCyaXUtERIaPgZaIiEzK3//+d4SHh+P1119vdDOoevHx8QgMDERUVBTWrl2LDz/8ECtWrEDv3r3V6qqrq3H9+nXpdffu3TFhwgQsWLAAWVlZiI6OblZNa/Hx8cGlS5ekda/19u7di8zMTPj6+qq1198KvWvXLlhbWyMgIEBqT05Oxv79+6XXraVbt27YtGkTunTpgn/84x+4cOGCdEwmk8Hb2xtnz57F5cuX1fpt3rwZtbW1am2HDx+GtbU1goODW218RERkGnjLMRERmRSFQoEVK1Y0q7Z+R+Ply5fDy8sLZWVlOHPmDOLj49XqSktLMXnyZAwZMgT+/v5wdnZGfn4+du/eDQCwsbFpVk1refbZZxEfH485c+Zg2rRp6NWrF1JSUvDzzz8DAGbMmKFWHxQUhK+++gqbN2/GwIEDYWlpCaBud+X63Ye7d+8Od3f3VhsjADg7O+PHH3/ErFmz8Pzzz+Pbb7/FoEGDAABPPfUU3nnnHTz77LN48skn0a1bNyQmJmL//v2wtrZWO8+RI0cwbNgwjXYiIiIGWiIiardefvllvPzyy9i2bZvU1rVrVyxevFjtubFWVlbo06cPzpw5gzNnzqidIyQkBOPGjUN1dfV9a1rL1KlTkZiYiE2bNmHr1q1Su0wmw6JFizBq1Ci1+sDAQFhaWqKyslLtKqyzszN69eqF1NRUTJw4sdXGdy9HR0ds3LgRs2bNwgsvvIAvv/wSQUFBePLJJxEbG4tff/0VP/zwg1S/ePFibNiwQQqvOTk5uHTpEp555pk2GR8RERk3BloiIjJaPXr0QHh4OPr27Xvf2vDwcHh5eam1jRkzBnv27MGBAwdQUFAANzc3TJkyBfn5+WrPKLW1tUVUVBTOnTuHCxcuIDc3F46Ojhg8eLD0yB8LC4v71jTFxsYG4eHh0u3A9eRyOcLDwzFw4EC19nfeeQdTp07F0aNHUVhYiC5dumDMmDEN7lJsZWWFhQsXIjMzE2PGjFE7NnfuXMTHx2PKlCn3HeNf7dmzBw4ODhg7dqz0eCMvLy+NZ+h27twZP/zwA9atW4fo6Gj4+fnBzs4OERERePzxxxEbGwtzc3OEhITAy8sLERER0vkOHz4MmUymEdIbe6969X9kaE5tVlYWYmJicPv2ba3/DYiISL9kov65AkRERETN8Pnnn+OLL76QXm/evFm6lVgbGRkZcHFxUWtbuXIl/vOf/2DFihUIDw/HnDlzUFRUhMjIyAced2Oio6Px0ksvSa//+nxfIiIyXLxCS0RERFrx8/NDeHi49Lpr164tOs+cOXPQu3dv+Pn5QQiBuLg4xMbGwt7eHhMmTAAAeHh4NPks4dZQf6W/3l+v5BMRkeHiFVoiIiLSi9mzZ+PEiRNqbTY2NlizZk2jj+ghIiK6FwMtERER6YVKpcLx48eRmJiIwsJCuLi4YOLEiXB2dtb30IiIyEgw0BIREREREZFRkut7AEREREREREQtwUBLRERERERERomBloiIiIiIiIwSAy0REREREREZJQZaIiIiIiIiMkoMtERERERERGSUGGiJiIiIiIjIKDHQEhERERERkVFioCUiIiIiIiKjxEBLRERERERERomBloiIiIiIiIzS/w/gNhQ/iaMg3AAAAABJRU5ErkJggg=="
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "\n",
+    "orifice_flow_rates_kg_per_hour = np.linspace(500.0, 3_000.0, 8)\n",
+    "orifice_sensitivity_rows = []\n",
+    "\n",
+    "for flow_rate in orifice_flow_rates_kg_per_hour:\n",
+    "    sensitivity_fluid = fluid(\"srk\")\n",
+    "    sensitivity_fluid.addComponent(\"methane\", 1.0)\n",
+    "    sensitivity_fluid.setMixingRule(\"classic\")\n",
+    "    sensitivity_fluid.setTemperature(30.0, \"C\")\n",
+    "    sensitivity_fluid.setPressure(10.0, \"bara\")\n",
+    "\n",
+    "    sensitivity_feed = jneqsim.process.equipment.stream.Stream(\n",
+    "        f\"orifice feed at {flow_rate:.0f} kg/hr\",\n",
+    "        sensitivity_fluid,\n",
+    "    )\n",
+    "    sensitivity_feed.setFlowRate(float(flow_rate), \"kg/hr\")\n",
+    "\n",
+    "    sensitivity_orifice = Orifice(name=\"sensitivity orifice\")\n",
+    "    sensitivity_orifice.setInputStream(sensitivity_feed)\n",
+    "    sensitivity_orifice.setOrificeParameters(0.07366, 0.05000, 0.61)\n",
+    "\n",
+    "    sensitivity_process = jneqsim.process.processmodel.ProcessSystem()\n",
+    "    sensitivity_process.add(sensitivity_feed)\n",
+    "    sensitivity_process.add(sensitivity_orifice)\n",
+    "    sensitivity_process.run()\n",
+    "\n",
+    "    orifice_sensitivity_rows.append(\n",
+    "        {\n",
+    "            \"mass flow [kg/hr]\": flow_rate,\n",
+    "            \"differential pressure [bara]\": (\n",
+    "                sensitivity_orifice.differential_pressure_bara\n",
+    "            ),\n",
+    "        }\n",
+    "    )\n",
+    "\n",
+    "orifice_sensitivity = pd.DataFrame(orifice_sensitivity_rows)\n",
+    "\n",
+    "figure, axis = plt.subplots()\n",
+    "axis.plot(\n",
+    "    orifice_sensitivity[\"mass flow [kg/hr]\"],\n",
+    "    orifice_sensitivity[\"differential pressure [bara]\"],\n",
+    "    marker=\"o\",\n",
+    "    color=\"#009E73\",\n",
+    "    label=\"ISO 5167 orifice calculation\",\n",
+    ")\n",
+    "axis.set_title(\"Orifice differential-pressure sensitivity\")\n",
+    "axis.set_xlabel(\"Mass flow [kg/hr]\")\n",
+    "axis.set_ylabel(\"Differential pressure [bara]\")\n",
+    "axis.legend()\n",
+    "figure.tight_layout()\n",
+    "display(figure)\n",
+    "\n",
+    "pressure_differences = np.diff(\n",
+    "    orifice_sensitivity[\"differential pressure [bara]\"].to_numpy()\n",
+    ")\n",
+    "assert (pressure_differences > 0.0).all()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "final-application-explanation",
+   "metadata": {},
+   "source": [
+    "\n",
+    "The monotonic, nonlinear curve is the expected meter response. Values near the upper end should\n",
+    "still be checked against applicable beta-ratio, Reynolds-number, pressure-loss, and uncertainty\n",
+    "limits in the governing standard.\n",
+    "\n",
+    "## 9. Final application: rich-gas conditioning and separation\n",
+    "\n",
+    "This end-to-end study configures a rich gas, cools it, throttles it to three delivery pressures,\n",
+    "and separates condensed liquid. It demonstrates current NeqSim `Stream`, `Cooler`,\n",
+    "`ThrottlingValve`, `Separator`, and `ProcessSystem` functionality. For each scenario the code\n",
+    "retrieves product conditions, verifies total mass closure, and reports the liquid-recovery trend.\n",
+    "\n",
+    "For inlet mass flow $\\dot{m}_{\\mathrm{in}}$, gas flow $\\dot{m}_{g}$, and liquid flow\n",
+    "$\\dot{m}_{l}$, the relative closure residual is:\n",
+    "\n",
+    "$$\n",
+    "r_m = \\frac{\\left|\\dot{m}_{\\mathrm{in}}-\\dot{m}_{g}-\\dot{m}_{l}\\right|}\n",
+    "{\\dot{m}_{\\mathrm{in}}}\n",
+    "$$\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "final-application-run",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>delivery pressure [bara]</th>\n",
+       "      <th>valve outlet temperature [degC]</th>\n",
+       "      <th>gas product [kg/hr]</th>\n",
+       "      <th>liquid product [kg/hr]</th>\n",
+       "      <th>liquid recovery [wt%]</th>\n",
+       "      <th>relative mass residual [-]</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>40.0</td>\n",
+       "      <td>-13.838194</td>\n",
+       "      <td>26749.451289</td>\n",
+       "      <td>3250.548711</td>\n",
+       "      <td>10.835162</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>55.0</td>\n",
+       "      <td>-6.007147</td>\n",
+       "      <td>27433.609681</td>\n",
+       "      <td>2566.390320</td>\n",
+       "      <td>8.554634</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>70.0</td>\n",
+       "      <td>0.638373</td>\n",
+       "      <td>28858.999347</td>\n",
+       "      <td>1141.000653</td>\n",
+       "      <td>3.803336</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   delivery pressure [bara]  ...  relative mass residual [-]\n",
+       "0                      40.0  ...                         0.0\n",
+       "1                      55.0  ...                         0.0\n",
+       "2                      70.0  ...                         0.0\n",
+       "\n",
+       "[3 rows x 6 columns]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "\n",
+    "def run_conditioning_case(outlet_pressure_bara):\n",
+    "    feed_fluid = fluid(\"srk\")\n",
+    "    composition = {\n",
+    "        \"methane\": 0.80,\n",
+    "        \"ethane\": 0.10,\n",
+    "        \"propane\": 0.06,\n",
+    "        \"n-butane\": 0.03,\n",
+    "        \"CO2\": 0.01,\n",
+    "    }\n",
+    "    for component_name, mole_fraction in composition.items():\n",
+    "        feed_fluid.addComponent(component_name, mole_fraction)\n",
+    "\n",
+    "    feed_fluid.setMixingRule(\"classic\")\n",
+    "    feed_fluid.setTemperature(30.0, \"C\")\n",
+    "    feed_fluid.setPressure(100.0, \"bara\")\n",
+    "\n",
+    "    feed_stream = jneqsim.process.equipment.stream.Stream(\"rich-gas feed\", feed_fluid)\n",
+    "    feed_stream.setFlowRate(30_000.0, \"kg/hr\")\n",
+    "\n",
+    "    feed_cooler = jneqsim.process.equipment.heatexchanger.Cooler(\n",
+    "        \"feed cooler\",\n",
+    "        feed_stream,\n",
+    "    )\n",
+    "    feed_cooler.setOutTemperature(15.0, \"C\")\n",
+    "\n",
+    "    export_valve = jneqsim.process.equipment.valve.ThrottlingValve(\n",
+    "        \"export valve\",\n",
+    "        feed_cooler.getOutletStream(),\n",
+    "    )\n",
+    "    export_valve.setOutletPressure(outlet_pressure_bara, \"bara\")\n",
+    "\n",
+    "    inlet_separator = jneqsim.process.equipment.separator.Separator(\n",
+    "        \"delivery separator\",\n",
+    "        export_valve.getOutletStream(),\n",
+    "    )\n",
+    "\n",
+    "    conditioning_process = jneqsim.process.processmodel.ProcessSystem()\n",
+    "    conditioning_process.add(feed_stream)\n",
+    "    conditioning_process.add(feed_cooler)\n",
+    "    conditioning_process.add(export_valve)\n",
+    "    conditioning_process.add(inlet_separator)\n",
+    "    conditioning_process.run()\n",
+    "\n",
+    "    inlet_mass_flow = feed_stream.getFlowRate(\"kg/hr\")\n",
+    "    gas_mass_flow = inlet_separator.getGasOutStream().getFlowRate(\"kg/hr\")\n",
+    "    liquid_mass_flow = inlet_separator.getLiquidOutStream().getFlowRate(\"kg/hr\")\n",
+    "    mass_residual = abs(inlet_mass_flow - gas_mass_flow - liquid_mass_flow) / inlet_mass_flow\n",
+    "\n",
+    "    return {\n",
+    "        \"delivery pressure [bara]\": outlet_pressure_bara,\n",
+    "        \"valve outlet temperature [degC]\": (\n",
+    "            export_valve.getOutletStream().getTemperature(\"C\")\n",
+    "        ),\n",
+    "        \"gas product [kg/hr]\": gas_mass_flow,\n",
+    "        \"liquid product [kg/hr]\": liquid_mass_flow,\n",
+    "        \"liquid recovery [wt%]\": 100.0 * liquid_mass_flow / inlet_mass_flow,\n",
+    "        \"relative mass residual [-]\": mass_residual,\n",
+    "    }\n",
+    "\n",
+    "\n",
+    "delivery_pressures_bara = [40.0, 55.0, 70.0]\n",
+    "conditioning_results = pd.DataFrame(\n",
+    "    [run_conditioning_case(pressure) for pressure in delivery_pressures_bara]\n",
+    ")\n",
+    "\n",
+    "display(conditioning_results.round(6))\n",
+    "\n",
+    "numeric_results = conditioning_results.select_dtypes(\"number\").to_numpy()\n",
+    "assert np.isfinite(numeric_results).all()\n",
+    "assert conditioning_results[\"relative mass residual [-]\"].max() < 1.0e-10\n",
+    "assert (conditioning_results[\"liquid product [kg/hr]\"] > 0.0).all()\n",
+    "assert conditioning_results[\"valve outlet temperature [degC]\"].is_monotonic_increasing\n",
+    "assert conditioning_results[\"liquid product [kg/hr]\"].is_monotonic_decreasing\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "final-application-figure",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<Figure size 960x600 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA7QAAAJMCAYAAADKcepuAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjExLjEsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvctoD+AAAAAlwSFlzAAASdAAAEnQB3mYfeAABAABJREFUeJzs3Xd8U9X7wPFPkqZ7D7qgLW1poSyZUvYQEGUI4gAUEVQQFXCB4N6iOPDrKEvBgTJkC4gMkVH2LrMtHdC9ZzqS/P6o5GelQNu0TVue9+vlC3vuyT1Pcu5t89xz7zkKvV6vRwghhBBCCCGEaGCUpg5ACCGEEEIIIYSoDklohRBCCCGEEEI0SJLQCiGEEEIIIYRokCShFUIIIYQQQgjRIElCK4QQQgghhBCiQZKEVgghhBBCCCFEgyQJrRBCCCGEEEKIBkkSWiGEEEIIIYQQDZIktEIIIYQQQgghGiRJaIUQQgghhBBCNEiS0AohhBBCCCGEaJAkoRWiCpYsWUJwcDCff/65UfuZN28ewcHBLFmypIYiE6Ywd+5cgoODWbp0ablyY46TmjrGjFEfYrhd1JdjRfr85m50rlfXjT5v6QchhKg6M1MHIERdW7NmDbNnzy5XplAosLGxwdfXl759+zJhwgTs7e1NFKEQQgghhBCiMmSEVghAr9eTl5dHREQEX3/9Nffddx/JycmmDks0Mt988w3BwcH873//M3Uoop6rL8eKKeKoL+9dCCFEwyAjtOK21bp1a9asWQOAVqslNTWVrVu3Mm/ePK5evcqXX37J+++/X+41kyZNYtKkSaYIVzQgxhwn9eEYqw8x3C7qy7EifV4/SD8IIUTVyQitEIBKpcLDw4MJEybw+OOPA7B3714TRyWEEEIIIYS4GUlohfiPli1bApCTk3PdtltN2HH48GFmzJhBnz59aNOmDb179+aJJ55g+/bt6HS6Cl9z9epVZs2aRc+ePWnTpg0DBw7kyy+/pKSkpFrxazQavvzySwYNGkSbNm3o2bMnM2fO5OrVqzec2KS0tJS//vqLF198kSFDhtC+fXs6dOjAfffdx9dff01hYeF17Wi1Wn755RcefvhhOnXqRNu2bRk4cCBPP/00O3fuvOH7vZGqfHZarZZVq1YxZswYOnfuTNu2bRk0aBDvvfdehbeK/3sSrqp+3kVFRXz99dcMHjzY8HnOmjWLhISEG76Xio6Tzp07M3/+fAC++uorgoODDf/9+06Amx1jdfW+bxSDMZ9jdY7Lm6nO8Xfo0CGmTZtmiLl79+5MmzaNM2fOVNhGdd9vVWKr6WNl6tSpBAcH8+uvv97ws7v2updfftnoOKZNm0ZwcDA///zzDdtbuHAhwcHBvPLKKzesU9X3DlU/H26lOuf6NVU9tm6kJvu0urH9+7iPiYnhpZdeomfPnoSEhPC///2vxvv8v21GRUUxbdo0QkNDadu2LUOHDmXp0qVotdoqx3pNXl4eYWFhjBo1io4dO9K+fXuGDRvGt99+i0ajqTCmuLg4Zs+eTf/+/WnTpg133nknI0eO5LPPPrvumKhs3StXrhAcHMzdd99dYZtFRUUEBwfToUOH67YFBwcTEhKCXq9n5cqVjB49mo4dOxIcHExRUZGh3smTJ3n++efp3bs3bdq0oVu3bjz99NMcPXr05p0gRAMmtxwL8R8REREAeHl5Vel1n376KQsXLixXlpycTHJyMnv27GH16tW0bdu23PbIyEhGjhxJdna2oSwuLo6vv/6a2NhYPv300yrFUFRUxIQJEzh+/LihLDU1lfXr1/P333/TtWvXCl+3fft2pk+ffl35uXPnOHfuHH/++Sc///wzNjY2hm2vvvoqa9euLVc/Li6OuLg4du7cyYoVK7jjjjsqFXdVPrvS0lKeffZZdu3aVa5+bGwsP/74I7///jvfffcdrVq1uq6dqn7excXFPPHEExw6dMhQlpqayrp169i9e/cNP8/aUJfv+1aqur/qHpc3U9Xjb/78+XzzzTfl6qenp/PHH3+wc+dO5s2bd8MvmVV9vzV5blTVqFGj2LFjB2vXruXhhx+usM66desMdY01ZswY/vjjD1asWMG4ceOu267X61m1ahUADz30kNHtXWPM+VARY851Y46tyjCmT42J7cKFC3z11VcUFBQYynQ6Xa32+fnz569r89KlS3z44YccO3aM+fPno1AoKh0rlCWRkyZNIiYmptxrLl68yMWLF9mxYwfLli0r9/ctOjqaBx98kNzcXENZVlYWWVlZnD17luPHj/Pjjz9WuW5NeOONN1i5cmW5smvv9bvvvuPjjz9Gr9cbtmVmZrJz507++usv3n33XUaPHl1jsQhRX8gIrRCUXelPTExkyZIlLFu2DIAHHnig0q//7bffDAnZuHHj2LRpE6dPn+bvv/9m0aJFDBgwAJVKdd3r1qxZg5eXF99//z2HDx9m7969zJgxA4BNmzZx8eLFKr2PsLAwjh8/jp2dHXPnzuXIkSOcOHGCBQsWYG1tzR9//FHh69RqNYMHDyYsLIzt27dz+vRpwsPD+eabbwgKCuLcuXN8//33hvoJCQmsXbsWtVrNG2+8wZ49ezh9+jQ7d+5kwYIF9OvXD6Wycr9eqvrZLV68mF27dqFWq5k9ezb79+/n1KlTLFu2jBYtWpCRkcGMGTMoLS29rq2qft6LFi3i0KFDWFtb8/7773P48GFOnDjBN998g7m5+Q0/z4ocOXLEcNHg2Wef5cKFC4b/Xn311Vu+vi7f961UdX/VPS5vpKrH3++//84333yDWq1mypQpbN26lZMnT/Lnn38yceJESktLmT17NikpKUa/35o4N4w5Vvr06YOzszMnTpzg8uXL122PiIjg4sWLeHl5ceeddxodR2hoKM2bN+fChQucOHHiun2Eh4cTFxdHUFBQhaNO1X3vxpwPFanuuW7ssVUZ1e1TY2Nbv349np6ehs/mwoULTJ8+vcb7/N82bNiAh4cHS5cu5dSpU4SHhzNr1izMzMz4448/rkvkbhWrTqfjueeeIyYmhlatWhEWFsb+/fs5cuQIS5YsISgoiNOnTzNv3rxy+/vhhx/Izc2lU6dOrFixgqNHj3L06FHWr1/Piy++WO6Cd1XqGkur1bJ69WomTJjA5s2biYiI4MKFC1hZWbF7927mzp2LUqlk4sSJbN68mRMnTrB9+3amTp2KQqHgrbfeIjY2tsbiEaK+kBFacduKiIggODj4unJzc3OefPJJHnvssUrv6+uvvwbgueee49lnnzWUu7u74+7uTu/evSt8nZubG8uWLcPBwcFQ9vTTT3Ps2DH+/vtvDh06RFBQUKVi0Gq1LF++HCi7gjt8+HDDtr59++Lq6sro0aPLXbm9ZsCAAQwYMKBcmbOzMwMGDMDf35+7776bnTt3Gt5bWloaAHfeeWe5K/Te3t54e3vTt2/fSsUMVfvsdDqd4YLD888/z4QJEwzbunXrxpIlSxg0aBAxMTHs2LGDwYMHl2urKp+3Tqfjp59+AuD1118vN/IxYMAAXFxcanTE6Wbq8n1XRlX2Z8xxeSNVPf6+/PJLAN58881yF6p8fHyYNWsWxcXF/PTTT6xevZqpU6ca9X5r8tyoDrVazbBhw1i2bBlr167lhRdeKLf92sjxiBEjKn3R6VYefvhhPvzwwwpHnlesWAHU7OissedDRfur7rlu7LFVGdXtU2Njs7a25ocffsDV1fW6bbXV52q1moULF9KsWTMALCwsmDhxIvn5+Xz11VcsXbq0wv3eKNbt27dz9uxZfHx8+PHHH7GzszNs69mzJy1atODee+9l9erVvPTSS4ZR2vT0dACmT59e7v21bNnS8FjSNVWpWxPGjh173dKDgOEW6xdffLHcxGLNmjVj+vTp6PV6vv32W3799VdmzZpV43EJYUoyQivEf3Tq1ImnnnqqwtuaKhIVFcXVq1extLTkiSeeqFJbd911V7kvyde0b98eKLvlrbIiIyPJysrC0dGRoUOHXre9TZs2dOzY8Yavv3jxIq+++iqDBw+mffv2hufWrt2OdvXqVUNdf39/rKysDFfQq5KM/FtVP7vIyEgyMjKwsLDg0UcfvW67u7u74b3/+9bBa6ryeV9ry9HRkREjRlz3mjvuuKPKow/VVZfvuzKq+jkac1xWpCrHX2xsLDExMdjZ2TFy5MgK6wwZMgSAY8eOVbi9Ku+3ps4NY1xLyNavX1/ued2SkhI2bdoEcMPPorrtWVpasmXLlnK3Xaanp7Njxw4sLS3LXcgwlrHnw432V9VzvSaOrcqqap/WRGyDBg2qMJm9Fk9t9Hn//v0Nyey/Pf744ygUCqKjow0XjSoT6+7duwG47777yiWz17i7u9OpUyeKi4sNjxsBhISEALBy5UoyMjJuGnNV6taEsWPHXleWkZHB6dOnUavVN7wt/Z577gGMPxaFqI9khFbctv69bE9BQQERERF89NFHhIeHM3XqVH744YdKjWBcm/AhICAAS0vLKsXg7e1dYbmtrS1Q9lzXNUuWLOHjjz++ru78+fO5++67DZOg+Pr63jBuPz+/CieG2LVrF88999xNJ6L6dyy2tra89dZbvPHGG0yYMAEXFxfatWtHu3bt6Nu3r+EP/K1U9bO79h6bNWuGubl5hXUCAwPL1f23qnzeSUlJQNloRkW3i0NZ8vLv50JrS12+78qoyv6MOS5vpCrH35UrVwDIzc2lXbt2AIYk87//Xhtp+a+qvN+aOjeM0bJlS1q1asW5c+cIDw+nR48eQNmX+8zMTDp16oSvr2+NtWdvb88999zDmjVrWL9+PY888ghQ9jhBSUkJw4YNw97evsbaM/Z8+K/qnus1cWxVVlX7tCZiqyixvKa2+rx58+YVltva2uLm5kZKSgpJSUnXJa83ivXa5/DVV18Z7gbS6/XXfQZAuUR5woQJ7N27l02bNrFlyxaCg4Np06YNnTt3pn///uWS46rUNZZCoajwvV57nyUlJXTp0qXce/vvvxVdEBCioZMRWiEou12pS5cuLF68GFdXVw4fPmy4bao21dQtf8bQ6/W89dZblJSUMGTIEFauXMmhQ4cMz+YcOXKkwtfdd9997Nixg9dee40uXbpw6dIl5s+fz8iRI5kwYQJ5eXm1EitQ6dHz/6rO532ztupq9M0U77su91cdlT3+/j2apdVq0Wq16HQ6dDpduS+2wA0v6FT1/Zri3PivayN61y7awf/fmlqTo7PXXBs1uvZ7U6/Xs3r1agAefPDBGm3L2PPhRqp6rtfEsVUVVenTmojNysrqpvHUZZ9f2z9U3E83ivXa56DT6cp9Dv/9DKD852BlZcXPP//MsmXLeOyxx7CysmLTpk3MnDmT3r17l5v0rSp1K/seb0SpVFZ4Eeffr6uLY1GI+kZGaIX4FycnJ6ZNm8Ybb7zBN998w6hRo7CwsLjpa65N+BAdHY1Go6nyKG1lTZo0qdxzMf/l7u4OlN1qptPpKvwS/t9ZHq/VT0pKokmTJnz++efXfVmIioq6YZtubm48+uijhtv+rl69ykcffcS2bdv49NNPefPNN2/6nqr62Xl4eAAQHx9PcXFxhX/Yr8V77fOormttxcbGotVqKxy5qWiClpup7hfwunzfNa26x2VlVOb48/T0BMo+w2u3H9YFY88NY5O1YcOG8fHHH7N9+3by8vIoLi5m9+7dWFlZGW41rYzKxtG2bVvatGnDmTNnOH78OBqNhtjY2GpNDHSrNmv6fKjuuV7Xx1ZV+rQuYqvJPr/mRr9T8/LyDCOLVfkdd+1zeOONNyqckflWunXrRrdu3YCymbV3797NzJkzef311+ncuXO50dLK1FWr1QDk5+dX2F58fHyVY4T/P4bt7e0JDw/HzEy+3ovbi+kvswtRz4waNQovLy9SUlIMSw/cTEBAAN7e3hQWFrJkyZI6iLBigYGBODo6kpWVZXim6t/OnDlT4bMz126XtLCwqPCL5KJFiyodg7e3t2EyrcrcilvVzy4wMBBnZ2c0Go1hoqF/S0lJMbx3Y5fUudZWVlYW69evv277iRMnqny78bUv3jf6MnOrWOrifde06h6X1VHR8RcYGIi3tzdJSUls3bq1RtqpqdhuprrHyjVOTk707dsXjUbDli1b2LRpEyUlJQwcONBwq3RlVCWOMWPGAGUjdsZMDHSrNmv6fKjuuV7Xx1ZV+rSuYqupPr9m586dFSZ133//PXq9Hn9//xs+11uRa5MKrly5stySPtVhZmbGgAED6NSpEyUlJZw+fbrKdZ2cnFCr1aSmppKYmHjd63777bdqxebu7k5wcDA5OTlVGhEWorGQhFaI/1Cr1YYJihYvXlyp5wuvzc77v//9j/fee4/IyEiKi4tJSUnh77//5plnnuHs2bO1GrdKpTJ8uXjnnXdYt24deXl5aDQadu/ezbRp0yq8ncnX1xdra2vi4+N57733SExMpLCwkIiICKZNm8b27duve822bduYPHky69evJzIykvz8fAoKCjh16pRhZk03N7dKxV2Vz06pVDJ+/HgAPvvsM3788UcyMjIoLi7m0KFDTJo0icLCQnx9fa+btbmqlEql4Yr+u+++y+rVq8nJyaGwsJAdO3ZUuG7vrVwbLfj777+Ji4tDq9VWOpa6et81rbrH5c1U9fi71lczZ85k3rx5nD9/ntzcXPLz84mKiuL3339n6tSpFSbcVVVT50Z1j5V/+/ctqtVde7YqcQwdOhR7e3u2bNnC9u3bsbKyqtbEQLdqs6bPB2PO9bo8tqBqfVoXsdVUn19TUlLC5MmTCQ8Pp6ioiIyMDL777jvCwsIAys1oXRlDhgwhODiY8+fP88gjj7B582YSEhIoLi4mOTmZ48eP87///e+6iZamTJnCxx9/zOHDh0lKSqKkpIS0tDRWrlzJwYMHgf8/j6tS19zcnA4dOqDX63n55Zc5f/48Go2Gy5cv8+GHHxpm766Oa0uJvfXWW3zwwQecPXuWnJwcCgoKiI6O5o8//mDatGn8+uuv1W5DiPpK7kkQogKjR4/m22+/JTExkXXr1t3yeaBRo0YRFRXF4sWL+fHHHytcRH3KlCm1Fa7B008/zYEDBzh+/Ph10/I7OTkxaNAgtm3bZrjtCcpGZidPnsznn39eYeyPPvrodWUlJSX89ddf/PXXXxXGYW1tzXPPPVepmKv62T355JOcPHmSXbt28d577/Hee+9d9z7nz59fI7dcPfXUUxw8eJBDhw7x6quvllsH09HRkcGDB1dpDdUePXpga2tLVFQUAwcONJSPHz/+luuL1uX7rmnVOS5vpqrH34gRI7h69SpffvklixYtuuFdB3fddVfl3lANxnYjxhwr1/Tu3RtXV1fDCHhl1p41Jg5LS0vuu+8+fvjhB4BqTwxUmTZr+nyo7rlel8cWVK1P6yK2murza4YNG8b27dsrTFwHDx5c5WdzVSoVYWFhPPXUU0RERPD8889XWO+/o76JiYns2rXrhncODRgwgM6dO1e5LpQtUff4449z+PDh62bVnjBhAkuXLq3s2yunf//+vPrqq3z00UcsW7bshslxVWeVF6IhkBFaISpgYWFheF514cKFlJaW3vI1L7/8MkuXLmXQoEG4ubmhVqvx9PSkT58+fP3117Ru3bq2w8bCwoLvv/+eZ555Bh8fH9RqNa6urgwfPpzffvvNsPTItbX2rpkyZQrvvvsuQUFBqNVq7Ozs6NixI5988gkvv/zyde0MGjSIhQsXMnLkSAIDA7G2tsbe3p6goCAmTpzIxo0bDTNrVkZVPjszMzO+/vpr3n33XTp06ICNjQ1qtZpmzZrx6KOPsn79elq1alXNT7A8c3NzFi9ezHPPPYevr6/h8xw6dChr1qy54ey3N+Lg4MDixYvp0aMHDg4OVXpOsi7fd02r7nF5I9U5/qZOncqqVasYOXIk3t7emJubY2dnR4sWLRg+fDjffvtthcsKVVVNnRvGHCvXmJmZlRstq87as1WN499LhlT31tPKtFnT54Mx53pdHVtQ9T6ti9hqos+vadWqFatWrWLgwIE4OTlhbm5OYGAgs2fP5rPPPqvWeeDl5cXq1at57bXX6Ny5Mw4ODqjVajw8POjYsSPTp0+/7tb1BQsW8Morr9C1a1fc3d0xNzfH09OT0NBQPv30U/73v/8ZYqlKXSi7Df67776ja9euWFtbY2VlRbt27fjkk0+uW2O4qsaPH8/atWt54IEH8PHxwcLCAhsbGwICArjnnnv48ssvDXfMCNGYKPSmWCRPCGESo0aNIiIighUrVpRbAF4IU5LjsvHYt28fEydOJCgoiI0bN5o6HFEHaqLP582bx6JFi5g5c+ZNJz8UQoiKyAitELeJI0eOEBERgY2NTb0dyRO3HzkuG5dffvkFMH6kTjQc0udCCFOThFaIRmb69OmsW7eOmJgYiouLSUtLY9WqVUydOhWgUksRCVHT5Lhs3IqLi1m/fj3bt2/H2traqImBRMMgfS6EqC/q3+whQgijnD179obLNLRu3dowE6IQdUmOy8br2i3j10yaNMmoiYFE/Sd9LoSoTyShFaKR+fLLL/npp584ceIECQkJAPj4+DBkyBDGjx+PtbW1iSMUtyM5Lhs/d3d3Ro0axdNPP23qUEQdkT4XQtQHMimUEEIIIYQQQogGSZ6hFUIIIYQQQgjRIElCK4QQQgghhBCiQZKEVgghhBBCCCFEgySTQtWSo0ePAqBQKEwciRBCCCGEEKK+ujalUadOnUwcScMkI7S3CZn7q/GSvm2cpF8bL+nbxkv6tnGSfm28pG8bBxmhrSXXRmY7duxo4kigsLCQs2fP0qpVK6ysrEwdjqhB0reNk/Rr4yV923hJ3zZO0q+NV33q22PHjpm0/YZORmiFEEIIIYQQQjRIktAKIYQQQgghhGiQJKEVQgghhBBCCNEgSUIrhBBCCCGEEKJBkoRWCCGEEEIIIUSDJAmtEEIIIYQQQogGSRJaIYQQQgghhBANkiS0QgghhBBCCCEaJElohRBCCCGEEEI0SJLQCiGEEEIIIYRokCShFUIIIYQQQgjRIElCK4QQQgghhBCiQZKEVgghhBBCCCFEgyQJrRBCCCGEEEKIBsnM1AGI2lWi1fF3dAan4gtJs8ygf0tP1Cq5jiGEEEIIIW4PcZ8PpyQlqlyZTq/HoqiIKxYWKBUKQ7m6SQA+z2+o6xCFESShbaRKtDo+2hnJ13tjSM4rKivck4mHnQVTe/jxSv9ASWyFEEIIIUSjV5ISRVHC2evKlUBJ3YcjapgktI1QiVbHfd8fZvO5FBT/2ZacW8QbWy9wMDaTtY93kaRWCCGEEEII0WBJNtMIfbQzks3nUgDQ/2fbtZ9/P5fC3J2RdRqXEEIIIYQQQtQkSWgbmRKtjq/3xlw3MvtfCuDrfTGUaHV1EZYQQgghhBBC1DhJaBuZfZczSM4rum5k9r/0QFJuEfsuZ9RFWEIIIYQQQghR4yShbWQyCqr2aHtV6wshhBBCCCFEfSEJbSPjbK2uUv2v9l5md1Qaev2txnSFEEIIIYRoWPR6PVpNrqnDELVIEtpGpkdzZ9xtLW75DO01u6LS6ftNOCEf/8X8v6PJLCiu1fiEEEIIIYSoC5orEcR9MpjSjHhThyJqkSS0jYxapeSZnn63fIYWoJ2nHeb/LNtzPiWPGesj8Hr7Tx7/9QQHYzNl1FYIIYQQQjQ4pXnpJP7wLNGvtyc/4k9ThyNqmaxD2wi90j+Qg7GZ/P7POrT/Tkuv/XxvqyasfbwL2YUlLD18hbDwGKLSC9CU6lh6OJ6lh+O5w8ueKd19GduhKXaWcqgIIYQQQoj6S19aQsbOb0ld9xa6/MyyQoUSpbXD//8sGh3JUhohtUrJ2se7MHdnJF/viyEpt8iwzd3Ogmd6+DGrfyBqlRJXWwte6hfAC3382RmZRlh4LOvOJKHV6TmRkMOU1ad5aeNZHunYlMmhvtzh7WDCdyaEEEIIIcT18k5tJemXFyhOOGcoswkZgPvYz0lZ/SolKVHl6uv0eoqKirCwsECp+P+H9dRNAuosZlEzJKFtpNQqJa8NDGJW/0B2nk/k1KXLtGvRnP4tPVGrrr/TXKlUcFeQG3cFuZGQreG7Q3EsPBBLfJaGvCItYeGxhIXHcqePI1NC/XjwDk+szeXwEUIIIYQQplOUeIHkX14g7+RmQ5m6SQAeYz7FtsNwFAoFPs9vuO51hYWFnD17loCQEKysrOoyZFHDJCNp5NQqJb39nXHVJBHi71xhMvtfXg6WvDYwiNkDWrD1fAph4bH8fi4ZvR4OxmVxMO4Ez2+I4LHOZaO2rdzt6uCdCCGEEEIIUUabn0nqunfI2PEVaEsBUFra4TridZwHTkOptjBxhKKuSEIrbkilVHBviDv3hrgTm1HA4oNxLD4YR1JuEVmFJczfc5n5ey7TJ8CFyd18GdXOAwszlanDFkIIIYQQjZReW0rmX4tIXfM62rz0skKFAsfek2hy/3uYObibNkBR5yShFZXi62zNu0Na8sagIDZEJBG2P5btl9IA2B2Vzu6odFzXmTOxazOe6uZLgKuNiSMWQgghhBCNSV7EDpKXz6DoyhlDmXVwb9zHfYGVbwcTRiZMSRJaUSVqlZL723lxfzsvLqXmsfBAHN8fiiO9oIS0/GI+3hXFx7uiGBTkxpTuvgwLccesErc5CyGEEEIIUZHi5EiSf32Z3GPrDGVqVz/cH/4Eu873o/jXpE7i9iMJrai2Fm62fDIshHfvDmbN6UTCwmPZE50BwLaLqWy7mIqXvSVP3OnDE3f60MxJHrgXQgghhBCVoy3MIW3De2Rsm4++tBgAhYUNrsPm4DL4BZTmliaOUNQHktAKo1mqVYzt2JSxHZsSkZTLgvBYlh2JJ0dTSkKOhnf+vMh72y8yNMSdyaG+DA5ugkopV9KEEEIIIcT19DotWXuWkrJ6DtqcFEO5Q4/xNHngQ9ROXiaMTtQ3ktCKGtXaw44vR7bhw3tasuJEAmHhsRyOz0Knhw0RyWyISMbXyYqnuvkysWszPOzlypoQQgghhCiTf2EPyT9PRxN73FBmFRiKx9gvsAroasLIRH0lCa2oFTYWZky804eJd/pwND6LBQdiWX7sKvnFWmIzC3l1y3ne/OMCI9t6MCXUj36BLvL8gxBCCCHEbao4NYaUFTPJObzKUGbm3BT3B+di323Mbf89Ua/Xs27dOv744w+ys7Px8/PjkUceoXXr1qYOzeQkoRW1rlMzRxY2c2TesBB+PnaVb/fHcDoxl1KdnlUnE1l1MpEgNxsmh/ryWOdmuNiYmzpkIYQQQghRB3SaPNI2fUT61nnoS4oAUJhb4XLPTFzveRmlhaycATBnzhy2bdvGzJkzCQgIYOPGjTz44IOEhYXRq1cvU4dnUpLQijpjb6nm6e5+TAn15UBsJmHhsaw4kUBRqY6Lqfm8uOEsczaf58H2XkwO9aW7n9NtfzVOCCGEEKIx0ut0ZO//iZRVsynNSjCU23cbg/uDc1G7NDNhdPVLeHg4a9as4YMPPuD+++8HoHPnzsTHx/P666/z559/olarTRyl6ch6KqLOKRQKQv2cWTamAwlvDuSz4SEEuZVdfSsq1fHj0Sv0/Gof7ebt5uu9l8kuLDFxxEIIIYQQoqYURIZz+d1QEhY9ZkhmLZt3xu+1fTR9erkks/+xfv161Go19957b7nykSNHkpiYyMGDB00UWf0gCa0wKWdrc57vE8D5Wf3Y+XQoD7b3wuyfGZDPJOXy7NozeL3zJ0+uPMnR+CzTBiuEEEIIIaqtJOMKV8LGEfNudzTRhwAwc/TE68mlNH/jINYtups4wvrpzJkz+Pr6YmlZfjLVli1bGrbfzuSW41pWWFho6hDQaDTl/q2vunnb0O2BED69J5C1pxNZeSqBhOyyZyl2nk9g5/kEWnvY8lB7b4a0bIKVucrEEZteQ+lbUTXSr42X9G3jJX3bOEm/1gxdcQHZ2z4n+4/P0JeUfTdWmFlgf9c0HO9+GaWlLZqiojqNqSH1bWpqKi1atLiu3NnZGYC0tLS6DqlekYS2Fun1es6ePWvqMAyio6NNHUKldbeH7j0dbrA1k8uRmXUaT33XkPpWVJ70a+Mlfdt4Sd82TtKv1aTXo7q0DbO9X6LMSzYUawP6U9JzOgUO3iRFx5kwwPrTtzebN0ar1aJUXn9j7bWykpLb+/E8SWhrkUKhoFWrVqYOA41GQ3R0NP7+/tfdqtBQJOdqWH0qkdUnk0jNL38Fr4OXPQ928GZQkCsWZrfXqG1j6FtxPenXxkv6tvGSvm2cpF+rryj2KOkrZ1IUFW4oM2/aFucH52EVZPpZeetT3547d+6m2+3s7MjPz7+u/FqZnZ1drcTVUEhCW8usrKxMHYKBpaVlvYqnKvysrHjpLidm9GvJprPJhIXH8seFVACiszP47VwGztZqHu/SjMmhvrRwszVxxHWrIfetuDHp18ZL+rbxkr5tnKRfK68kK5GUVXPI3rvUUKayc6PJ6Pdx7D0RhbJ+DT40hL719/ev8DnZ+Ph4w/bbmSS0okExUym5r60n97X1JDo9n0UH4lhyKI7UvGIyCkr4dHc0n+6OZkALV6aE+jKijQdqlcx9JoQQQghRm3TFGjL++Jy0TR+g0+SVFarUuAyajuvw11BZ3+hRMnErvXr1Yu/evZw5c4Y2bdoYyvfs2YNKpaJnz54mjM705Ju+aLD8XWz48N5WxL9+F78+0pG+AS6GbTsupfHAD0fxeXc7r205T2xGgQkjFUIIIYRonPR6PTmHfyNqTggpq+cYklnbDsMJ+CAC94c/kWTWSA888AAeHh58+OGHhtuMIyIi+OWXXxgzZgxNmjQxcYSmJSO0osGzMFPxUAdvHurgzfnkXBYciGXp4StkFZaQlFvE+9sv8cGOSwxp2YQpob7c08odlfLGD94LIYQQQohb08SeIGn5DArO7zaUWXi3xn3s59i2GWjCyBoXGxsbvvvuO1555RV69+6Nh4cH8fHxjBw5kldeecXU4ZmcJLSiUWnpbsfnI9rwwT2tWHkigbDwWA7EZqLXw+ZzKWw+l0IzR0ue7ObLpK4+eDnIBA9CCCGEEFVRmpNCyurXyPp7Mej1AKhsXXAb9Q5OfZ9CoZIUo6YFBASwatUqkpKSyM7OxtvbG1vb22vOmBuRo000SlZqFY91acZjXZpxMiGbBeGx/Hj0CnlFWuKzNLyx9QJvb7vIiNbuTAn1Y0ALV5QyaiuEEEIIcUP60mLSt31J2oZ30RXmlBUqVTjf9Sxu972JysbJtAHeBjw8PPDw8DB1GPWKJLSi0Wvv5cA397dj7r0h/HL8Kt/uj+FEQg5anZ41p5NYczqJABdrJof6MqFLM9xsLUwdshBCCCFEvaHX68k7sYnkX16gODnSUG7T9m48xn6GhZfpl6kUty9JaMVtw87SjKdCfXmymw+H47MI2x/LryeuUliiIyq9gJmbzvHalgvc386TKaG+9PJ3vuki10IIIYQQjZ3mSgTJy58nP+JPQ5m5ZzDuYz7Hrv0QE0YmRBlJaMVtR6FQ0NXHia4+Tnw6PIQfj14hLDyWc8l5FGt1/HL8Kr8cv0ord1umhPoyvnMzHK3Upg5bCCGEEKLOlOalk7rmTTJ3hYFOC4DS2hG3kW/h3H8qCjP5biTqB0loxW3Nydqcab38ea5nc/ZEZxAWHstvpxIp1uo4l5zH9HURvPL7OR6+w5sp3X3p0sxRRm2FEEII0WjpS0vI2PktqeveQpefWVaoUOLUbzJuo97BzM7VtAEK8R+S0ApB2aht7wAXege4kJpXxNLD8SwIjyUqvYDCEh3fH47n+8PxdPC2Z0qoH2M6eGNnKaePEEIIIRqPvFNbSfrlBYoTzhnKbEIG4D72cyybtTVhZELcmHwjF+I/3GwteLlfIC/2CWDHpTTCwmNYH5GMVqfn+NUcJq8+xYsbI3ikY1OmdPelvZcsFi6EEEKIhqso8QLJv7xA3snNhjJ1kwA8xnyKbYfhcneaqNckoRXiBpRKBQOD3RgY7EZCtoYlh+JYGB7LlWwNeUVawsJjCQuPpZuvE1NCfXnwDi+s1CpThy2EEEIIUSna/ExS171Dxo6vQFsKgNLSDtcRr+M8cBpKtaz8IOo/SWiFqAQvB0teHxjE7P6BbDmfQlh4LFvOp6DXw4HYTA7EZjJjfQQTujRlcjdfWrrbmTpkIYQQQogK6bWlZP61iNQ1r6PNSy8rVChw7D2JJve/h5mDu2kDFKIKJKEVogrMVEqGtfZgWGsPYjIKWHwwjsUH40jOLSKrsIQv/r7MF39fpm+AC1NCfRnZ1hNzM6WpwxZCCCGEACAvYgfJy2dQdOWMocw6uDfu477AyreDCSMTonokoRWimvycrXlvSEveHBTE+jNJhIXHsuNSGgB/RaXzV1Q6brbmTOziw1OhPvi72Jg4YiGEEELcroqTI0n+9WVyj60zlKld/XB/+BPsOt8vz8mKBksSWiGMpFYpGd3ei9HtvbiYmsfC8Fi+PxxPRkEJqXnFzN0VydxdkQwOdmNKqC9DQ9wxU8morRBCCCFqn7Ywh7QN75GxbT760mIAFBY2uA6bg8vgF1CaW5o4QiGMIwmtEDUoyM2WecNb896Qlqw+lUjY/hj2xZSt4fbHhVT+uJCKl70lT3bz4Yk7fWjqaGXiiIUQQgjRGOl1WrL2LCVl9Ry0OSmGcoce42nywIeonbxMGJ0QNUcSWiFqgaVaxSOdmvJIp6acScxhQXgsPxy9Qo6mlIQcDW9vu8i7f15kWIg7U7r7MSjIDaVSbvURQgghhPHyL+wh+efpaGKPG8qsAkPxGPsFVgFdTRiZEDVPElohalkbT3v+N6otH93bil9PJBAWHsOR+Gx0elgfkcz6iGT8nK14qpsvE7v64G4nU+QLIYQQouqKU2NIWTGTnMOrDGVmzk1xf3Au9t3GyHOyolGShFaIOmJjYcakO32YdKcPR+KzWBAey/LjVyko1hKTUciczed5848LjGzjyZTuvvQNcJE/PEIIIYS4JZ0mj7RNH5G+dR76kiIAFOZWuNwzE9d7XkZpIRNTisZLElohTKBzM0c6N3Nk3rAQfjp6hbDwWM4k5VKi1bPyZAIrTyYQ5GbDlFBfHuvSDGdrc1OHLIQQQoh6Rq/Tkb3/J1JWzaY0K8FQbt9tDO4PzkXt0syE0QlRNyShFcKEHKzUPNOzOVN7+BEek0lYeCwrTyZQVKrjYmo+L2w4y+zN53noDi+mhPrSzddJRm2FEEIIQUFkOEk/z0ATfchQZtm8Mx7j5mPdorsJIxOibklCK0Q9oFAo6N7cme7Nnfl8RGuWHYknbH8sl9LyKSrV8cORK/xw5AptPe2YEurHI528sbdUmzpsIYQQQtSxkowrJK+cRU74ckOZmaMnTR74EIfuj6JQytKA4vYiCa0Q9YyLjTkv9Ang+d7+7IpMJyw8hrWnkyjV6TmdmMsza04zc9NZxnb0ZkJHD2QKKSGEEKLx0xUVkL75E9I2z0VfXAiAQm2By90v4jp0NkpLWxNHKIRp1OuEVqvVsnfvXs6ePUtBQQGenp7cddddNGnSpML6iYmJbN26leTkZDw8PBgyZAju7u51WleImqJQKOjfwpX+LVxJytHw/eF4FoTHEptZSH6xlkUH4lh0II4QZzXPFV7l0S5+2FjU61NaCCGEEFWk1+vJObiC5BUzKc2IN5Tbdb4f94c/wdytuQmjE8L06u09CVFRUdxzzz2sWLGC0tJSLC0t2bhxI/379+fHH3+8rv7u3bsZMmQIhw4dws3Njf379zNkyBDCw8PrrK4QtcXD3pLZA1oQNWcAm5/oyvDW7lxbtvZsRglPrz2H9zt/Mm3tGSKSck0brBBCCCFqROHlI8S834ur344xJLMWPu3xnf0XzZ5bLcmsEIBCr9frTR1ERdLS0gBwdXUtV/7kk0+yb98+du/ejZubGwDZ2dkMHDiQ0NBQ5s+fb6j79NNPc/r0af744w9sbGxqte5/HTt2DICOHTsa+1EYrbCwkLNnzxISEoKVlZWpwxE1JD6zkG/3RbHoQCxphbpy23r5OzO5my/3t/PEUq0yUYSiuuScbbykbxsv6dvGyVT9WpKVSMqqOWTvXWooU9m50WT0+zj2nohCKX/bjVWfztn6lDc0RPV2hNbV1fW6ZBagS5cuaLVaEhMTDWWbN28mOzub8ePHl6s7fvx4UlNT+fPPP2u9rhB1rZmTFa8PCGDTCHd+GduOQUFuhm17ojN4ZPlxmr7zJy9vPMul1DwTRiqEEEKIytAVa0jb+CFRs4L+P5lVqXEZ8hKBH1/Cqe+TkswK8R/1NqGtSGlpKbt378bd3Z2goCBD+bFjx1AoFLRt27Zc/fbt2xu213ZdIUzFTKlgREgT/pjcjcjZ/ZnVLxBXm7J1a9MLSpj3VxRBH+1iYFg4v51KoESru8UehRBCCFGX9Ho9OYd/I2pOCCmr56DTlF2Itu0wnIAPInB/+BNU1g4mjlKI+qnezyCzZ88edu3aRX5+PkeOHKFFixb88MMPWFpaGuokJSXh4OCAubl5uddaW1tja2tLQkJCrde9kcLCwiq939qg0WjK/Ssaj//2rZeNkjcH+PFKHx82nE1h8aEr7InJAmD7pTS2X0rD3dacCZ29mdjZm2aOljfatTAhOWcbL+nbxkv6tnGqi34tij9JxsqZaC7tMZSpvUJwGT0Xq5AB6Kgf3ycbGzlnG496n9A6Ojri7+9PVlYWcXFxnDx5kmPHjuHn52eoU1RUdF3SeY25uTlFRUW1Xrcier2es2fP3rROXYqOjjZ1CKKWVNS3rc3g8+7WXG6tZk1kAZuiC8gt0ZOcV8zcvy7zye7L9PC0YFQLG7p7WqC6NsuUqDfknG28pG8bL+nbxqlW+rUgA3X4t6gi1qGgbEobvaUDJd2mUNhmJDmYQT36HtlY1ZdzVqGQ72HVVe8T2rZt2xpu+X322Wd54403mDNnDkFBQbRp0wYAS0vLGyaXGo2m3IPetVW3IgqFglatWt20Tl3QaDRER0fj7+9fbmRbNHyV6dsQ4N5QKCjW8tuZZBYfusLhKzno9LAnoYg9CUU0c7Dk8c5ePNbZG087WdnW1OScbbykbxsv6dvGqTb6VV9aTM7Ob8jc/BF6TU5ZoVKFfd8pON47B5WNU420I26uPp2z586dM2n7DV29T2j/a/To0axYsYK9e/caEtpmzZpx8OBB8vPzy806nJ2dTUFBAc2aNTOU1VbdGzH1rGn/ZmlpWa/iETWnMn1rZQVP9bDlqR4BnLiazYLwWH46doW8Ii3x2Rre2RHNB7suM6KNB1NCfekf6IpSRm1NSs7Zxkv6tvGSvm2caqJf9Xo9eSc2kfzLCxQnRxrKbdrejcfYz7DwMv0gyO1IztmGr0FNCgWQn58PUO5KSteuXYHrJ2k6fPgwAN26dav1ukI0JHd4O/Dt6HYkvDGIsNFtae9lD0CpTs9vpxIZuOAAwXN3MW9XFGl5N7+1XgghhBA3p7kSQdwng4n/YrghmTX3DKbZC7/j+9IWSWaFMEK9TWjDw8PJzMwsV5afn88333yDpaUlAwcONJQPHjwYT09PFi5cSElJCQDFxcUsXrwYPz8/+vbtW+t1hWiI7CzNmBzqx/EXenNgWk8mdGmGpVnZr4XItHxe3nQW73e288jPx9gTnU49XbZaCCGEqJdK89JJ/OFZol9vT35E2XKPSmtH3Md+TsB7p7Frf4+JIxSi4au3txynp6fz8MMP4+Hhgbe3N7m5uRw6dAgbGxvCwsLw9vY21LW0tOTrr79m6tSpjBw5kjvuuINjx46h0WhYsGABarW61usK0ZApFAru9HXiTl8nPhsewg9HrhAWHsv5lDyKtTp+PnaVn49dJcTdlimhfjzauSmOVnL8CyGEEBXRl5aQsfNbUte9hS7/nwEahRKnfpNxG/UOZnaupg1QiEZEoa/HQy4lJSWcPHmSmJgYlEolzZs3p127dqhUFS8ordFoCA8PJyUlBQ8PD0JDQ284S3Ft1b3m2m3KHTt2rMI7rh2FhYWcPXuWkJAQeUagkanNvtXr9eyJziAsPJbVpxIo0f7/rwortZIxHbyZEupH52YOMjNfDZNztvGSvm28pG8bp+r0a96prST98gLFCf8/0Y9NyADcx36OZbO2tRWqqKL6dM7Wp7yhIaq3I7QAarWazp0707lz50rVt7S0pF+/fiatK0RjoVAo6B3gQu8AF77Ibc3Sw/EsOBBLdHoBhSU6vjsUz3eH4unY1IHJ3XwZ29EbW4t6/StFCCGEqDVFiRdI/uUF8k5uNpSpmwTgMeZTbDsMl4u/QtQS+fYphLilJnYWzOwfyEt9A9h+KZWw8Fg2RCSj1ek5diWbyatP8dLGszzSqWzUtt0/k0wJIYQQjZ02P5PUde+QseMr0JYCoLS0w3XE6zgPnIZSLcvhCVGbJKEVQlSaUqlgUHATBgU34Wp2IUsOxrPoQCxXsjXkFpXy7f5Yvt0fS6ivE1O6+/JAey+s1BU/IiCEEEI0ZHptKZl/LSJ1zeto89LLChUKHHtPosn972Hm4G7aAIW4TUhCK4SoFm8HK94YFMScAYFsOZ9CWHgsW86noNdDeGwm4bGZzFgXwYQuzZgc6ktwE1tThyyEEELUiLyIHSQvn0HRlTOGMuvg3riP+wIr3w4mjEyI248ktEIIo5iplAxr7cGw1h7EZBSw6EAsiw/GkZJXTGZhCZ//Hc3nf0fTL9CFyd18GdnWE3OzertimBBCCHFDxcmRJP/6MrnH1hnK1K6+uD88D7vO98tzskKYgCS0Qoga4+dszfv3tOLNQcGsj0gibH8sOyPTANgVmc6uyHSa2JozsasPT3XzpbmLtYkjFkIIIW5NV5hD8oY3ydg2H31pMQAKCxtch87G5e4XUJrLzNZCmIoktEKIGmdupuSB9l480N6LCyl5LDwQy9LD8WQUlJCSV8xHOyOZuyuSwcFuTAn1495WTTBTyaitEEKI+kWv06KKWEf89wvR5aYYyh16jKfJAx+idvIyYXRCCJCEVghRy4Kb2PLp8Na8P6Qlq08lErY/hn0xmej1sPV8KlvPp+LtYMmTd/rwRDcfvB3kKrcQQgjTy7+wh8Qfn8M8/iS6f8qsAkPxGPsFVgFdTRqbEOL/SUIrhKgTlmoVj3RqyiOdmnI6MYcF4bH8cOQKuUWlXM3W8Na2i7y7/RLDQtyZHOrLoCA3lEp5FkkIIUTdKk6NIWXFTHIOrzKUqZy88XjoY+y7jZHnZIWoZyShFULUubae9nw1qi0f3duKX49f5dvwWI5dyUar07PuTBLrziTR3Nmap7r5MLGrD03sZA0/IYQQtUunySNt00ekb52HvqQIAIXaiuIOj+A77gNsHF1NHKEQoiKS0AohTMbWwownuvnyRDdfjsRnEbY/ll9OXKWgWMvljAJmbz7PG39cYFRbT6aE+tInwEWujAshhKhRep2O7P0/kbJqNqVZCYZy+25jcBj+NheTclBa2JgwQiHEzUhCK4SoFzo3c2TxQ458OjyEn45e4dvwWCKScinR6llxIoEVJxIIdrNhSnc/xnduirO1ualDFkII0cAVRIaT9PMMNNGHDGWWzTvjMW4+1i26U1hYCElnTRihEOJWJKEVQtQrDlZqnunZnKk9/Ngfk0lYeAyrTiZSVKrjQmo+z6+PYPbv53joDi8mh/rSzddJRm2FEEJUSUnGFZJXziInfLmhzMzBgyYPfoRD90dRKGXmfSEaCklohRD1kkKhoEdzZ3o0d+bz4UUsO3KFsPBYItPy0ZTqWHbkCsuOXKGdpz1TuvsyrqM39pZqU4cthBCiHtMVFZC++RPSNs9FX1wIgEJtgfPgF3AdOhuVlZ2JIxRCVJUktEKIes/V1oIX+wbwfG9/dkWmERYey7ozSZTq9JxKzGHqb6d5eeNZxnX0ZkqoHx2aOpg6ZCGEEPWIXq8n5+AKklfMpDQj3lBu1/l+3B/+BHO35iaMTghhDElohRANhlKpYECQGwOC3EjK0fDdoXgWHoglNrOQ/GItCw/EsfBAHF19HJkS6stDd3hhbS6/5oQQ4nZWePkIST/PoPDSPkOZhU97PMbNx6ZlHxNGJkTdiI+PJyYmBltbWwICArC3tzd1SDVKvukJIRokD3tL5tzVgln9A/njQgph+2P5/VwyOj0cisviUFwWz6+P4LEuzZjczZcQD7mNTAghbiclWYmkrJpD9t6lhjKVnRtNRr+PY++JKJQq0wUnRB3YsGEDixYt4urVq3To0IHMzEyioqJ49NFHmTFjBmZmjSMVbBzvQghx21IpFdzTyp17WrkTl1nA4oNxLD4YR2JOEdmaUr7cc5kv91yml78zU0J9ub+dJxZm8iVGCCEaK12xhow/Pidt0wfoNHllhSo1LoOm4zr8NVTW8liKuD2sWrWKdu3asXz5cuzsyi7sb9myheeffx6lUskLL7xg4ghrhkzhJoRoNHycrHnn7pbEvnYXvz3WmYFBroZte6IzGPfzcZq+s52ZG88SmZZvwkiFEELUNL1eT87h34iaE0LK6jmGZNa2w3ACPojA/eFPJJkVt5XnnnuO999/35DMAgwZMoRWrVqxfv16E0ZWs2SEVgjR6KhVSka182RUO08i0/JZGB7L94fjScsvJi2/mE/+iuKTv6IYGOTKlFA/hrV2R62S63tCCNFQaWJPkLR8BgXndxvKLLxb4z72c2zbDDRhZEKYTteuXSss1+l0aDSaGm0r++AKUte+We3X29/5ME1GvlWt10pCW8sKCwtNHYLhgK3pA1eYnvTtrXnbKHn7rua82s+H7RfSWHEygaNXsgGISs7i5XUn+PhPc+5v58n97TzxtLc0ccTSr42Z9G3jJX1rGtqcFDI3vE3uvqWg1wOgtHHGadjr2PWahEJlZtR3MenXxqsh9W1aWhpHjhypVN127drh5eV1w+1Hjx7l/PnzDB48uKbCA0Cbn0lx4gVU9k2qNGt4aU4KJamX0WYnVbtthV7/z9kvatSxY8eQj1YIIYQQohZoSzA7+StmhxajKC57hESvUKFt9wAldz4JlnJrsWhYFAoFHTt2rHDb33//zZNPPlmp/Xz88ceMGDGiwm1ZWVncf//9pKens2bNGvz9/asd739l7AwjadnTOPWbjOeEsFp/3b/JCG0tUigUtGrVytRhoNFoiI6Oxt/fH0tL048+iZojfWscTYmWLedTWHkygdOJueW2edpb8EA7T0a19cTV1qJu45J+bbSkbxsv6du6odfrKTy9mfRVr1CaGmUot2o9EOfRczH3bFmj7Um/Nl71qW/PnTt30+1ubm6VHlH19vausLygoIApU6aQmJjI559/XqPJLIDK0g61qy8qW5c6ed2/SUJby6ysrEwdgoGlpWW9ikfUHOnb6rGygrFdbRnb1Z9jV7JYEB7Lz8eukl+sJTq7lH3xkby0JYr72ngwJdSXfoGuKJWKOotP+rXxkr5tvKRva4/mSgQpy58nP+JPQ5m5ZzDuYz7Drv09tdq29Gvj1RD6tlWrVnz55ZfVfr1Go2HKlCmcPHmSjz/+uMZvNwZw6D4Oh+7j6ux1/yYJrRBCAB2bOrLgAUc+GRbC8mNX+XZ/LKcScyjV6Vl9KpHVpxJp4WrD5FBfHuvctM5HbYUQ4nZVmpdO6po3ydwVBjotAEprR9zuexPnAc+gMFObOEIh6q/i4mKeeeYZDh8+zEcffcSwYcNMHVKNk4RWCCH+xd5SzZTufkwO9eVgXBZh+2NYcSIBTamOS2n5vLTxLHM2n+eB9p5MCfWlR3NnFIq6G7UVQojbhb60hIyd35K67i10+ZllhQolTv0m4zbqHczsXG++AyFuc6WlpUyfPp39+/fz4Ycf3vDZ2oZOElohhKiAQqGgm68T3Xyd+GxEa344coWw/TFcSM2nWKvj52NX+fnYVVp72DEl1JdHOzXFwUpGCYQQoibkndpK0i8vUJzw/88W2oQMwH3s51g2a2vCyIRoON544w127tzJoEGDsLS0ZOvWreW2Dxo0CKWyZpctTPzxObJ2L8Lj0a9x6jOpwjqF0YeJ+aAXVgHd8Jv9l9FtSkIrhBC34Gxtzoze/kzv1ZzdUemEhcey5nQiJVo9EUm5PLf2DLN+P8eYO7yZ0t2Xzs0cTR2yEEI0SEWJF0j+5QXyTm42lKmbBOAx5lNsOwyXO2KEqAI7OzvD87KbN2++bvuAAQNqNKHVFWvI3v8TKFTYd33ghvWs/Ltg3iSQgvO7KUq6iIVHkFHtSkIrhBCVpFAo6BvoSt9AV1Jyi/j+cDwLwmO5nFFAQbGWJYfiWHIojk5NHZgS6svDHbyxtZBfs0IIcSva/ExS171Dxo6vQFsKgNLSDtcRr+M8cBpKtcxbIERVzZ49u07b08SfRFeQhVVAN1RW9jetax3Uk6KrERSc3y0JrRBCmEITOwtm9Q/k5b4B/HkxlbDwWDaeTUar03P0SjZPrjrFCxvO8minpkzp7ktbz5v/YhdCiNuRXltK5l+LSF3zOtq89LJChQLHXhNpMvp9zBzcTRugEKLSSjPiAVC7+Nyyrtk/dUrS44xuVxJaIYQwglKpYHDLJgxu2YQrWYUsORjHooNxXM3WkFtUyjf7Y/hmfwzd/ZyYEurL6PZeWKlVpg5bCCFMLi9iB8nLZ1B05YyhzDq4N+7jvsDKt4MJIxNCVIeuMBcApYXNLeteq6MrzDG6XUlohRCihjR1tOLNwcG8elcLfj+XQlh4DH9cSEWvh/0xmeyPyWTG+ggmdGnG5FBfgtxsTR2yEELUueLkSJJ/fYncY+sNZWpXX9wfnodd5/vlOVkhGiiVfRMAilMv37JuyT91VDVwF4YktEIIUcPMVEpGtPFgRBsPLqcXsOhgLEsOxpGSV0xGQQmf7Y7ms93R9A90ZUp3X0a09sDcrGZnGRRCiPpGW5hD2ob3yNg2H31pMQAKCxtch87G5e4XUJpbmThCIYQxrALuBIWSwsj9lGQlonb0rLCeXltquKBlHdjd6HblG5QQQtSi5i7WfHBPK+JfH8iKRzvRL9DFsG1nZBoP/nCUZu/+yZzN57icXmDCSIUQonbodVoydy8hcmYL0jd/YkhmHXqMJ3DuRdyGvyrJrBCNgJmdK/ad70dfWkzC4sfRFRdeV0ev15P8y4uUpMVg4RWCdXBv49s1eg9CCCFuydxMyYN3ePHgHV6cT85l4YE4lh6OJ7OwhJS8Yj7cEclHOyO5O7gJj3fyxEenN3XIQghhtPwLe0j+eTqa2OOGMqvAUDzGfoFVQFcTRiaEqA3u476g4NI+8k//QdSc1jj2noRl07agVFGcEkX2/h/RXD6CQm2J15NLUdTAskGS0AohRB1r6W7HZyNa8/49LVl1MoGw/bGEx2ai18OW8ylsOZ+Cu7WSJ1OsmNLTH28HGbkQQjQsxakxpKyYSc7hVYYyM+emuD84F/tuY+Q5WSEaKbWTF83fCOfqogkUnNtF6m+vXVfHwisEr6eWYdW8c420KQmtEEKYiJVaxfjOzRjfuRmnEnJYEB7Lj0evkFtUSnKBjvd2RvPhX5cZ3tqdKaG+3NXCDaVSvgQKIeovnSaPtE0fkb51HvqSIgAU5la43DMT13tertTsp0KIhk3t4oPfKzspjD1OfsQOSjPi0eu0mDl4YB3UE+uWfWr0opYktEIIUQ+087Ln6/vbMndoK5YdjOF/f0dyIbMErU7P2tNJrD2dhL+LNU918+XxLs1oYmdh6pCFEMJAr9ORvf8nUlbNpjQrwVBu320M7g9+VKl1KYUQjYuVb4c6WYJLElohhKhHbC3MmNjFmzutsyh0aMrSY0n8cvwqhSU6otMLeOX3c7y+9Tz3t/VkSndfevu7yK17QgiTKogMJ+nnGWiiDxnKLJt3xmPcfKxbGD+DqRCi4dHmZ1KSefUmNRQoza0wc3A3+s4NSWiFEKIeUigUdG7qQK8WHnw6vDU/HrlCWHgMZ5PzKNHq+fVEAr+eSKBlE1umhPoyvnNTnKzNTR22EOI2UpJxheSVs8gJX24oM3PwoMmDH+HQ/dEamexFCNEwZR9cQdKyp29dUaHAwrsNTn2fxKn/0yhUVU9PJaEVQoh6ztFKzXO9mvNsTz/2Xc4gLDyWVScTKdbqOJ+Sx4z1Ebzy+zke7uDNlFBfuvo4yqitEKLW6IoKSN/8CWmb56L/Z1kOhdoC58Ev4Dp0NiorOxNHKIQwNevAUJo88CEZO75Bm5OMfdeHMHcPpDQrkeyDv4JOi2OfJyjNSSb38GqSfppGwYU9NH12ZZXbkoRWCCEaCIVCQU9/F3r6u/DFiCKWHr7CggOxRKbloynVsfRwPEsPx3OHlz2TQ30Z17Epdpbya14IUTP0ej05B1eQvGImpRnxhnK7zvfj/vAnmLs1N2F0Qoj6xNKnPalr36I0O4nmr+8vN6Ox631vEP1GB/Ij/qT5GwcoGfYq0W91IefwKvLP7cKmVb8qtSX3ggghRAPkamvBS/0CuDCrH39O7sb97Twx+2cG5BMJOTz922m83tnGlNWnOHE128TRCiEausLLR4h5vxdXvx1jSGYtfNrj+8oumj23WpJZIUQ5BVEHyT22DtvWd123PI/a0RPHno9TdOUM2ft/xsI7BMce4wHIP7uzym3JpXshhGjAlEoFdwW5cVeQG4k5Gr47FMfCA3HEZRaSV6RlQXgsC8JjudPHkSmhfjx4hyfW5vKrXwhROSVZiaSsmkP23qWGMpWdG01Gv49j74kolCrTBSeEqLeKE84BoLRxqnC76p/yon/qmbsHAqAryq9yW/KtRgghGglPe0tevSuIV/q3YOv5FMLCY/n9XDJ6PRyMy+Jg3Ame3xDBY52bMjnUl1bu8pybEKJiumINGX98TtqmD9Bp8soKVWpcBk3HdfhrqKwdTBugEKJeU9m7A1B4aR+6Yg1Kc8ty2/PP7gDAzKGsXknGFeD/E9uqkIRWCCEaGZVSwb0h7twb4k5sRgGLD8ax+GAcSblFZBWWMH/PZebvuUyfABcmd/NlVDsPLMxklEUIUfacbO6RNSSveJmS1MuGctsOw3F/eB4WHi1MGJ0QoqGwCemP2s2fktRorvxvFG4j3y6bFCo7ifQ/viD/zDYUFjY4hI5Fr9OSd2ozqMywbTekym1JQiuEEI2Yr7M17w5pyRuDgtgQkUTY/li2X0oDYHdUOruj0nFdZ87Ers14qpsvAa7GrQUnhGi4NLEnSFo+g4Lzuw1lFt6tcR/7ObZtBpowMiFEQ6NUW+Dzwu/Ef3kfeae2kHdqS7ntKvsmeE9ZjtrFh5L0eJz6P43axbdaz+NLQiuEELcBtUrJ/e28uL+dF5Fp+SwMj+W7Q3GkF5SQll/Mx7ui+HhXFIOC3JjS3ZehIe6oVTJvoBC3g9KcFFJWv0bW34tBrwdAZeOM2/3v4tT3qWqtCymEEBZeLQl47zR5pzZTcGk/2rx0lJZ2WPp1xL7TSJSWtgCoXZrhMnhGtduR31BCCHGbCXS14eNhIbxzdzBrTicSFh7LnugMALZdTGXbxVS87C154k4fnrjTh2ZOViaOWAhRG/SlxaRv+5K0De+iK8wpK1SqcB7wDG73vYnK1tm0AQohGjyFmRq7jiOw6zii1tqQhFYIIW5TlmoVYzs2ZWzHpkQk5bIgPJYfjsSTrSklIUfDO39e5L3tFxka4s7kUF8GBzdB9c/SQEKIhkuv15N3fCPJv75IcXKkodym7d14jP0MC69WJoxOCNHYFF4+QmH0IbQFWVj6dMCmZR+0+RkoLWwMsx0bQxJaIYQQtPaw48uRbfjwnpasOJFAWHgsh+Oz0OlhQ0QyGyKS8XWy4qluvkzs2gwPe8tb71QIUe9orpwhefnz5EdsN5SZewbjPuYz7NrfY8LIhBCNTWlWEle+eYiCC38bypz6TcbcPYCoV1pi7hFM4EfnjG5HHpASQghhYGNhxsQ7fTg0oxdHn+/Fk918sDEvmwE5NrOQV7ecp9m723nwhyPsvJSG/p/n7YQQ9VtpXjqJPzxL9Ot3GJJZpbUj7mM/J+C905LMCiFqlF6vJ/5/oyi48DdOA6biOmyOYZuFRxA2IQMoTjxP/r8moasuSWiFEEJUqGNTRxY+0J6ENwfyzf1taetZtm5tqU7PqpOJDAgLp+XcXXy2O4r0/GITRyuEqIi+tIT0bV8SObMFmTu+Bp0WFEqc+j9N4MeXcBk8A4WZ2tRhCiEamcLoQxRGhmPu2RKPR7/CzLlZue2Wvh0Bys2qXl1yy7EQQoibsrdU83R3P6aE+nIgNpOw8FhWnEigqFTHxdR8Xtxwljmbz/Ngey8mh/rS3c8JhUKetRXC1PJObSXplxcoTvj/W/psQgbgPvZzLJu1NWFkQojG7trvHavmXSr8TmDm5AVAaW6q0W1JQiuEEKJSFAoFoX7OhPo58/mI1iw7HE9YeCwXU/MpKtXx49Er/Hj0Cm087JgS6ssjnZriYCUjP0LUtaLECyT/8gJ5JzcbytRNAvAY8ym2HYbLBSchRK1TmFkAoC/RVLhdm1e2uoLKxvjZ1Kuc0Pb9Zr9RDf41tbtRrxdCCGF6ztbmPN8ngBm9/dkdlU5YeCxrTidSotVzJimXZ9eeYebv5xjbwZspob50auZo6pCFaPS0+ZmkrnuHjB1fgbYUAKWlHa4jXsd54DSUagsTRyiEuF1Y+XcBoODiHvSlJddtzz+7AwDrFsbnhlVOaHdHpQPgW8V1CWMzC6valBBCiHpOoVDQN9CVvoGuJOcW8f2hOBYciCUmo5CCYi2LD8ax+GAcnZs5MLmbL2M6eGNjITcHCVGT9NpSMv9aROqa19HmlX1PQ6HAsddEmox+HzMHd9MGKIS47Zi7B2LXZTS5h1dzdcEjqN2aA6DV5JK67h0KL+3D0rcjNm0GGd1Wtb9VxLx2V5XqK17cWN2mhBBCNADudha8MqAFM/sFsu1iKmH7Y9h4NhmdHo7EZ3Mk/hQvbjzLo52aMiXUlzae9qYOWYgGLy9iB8nLZ1B05YyhzDqoF+6PzMfKt4MJIxNC3O68Ji3hiiaXnEMrDWU54csBsGjalmbT19bIIxBVTmgtzKo3MXJ1XyeEEKJhUSoV3N2yCXe3bMKVrEIWH4xj0YE4EnI05GhK+XpfDF/vi6GHnxNTuvsxup0nlmqVqcMWokEpTo4k+deXyD223lCmdvXF/aFPsOsyWp6TFUKYnMrKHt+XtpJ//m/yI/6kNDsZpZUd1oHdses4AoWqZu7YqvJeNHPvrVZD1X2dEEKIhqupoxVvDQ7mtbta8Pu5FMLCY/jjQip6PeyLyWRfTCbT153h8S7NeCrUlyA3W1OHLES9pi3MIW3De2Rsm4++tGy5LIWFDa5DZ+Ny9wsozav2SJgQQtQ2m5a9sWnZu9b2b3RaPHrZEXR6PWsmdKmJeIQQQjRCZiolI9p4MKKNB9Hp+Sw6EMeSQ3Gk5hWTUVDCp7uj+XR3NANauDI51JcRrT0wlzt7hDDQ67Rk7VlKyuo5aHNSDOUOPcbT5IEPUf+zBIYQQpiCNj+TksyrVX6dysbZ6N9fRie0W86nUFCsRavTo1LK7S1CCCFuzt/Fhg/vbcVbg4NYdzqJsPBY/vpnwsEdl9LYcSkNdzsLJnVtxpPdfPFztjZxxEKYVv6FPST/PB1N7HFDmVVgKB5jv8AqoKsJIxNCiDLZB1eQtOzpKr/Oqd9kPCeEGdW20Qltp6YO7InOICo9X24VE0IIUWkWZioe6uDNQx28OZ+cy4IDsSw9fIWswhKSc4v4YEckH+6MZEjLJkwJ9eWeVu5y4VTcVopTY0hZMZOcw6sMZWbOTXF/cC723cbIc7JCiHrDOjCUJg99Ur5QV0rGjm8ozU7CoeuDmHsEUZqVQPbBX0Gvx3nQdKyDjb8V2eiEdu69rRgQFs4bWy/w49gOqFVyi5gQQoiqaelux+cj2vDBPa1YeSKBBeGxhMdmotfD5nMpbD6XQjNHS57s5sukrj54OViaOmQhao1Ok0fapo9I3zoPfUkRAApzK1zumYnrPS+jtLAxcYRCCFGepU97LH3alyuLnz+S0uxE/Ob8jXVgqKHcdfjrRL/Rgdyj63C99xWj2zY6of3tVCIDWrix4kQCR+Kz6O3vgrO1+rp684a3NrYpIYQQjZyVWsVjXZrxWJdmnEzIZkF4LD8evUJekZb4LA1vbL3A29suMqK1O5NDfbmrhRtKGbUVjYRepyN7/0+krJpNaVaCody+2xjcH/wItYuPCaMTQojKK4g8QO6xddi0HVwumQVQO3vj2Hsi6b/PJXv/Tzj1e8qotoxOaD/dHW34/6j0AqLSCyqsJwmtEEKIqmjv5cA397dj7r0h/HL8Kt/uj+FEQg5anZ41p5NYczoJfxdrJnfz5fGuzXCztTB1yEJUW0FkOEk/z0ATfchQZunXCY9x87EO6mHCyIQQouqKE88DZZM+VeRaeVHCOaPbMjqhTX17kNFBCCGEEDdiZ2nGU6G+PNnNh8PxWYTtj+XXE1cpLNERnV7ArN/P8frWC9zfzpMpob708neWZwtFg1GScYXklbPICV9uKDNz8KDJAx/i0GM8CqU8yiWEaHjMHDwAKLy0D11x4XVLiuVH/FlWz9HD+LaM3YGrXBEXQghRBxQKBV19nOjq48Snw0P48egVFoTHcjY5j2Ktjl+OX+WX41dp5W7LlFBfHu3UFCdrc1OHLUSFdEUFpG/+hLTNc9EXFwKgUFvgPPgFXIfORmVlZ+IIhRCi+mxC+mPuHkhxciTxX4zA7f53sfAIoiQzgYxtX5AfsR2FhQ0O3cYa3ZbRCe01er2ehBwNeUVa9Hr9ddtbussvZiGEEDXDydqcab38ea5nc/ZeziBsfyyrTyVSrNVxLjmP6esieOX3czx8hzeTQ33p6uMoo7aiXtDr9eQc+JXklbMozYg3lNt1vh/3hz/B3K25CaMTQoiaoTAzp9kLvxM//z7yI/40jMheo7JvQtOnf0Ht0szotoxOaEu0Ol7fcoFFB2PJKCi5YT39p8OMbUoIIYQoR6FQ0MvfhV7+LnyRV8TSw/EsCI8lKr2AwhId3x+O5/vD8dzhZc+U7r6M7dAUO8sau5YrRJUUXj5C0k/TKYzcbyiz8GmPx9gvsGnV13SBCSFELbDwCCLgvVPkndxMwaV9aPPSUVraYenXEftOI1Fa1sySr0b/VZ/9+zk+3R2NrYWKqd398HO2QoFcBRdCCFG33GwteLlfIC/2CWDHpTTCwmNYH5GMVqfnREIOU1af5qWNZ3mkY1OmdPelvZeDqUMWt4mSrERSVs0he+9SQ5nKzo0mo9/HsfdEFEqV6YITQohapFCZYddxOHYdh9daG0YntD8evQLAqvGdubtlE6MDEkIIIYyhVCoYGOzGwGA3ErI1LDkUx6IDscRnlT0WExYeS1h4LN18nZgS6suDd3hhpZaEQtQ8XbGGjD8+J23TB+g0eWWFKjUug6bjOvw1VNZyUUUIIYxldEKboykFoLd/xVMyCyGEEKbi5WDJ6wODmDOgBVvOpxC2P4bN51PQ6+FAbCYHYjOZsT6CCV2aMrmbr8z3IGqEXq8n98gakle8TEnqZUO5bYfhuD88DwuPFiaMTgghal5exHaydi/GpvVAnPpMqvXX/ZvRc8Hf6esEQGJOkbG7EkIIIWqFSqlgaIg7m564k8tzBvDqXS1wtyubpT+rsIQv/r5Mq4//ou83+/n1+FWKSrUmjlg0VEXxJ4n9qB9XvhptSGYtvFvj8/I2fGasl2RWCNEoFSdHknNwBZrLh+vkdf9m9AjtZ8ND6PtNOB/suMTiB9vLLJJCCCHqNV9na94b0pI3BwWx/kwSYeGx7LiUBsDuqHR2R6XjZmvOxC4+PBXqg7+LjYkjFg2BNicF9Y73STi7Dv5Z7UFl44zbqHdw6jcZhUomIxNCNH4FUQdI+uWlStcvij9pdJtV/u360oaI68r6Bbrw3aF4jl/NprufM5Zm1w/8zhveunoRCiGEELVArVIyur0Xo9t7cTE1j4XhsSw9HE96QQmpecXM3RXJ3F2RDA52Y0qoL0ND3DFTGX1jk2hk9KXFpG/7ktT172KmySkrVKpwHvAMbve9icpWHskSQtw+iuJOUhRnfJJaFVVOaD/dHX3Dbcev5nD8ak6F2yShFUIIUV8Fudkyb3hr3hvSkt9OJRIWHsveyxkA/HEhlT8upOJlb8mT3Xx44k4fmjpamThiYWp6vZ684xtJ/vVFipMjDeVWrQfi9ch8LLxamTA6IYSoW449J2DfZXS1X680r/7f1SontKlvD6p2Y0IIIUR9ZqlWMa5TU8Z1asqZxBwWhMfyw9Er5GhKScjR8Pa2i7z750WGhrgzJdSXQcFNUCnlUZvbjebKGZKXP09+xHZDmdo9iLw7p9L8nqewsJILHkKI+mfLli189tlnAGzduhWVquZm+FeaW6I0t6yx/VVFlRNaV1sLjl/JpkNTmWpeCCFE49XG057/jWrLR/e24tcTCYSFx3AkPhudHjZEJLMhIhk/Zyue6ubLxK4+hkmmRONVmpdO6po3ydwVBrqyicOU1g643fcWVj0mcu7CJRNHKIQQFUtOTuatt96ipKSE/Px89P88698YVGuGgo6f/00zR0uGhXgwvLU7/QJdMa/guVkhhBCiobOxMGPSnT5MutOHI/FZLAiPZfnxqxQUa4nJKGTO5vO8+ccFRrbxZEp3X/oGuFQ4QWKJVsff0Rmcii8kzTKD/i09UcszuQ2CvrSEjJ3fkrruLXT5mWWFCiVO/SbjNuodzOxcKSwsNG2QQghxE3PmzCEoKAgXFxe2bNli6nBqVLUS2k2TurI+Iom1ZxL5Zn8MdhZmDA52Y3hrd+4NccfZ2rym4xRCCCFMrnMzRzo3c2TesBB+PnaVb/fHcCYplxKtnpUnE1h5MoEgNxumhPryWJdmOFubU6LV8dHOSL7eG0Ny3j9L3O3JxMPOgqk9/Hilf6AktvVY3qmtJP3yAsUJ5wxlNiEDcB/7OZbN2powMiGEqJyff/6ZI0eOsH79eubPn2/qcGpctRLae0PKEle9Xs/h+Kx/br1KYvwviaiUCrr7OTE8xIPhbdwJcrOt6ZiFEEIIk3KwUjO1hx9Pd/clPCaTsPBYVp5MoKhUx8XUfF7YcJbZm88zup0n0ekFhMdm8t8x2+TcIt7YeoGDsZmsfbyLJLX1TFHiBZJ/eYG8k5sNZeomAXiM+RTbDsNlmUIhRIMQExPDJ598wrPPPoufn5+pw6kVRi2KplAo6OrjRFcfJ94b0pKYjAI2RCSx/kwyc7ac4+VNZwl2s2F467Jbk7v7OaO8zSbPqA+3IGk0mnL/isZD+rZxkn5tWDp4WLFgZEvm3h3A+ogkVh5PIDar7Hd/eFQyAP4ON/5zey4hg693X2ByqF9dhCtuQZufSdbvH5LzVxjoSgFQWNrhOGQWDv2fQaG2qPDclPO2cZJ+bbwaUt8eOXKE2bNnV6rurFmzuOuuuwDQarXMmjULf39/Jk6cWJshmlSNrvLt52zNtF7+TOvlT3ZhCZvPpbAhIolFB+P45K8oXG3MSX1ncE02Wa/p9XrOnj1r6jAMoqNvvOSSaNikbxsn6deGp4s1dOlhB9hV8ZUF9ervxW1JV4rqzDrUB75FockGQI8CbchwSrpPpcDahYRLUbfcjZy3jZP0a+NVX/r2Znd9FBQUEBcXV6n95OfnG/5/wYIFnDlzhtWrV9fojMb1TY0mtP/mYKVmTEdvxnT0plSrY3dUOhvOJtdWc/WSQqGgVSvTr0On0WiIjo7G398fS0vTTKctaof0beMk/do4HI7L5PEVlV9c/vuH2tPFx6kWIxI3Unh+F+mrZ1KSEGEoswjsgcuDn2Dhc0el9iHnbeMk/dp41ae+PXfu3E23d+nShW3btlVqX66urgDExsbyzTff8MQTT5g8Hym8fITC6ENoC7Kw9OmATcs+aPMzUFrYoLIx/u+e0Qlt2rUJLm5ArVJia2HGgCA3BgS5Gdtcg2NVj9ais7S0rFfxiJojfds4Sb82bGlFWURnl1ahvkL6u44VJ0eS/OtL5B5bbyhTu/ri/tAn2HUZXa3nZOW8bZykXxuvhtC3VlZW+Pr6Vuk1SUlJlJSUsGHDBjZv/v+5ANLS0gAYMmQIrVq14ssvv6zRWP+tNCuJK988RMGFvw1lTv0mY+4eQNQrLTH3CCbwo5sn85VhdELr9uatrxaolAqC3WwY0caDl/oGyCzIQgghGj1na3Wt1hfVpy3MIW3De2Rsm4++tBgAhYUNrkNn43L3CyjN6/eXWyGEuJX27dtXOKr7wQcf8Ndff7FgwQKsra1rrX29Xk/8/0ZRGBmO04CpqKwdSdv4AQAWHkHYhAwgP2I7+ed3Y9Oyj1FtGZ3QvtjHnwup+Ww6m0yAizW9/F0A2BOdTlR6AUNaNsHWQsVfUel8uCOSn49dZd+zPWjqKH8shBBCNF49mjvjbmtBSl4Rt1q+3s5CRXc/ud24tul1WrL+/p6U315Fm5NiKHfoMZ4mD3yI2snLhNEJIUTNsbS0rHBU91oS6+Pjg5lZrT19SmH0IQojwzH3bInHo1+RuWtB+fh8O5IfsZ2CGkhojV4jYGRbT7ZfTOXhO7w4N6sf3z98B98/fAfnZvXjgfae7IpMY3ovfyJn96dPgAtxmYW8vvWCsc0KIYQQ9ZpapeSZnn63TGYBcou0PLf2DCVaXa3HdbvKP/83l9/qQuL3TxqSWavAUJq/cRDvp5ZJMiuEEDXo2trdVs27VPj4htk/v3NLc1ONbsvohPaljWfRlOp4d0jLcmvoqVVK3h/SEk2pjpc3nsXeUs3HQ8seSN56PuVGuxNCCCEajVf6B3JvqyYA161De+1nC7Oyv50LD8QxZNFBMguK6y7A20BxagxXvnqQ2A/7oIk9DoCZc1O8p/yM32v7sAroauIIhRCi7rz66qts27atVkdnARRmFgDoSypeFkmblwGAysbZ6LaMTmhPXC2b2t7DzuK6bZ72ZTOGnUgoq9PavWwZg6zCEmObFUIIIeo9tUrJ2se78O7dwbj/5++ku50F794dzIVZ/ejU1AGAHZfSCP1yL5Fp+RXtTlSBTpNHyurXiJrdkpzDqwBQqC1xHfEGgR+dxyF0bLUmfRJCiIbM1dW1yhNMVYeVfxcACi7uQV96fe6Xf3YHANYtuhvdltGpuZO1msScIsJjMhkYXH4W432XyzJvJ6uySaCScstmRG7uUnsPIAshhBD1iVql5LWBQczqH8jO84mcunSZdi2a07+lp+HOpt1TuzP+l+OsOZ3EhdR87py/h7UTutA7wMXE0Tc8ep2O7P0/kbJqNqVZCYZy+25jcH/wI9QuPiaMTgghbg/m7oHYdRlN7uHVXF3wCGq35gBoNbmkrnuHwkv7sPTtiE2bQUa3ZXRC+0jHpnzyVxRPrT7J4gfaG/747o5KZ/LqUwCM79wUgG0Xy+6RHlTF5Xtyc3NRqVQ3nIlLq9WSmJhY4TZ7e3vs7e0r3FZcXExWVhaOjo6Ym9985uWq1BVCCCH+S61S0tvfGVdNEiH+zuUe07GxMGPV+M68uuU8H+2MJKOghLsWhLPogfY81qWZCaNuWAoiw0n6eQaa6EOGMku/TniMm491UA8TRiaEELcfr0lLuKLJJefQSkNZTvhyACyatqXZ9LU1cqeM0QntO3cHE5mez9rTSdy14AAqZVlQWl3ZNBij23ny1uAgADQlWmb1C+SFPv633G9sbCzLly9ny5YtFBQUoNVqcXJyYtKkSYwZMwal8v+/CGRkZDBgwAAcHBywtbUtt5/x48czYcKEcmV5eXm8//77bNmyBRsbGwoKChg2bBizZ8++bh2qqtQVQgghqkupVPDhva0IdrPlqdUnKdHqmfDrCS6k5vHe3S1RKuX22BspybhC8spZhi9KAGYOHjR54EMceoxHoTT6CSshhBBVoM3PpCTjCl4Tl1CcEkV+xJ+UZiejtLLDOrA7dh1HoFDVzHO8Ru/FUq1izYQu7IpMY0NEEtHpBSgou614RGsP+ga6Guo+3yeg0vtdsmQJ+/fv591336VPnz7o9XpWrlzJm2++yZUrV5g1a9Z1r5k8eTKTJk265b5nzJjBxYsX+e233wgICODSpUtMmDCBrKys6xYXrkpdIYQQwlgTujbD38WakUsPk1FQwoc7IrmQksePYztgbV67k3g0NLqiAtI3f0La5rnoiwsBUKgtcB78Aq5DZ6OysjNxhEIIcXvKObSKxKWTceo3Gc8JYdi07F1rbRl9yTI1r+y52H6Brnw+og3rJ3Zl3cSufD6ijSGZPRyXVeX9durUiTVr1tCnT9m6RAqFgoceeog+ffrw008/UVRUVK14Dx06xJ49e5g2bRoBAWUJdosWLZg6dSp//PEHp0+frlZdIYQQoqb0DnDh4PReBLnZALDmdBK9v95PQnbFs0XebvR6PdnhvxD5SktS171lSGbtOt9PwIfncH/gA0lmhRDChK4ty6MtyKr1toxOaO9dfIj8otIbbj92JYtBCw9Ueb8jRoyo8NlXZ2dniouLycnJuW6bXq8nNTWVjIyMG+53586dAPTuXf4qQd++fQHYsWNHteoKIYQQNSnQ1YYD03rS/5+Lw0evZNN1/h6OX8k2cWSmVXj5CDHv9eRq2FhKM+IBsPBpj+8ru2j23GrM/5l4RAghhOnYhAzAzMGDgkv70BUV1GpbRie0F1PzGP3DEUorWAz+ZEI2AxccwM2mZiZRysvLY/fu3bi5ueHicv3Mj/PmzWPo0KH07NmTHj168NVXX1FSUn6a6MjISKytrWnSpEm5ci8vL9RqNVFRUdWqK4QQQtQ0J2tztj51J092K5uZ92q2hl5f72PDmSQTR1b3SrISubrocS6/1YXCyP0AqOzc8Hx8If5vH8WmVV/TBiiEEMJAoVLj/cxKQEH8/BEUXNqPNi8DnSav/H8l1bvr9t+Mfhhn/cQuDF54kCdWnmTpmA6G8jOJOdwVdgBHKzU7nw41thkA3n//fdLT03n77bfLTQqlUqmYOnUq48aNw9XVleLiYn766Sc+/vhjYmJimDdvnqFubm4uNjY21+1boVBgY2NDdnZ2tereSGFhYVXfZo3TaDTl/hWNh/Rt4yT92nhVt2+/uLcFAU4WzN56ifxiLfctPcz7g1swvYdPo19LVVeiIWfH/8ja8gn6oryyQpUah/7P4HjPLJRWDmiKik0bJHLeNlbSr42X9G3tyty9mKRlTwNQmhFPfsT2Cutde8bWGEYntH0CXPlxbAce/vEo3g6WvH9PK84l5zIgLBwbcxU7p4TS1NH42YAXLFjAmjVrGDp0KA8//HC5bc7OzkyfPt3ws7m5ORMnTiQmJoYVK1bw1FNPERRUNtOyQqFAp7t+NBnKbllWqVSGn6tS90Z1zp49W6n3Vxeio6NNHYKoJdK3jZP0a+NVnb69ywnUvZx5bX8mhaV65my9xKFLV5nV2QG1qhEmtXo9yqidqPd+iTLnqqFY27w3Jb1mUOjoQ9Llq8DVG+/DBOS8bZykXxuv+tK3je3ipGXTNjgNeOaW9ayDexndVo1Ml/hAey8SczRMXxeBHvj+UDzmKiU7nw7F17nitWOr4scff+Szzz5j4MCBzJ07t9KvCw0NZcWKFURERBgSWhcXF86cOYNery934JSWlpKXl4ezs7OhrCp1K6JQKGjVqlWl460tGo2G6Oho/P39sbS0NHU4ogZJ3zZO0q+Nl7F9GxIC3dvmMvrHE1zNKWJdVAGZOguWj22Hk5W6FiI2jaL4k2SsnInm0h5DmdorBJfRc7EKGWDCyG5MztvGSfq18apPfXvu3DmTtl8brIN6Yh3Us07aqrH5/6f18udKloYPd0TiZW/Jrqnd8Xe5/nbdqlqxYgXvv/8+AwYM4PPPP8fMrPIhX7uFwNz8/5/hDQkJYfv27Vy+fBl///9fDzcqKgqtVktISEi16t5IfVqr1tLSsl7FI2qO9G3jJP3aeBnTt938rTj8fG+Gf3eII/HZ7L6cSb+FR9g0qSst3GxvvYN6rDQnhZTVr5H192LQl61nr7Jxxm3UOzj1m1xjaxbWJjlvGyfp18ZL+rbhq/Jfhpc2RNxwmx6wszCjU1MHwvbHlNs2b3jrqjbFunXrePPNN+nXrx/z589Hra746nNpaWmFie7GjRtRq9V07tzZUHb33Xfz1VdfsXnzZp599tnr6t59993VqiuEEELUFU97S3ZP7c5jv5xg9alELqbm0+3LvayZ0Jk+Aa633kE9oy8tJn3bl6RteBdd4T+rGChVOA94Brf73kRle/M7ooQQQtQvBZf2k3No5S3rWbfogX3XB4xqq8oJ7ae7b32f+cazydeVVTWh/fPPP5kzZw7t2rVj5syZJCeX32eTJk0MI68ff/wxxcXF9OvXj6ZNm5KSksJPP/3Evn37eOWVV3B3dze8LiAggMcff5yFCxfSpEkTOnfuzIEDB1i6dClTpkzB29u7WnWFEEKIumRtbsaKRzvx+tbzfLAjkoyCEgYuOMCC0e14vKuPqcOrFL1eT97xjST/+iLFyZGGcpu2d+Mx9jMsvEz/2I4QQoiq08SfImPb/FvW05do6j6hTX17kFENVta+ffvw8PAgLS2NSZMmXbd94cKFBAYGAvDSSy/x+++/8+uvvxIbG4uZmRnBwcH89NNPdOnS5brXvvzyywQGBrJ27VqWLFmCu7s7H3zwAcOHDzeqrhBCCFGXlEoF79/TiuAmtjyx8iQlWj0TV5zkfEoeH97TCqWy/k4yorlyhuTlz5eb+dLcMxj3MZ9h1/4eE0YmhBDCWE69J+Jw58PXlZdmJ5Kx4xuy9/+I16TvsG03xOi2qpzQutpaGN1oZbz11luVrmtubs7IkSMZOXJkpeorFApGjRrFqFGjarSuEEIIYQrjOzejubM1I78/THpBCR/viuJSWj4/jumAjUX9eu60NC+d1DVvkrkrDHRaAJTWDrjd9xbOA55BYdZ4JrcSQojblcLMHJWZ+XXlKhtHPB/9H8UJ57i6cDwB75/B3M3PqLaUt64ihBBCiPqul78LB6f3omWTsomh1p5Oovc3+7mabfr10AH0pSWkb5tP5MuBZO74uiyZVShx6v80gR9H4jJ4hiSzQghxm7BpMxB9UT7Z+38yel9VTmhnrDvDjHVnqtxQdV8nhBBCiMoJcLUhfFpPBrQomxjq2JVsun6xl2NXskwaV96prUS91o7kn2egKyiLxSZkAP7vnsDzsW8ws2t4E1kJIYSoPl1RAQDavDSj91XlhHb+nsvM33O5yg1V93VCCCGEqDxHKzVbnryTyaG+ACTkaOj19X7WnU6s81iKEi8Q99m9xH06hOLE8wComwTQbPo6fGb+iWWztnUekxBCCNMqvHyUzL8WAGDpc4fR+6v2gzXzdkUZ3bgQQgghap5apeTb+9vSsoktL2yIoKBYy6hlR5h7byte6huAQlG7k0Vp8zNJXfcOGTu+Am0pAEpLO1yHv4bzoOko1XUzH4cQQgjTyNq7jORfXryuXFdciL64bHTWOqQ/DqHjjG6r2gnty5vOGt24EEIIIWqHQqFgRm9/Al1tGPPTUfKKtMzcdI7zKXl8e387zM1qfhoNvbaUzL8WkbrmdbR56dcCwbHXRJqMfh8zB/eb70AIIUSjYObggXVQz+vKFWYWmDk3w6ZVX+zuGFozbVX1Badf6lMjDQshhBCi9g0NcWffsz0ZuuQg8VkavjsUT3R6Ab9N6Iyz9fUzUFZXXsQOkpfPoOjK/8+XYR3UC/dxX2Dl17HG2hFCCFH/2bYdjG3bwXXSVpUT2jae9rURhxBCCCFqSTsvew5O78WI7w5zOD6Lv6LS6TZ/L5ue6EqQm61R+y5OjiT515fIPbbeUKZ29cX9oU+w6zK61m9vFkIIUf8UXT1L/oW/sfBujU1wrypvrwpZtkcIIYS4DXjaW7L7me480N4TgEtp+XSbv5ddkdWbYVJbmEPyiplEzWltSGYVFja43f8eAR+ew77rA5LMCiHEbSr/wt8kLXuanPCfq7W9KiShFUIIIW4TVmoVvz7SidfuagFAZmEJgxYcYMnBuErvQ6/TkvnXYiJntiB98yfoS4sBcOgxnsC5F3Eb/ipKc6taiV8IIUTjcO1vByrj1x+v9qRQQgghhGh4lEoF7w5pSZCbDU+sPEWxVscTK09yISWPD+9thUp541HV/PN/k7x8BprY44Yyq8BQPMZ+gVVA17oIXwghRD2lK9agK8oDQF+UX1ZWoqE0t/ydQDpNLnmntgCgdm5mdLuS0AohhBC3oUc7N6O5szUjlx4hLb+YT/6K4mJqHj+P64iNRfmvB8WpMaSsmEnO4VWGMjPnprg/OBf7bmPk1mIhhBBk7V1K0rKny5Vl711G9t5lFdZXWjvi0O1ho9uVhFYIIYS4TfX0d+Hg9J4MXXKIc8l5rI9IptfX+9gwsStNHa3QafJI2/QR6VvnoS8pAkChtsTlnpm43jsTpYWNid+BEEKI+sLS5w6c7y5be7Yo/iT5Edux8GmPTchd5eopzMxRu/hg3/E+zBw9jG5XElohhBDiNubvYsP+53ry4A9H+PNiGsev5tDti7/Z1PEy1jvepTQrwVDX/s6HcX9oLmoXHxNGLIQQoj6yDuyGdWA3AHJPbAK9HtsOw3AZNL1W261yQpuWV1SthlxtLar1OiGEEELULkcrNZufuJNp686wf/cfvBK/GPPLFyn9Z7ulXyc8xs3HOqiHSeMUQgjRMNjdMRS7O4bWSVtVTmjd3txWrYb0nw6r1uuEEEIIUfv02QnMSZlLTvZyQ1mqwokrobMY88RLKFUqE0YnhBCiISvJTEBXmI1epy1XrrJxRu3kZdS+q5zQvtjH/7qyC6n5bDqbTHNna3r7O6NQKNgdlc7ljAKGhrgT7CbP2AghhBD1ka6ogPTNn5C2eS764sKyMpUFP1iN4GvzURRctGbHqtOEjW6HuZms9ieEEKJydMWFpK57m6y/l6DNrXjNc6d+k/GcEGZUO1VOaOcNb13u573R6QxccID723myfFxHwx+74lIdY346ypbzKczuH2hUkEIIIYSoWXq9npwDv5K8chalGfGGcrvO9+P+8Cc8WurCiiWHiMss5PvD8USl57NmQhdcbMxNGLUQQoiG4uq3Y8k9tg7L5p2xCggl78RGrAK6obJxouDSPlzufhHroJ5Gt2P0pdaXNp5FU6rjw3talrtya26m5MN7W1FYouOljWeNbUYIIYQQNaTw8hFi3uvJ1bCxhmTWwqc9vq/sotlzqzF3a05bT3sOTe/FnT6OAPwdncGd8/dwISXPhJELIYRoCDRXzpB7bB0qO1f8Zu/Gtv09AFj6tKfZ85tQuzUn9+harAK7G92W0QntyYQcADztLa/b5vVP2YmEbGObEUIIIYSRSrISubrocS6/1YXCyP0AqOzc8Hx8If5vH8WmVd9y9d3tLNg1tTsP3VH2fFNUegHdvtzLzksV3zomhBBCAGhijwNg3bIvSgtrw3rler0ehVKJXYcRaOJOkHNopdFtGZ3QOluX3Xq073LGddv2/lPmZCW3JwkhhBCmoivWkLrxAyJntiB779KyQpUalyEvEfjxJZz6PolCWfGkT1ZqFcvHdeSNgUEAZBWWMHjhARYfiK2j6IUQQjQ0CrOy/E+pLhvgVJhbA6AvLgDAzM4VAE38SaPbMjqhHd+5KQBPrjrJtgsplGh1FJfq2HYhhadWnSxXRwghhBB1R6/Xk3P4N6JmtyJ19avoi/IBsL1jGAEfROD+8CeorB1uuR+lUsHbdwfz09gOmKuUlOr0PLnqFC9tiECr09f22xBCCNHAWHiXzbtUlHQRAHP3sjmVipMjy/5NK7soqrK0N7qtKk8K9V9vDQ4iMi2f1acSGbzwICpl2XDytT9wD7T35K3BQcY2I4QQQogq0MSeIGn5DArO7zaUWXi3xn3s59i2GVitfY7r1JTmztbct/QwqXnFfLo7mktp+fw8riO2FkZ/pRBCCNFIWDZtg6XPHWguH6Eo8QJW/l0xc25GYdQBEr6fTM6hFQDYtB1sdFtG//WxMFOx6rHO/BWZxoaIZKLS81EA/i42DG/tTt9AV6ODFEIIIUTllOakkLL6NbL+Xgz6sovLKhtn3Ea9g1O/yShUxv3p797cmYPTejF0yUHOJuexISKZnl/tY+PErjRzsqqJtyCEEKIR8JywgMLoQ+g0uSiUKppO/ZUr3zxM1l8LUagtcX94HtaB3Yxup8Yup/YNdJXkVQghhDARfWkx6du+JG3Du+gKyyZsRKnCecAzuN33Jipb5xprq7mLNfuf68lDPx7ljwupnEzI4c4v97BhYlc6N3OssXaEEEI0TNr8TBTmVth1Gona2RsA6xbdafFpDKVZCZg5eBh9gfUaWSFdCCGEaMD0ej25xzYQNac1KSteNiSzNm3vJuD903g8Mr9Gk9lrHKzUbJrUlWd6+AGQmFNE76/3sfpkQo23JYQQomHJObSK6Nfakbbh3XLlCqUStXPTGktmoRojtFNWnwIgbHS7cj/fyrX6QgghhKgZmitnSF7+PPkR2w1l5p7BuI/5DLt/1vyrTWYqJV+NakvLJrZMX3eGwhIdD/xwlA/uyeeV/oGGZRqEEELcXsycypZ70xZk1X5bVX3BgvCyGamuJajXfr4VSWiFEEKImlGal07qmjfJ3BUGOi0ASmsH3O57C+cBUw3LJdSVZ3s2J8DFmod+PEZuUSlzNp/nQkoeCx5oh4VZxcsBCSGEaLxsQgZg5uBBwaV96IoKUFpY11pbVU5oSz6+96Y/CyGEEKJ26EtLyNj5Dalr30J37aq3QolTv8m4jXrHsK6fKQxp5c7+53owdMkhYjMLWXbkCtEZBax5rDOuthYmi0sIIUTdU6jUeD+zkqth44ifPwK3kW9j4dny+guuKjVKtXF/I6qc0JqplDf9WQghhBA1L+/UVpKWP09x4nlDmXVIfzzGfoFls7YmjOz/tfG05+D0Xtz3/WEOxGayJzqDbl/uZdOkrrR0tzN1eEIIIepI5u7FJC17GoDSjPhyj8b8m1O/yXhOCDOqLaOfxs0qLKlUPUcrtbFNCSGEELedosQLJP/yAnknNxvK1E0CcH94HnYdR9S751Td7SzY9XQoE1ec5JfjV4lKL6Dbl3tZ/Vhn7gpyM3V4Qggh6oBl0zY4DXjmlvWsg3sZ3ZbRCa3Ta1srVU//6TBjmxJCCCFuG9r8TFLXvUPGjq9AWwqA0tIO1+Gv4TxoutG3aNUmS7WKn8d1INjNhre2XSRbU8rdiw7y9ag2TA71M3V4Qgghapl1UE+sg3rWSVtGJ7TTezW/rqywRMu+mEwiknIZ3tqd5s619xCwEEII0ZjotaVk/rWI1DWvo81LLytUKHDsNZEmo9/HzMHdtAFWkkKh4M3BwQS52fL4ihMUleqYsvo0F1Ly+WRYCCpl/RpZFkII0TAZndB+cV+bCsu1Oj3jlx/n93PJvHt3S2ObEUIIIRqUuM+HU5ISVa5Mp9djUVTEFQsLlP+6VVjdJACf5zeQF7GD5OUzKLpyxrDNOqgX7uO+wMqvY53FXpPGdPTGz9mK+74/TEpeMZ//Hc2ltHyWj+uInWXNrUMohBDixlJTUzlx4gRarZb27dvj6elZJ+1q4k6R8eeXFEYfQluQhUPoOBx7P0723h8w92yJY49HjG6j1v6SqJQK3hwcxPLjV5mx/gw7n+5eW00JIYQQ9U5JShRFCWevK1cC/519Qq8tJn7+feQeW28oU7v64v7QJ9h1GV3vnpOtqlA/Zw5O78WwJYc4k5TLprPJ9PxqHxsndcHHSe7iEkKI2lJcXMx7773Hxo0b6dKlCw4ODnzxxRf079+fmTNn1mrbOYdWcSVsHAqlEjMHD0oz4tEVZKJ2akrmzm/RlRZh13E4Kit7o9qp1UujTR0sATgYl1WbzQghhBANWnFyFMXJkQAoLGxwHTobl7tfQGluZeLIao6fszX7nuvBQz8eZev5VE4l5tB1/l42TOxCVx8nU4cnhBCN0syZM4mIiGDTpk14e3sDoNVq2bVrV622qy3IJuH7J0Gvw2/2XgpjjxlmPVZaWGPbYRjZe5eRe3Qdjj3HG9VWra65syc6AwBbc1lUXQghhLgxPQAOPcYTOPcibsNfbVTJ7DX2lmo2TuzKcz3L5t9Izi2iz9f7WXUywcSRCSFE4xMeHs6WLVt47bXXDMksgEql4q677qrVtgvO/4WuIBub1ndhFdD1uu3m7i0AKLpy2ui2jB6h/Wrv5evK9Hq4nFHAd4fiABjXsamxzQghhBCNlkJthd/svyr8o9/YmKmUfDmyDcFuNkxfH4GmVMeDPxzlvSF5zBnQosHfXi2EEPXFhg0bsLa2pnv37pw4cYKYmBgcHBzo1KkT9vbG3eZ7K6X/TGpo5lDxs7pKddmdvPp/ZvE3htEJ7XNrz9xwm6OVmtcHtuD1gUHGNtNgFRYWmjoENBpNuX9F4yF92zhJvzYOOr2+0nXNXP3Aq229+JtRVyZ28iDY2ZwXN0SQV6zlu/1RpGTl8s7dwZirGt6dXXLeNk7Sr41XQ+rbpKQk9uzZU6m6d955Jz4+PgCcO3cOBwcHxo0bR0ZGBm3atOHcuXOkpqby9ttvM2xY7S2rei2RLc2Ir3B7cWrZoKjazc/4tozdwfEXel9XplQocLM1x8PO4ra+0qrX6zl79voJQUwlOjra1CGIWiJ92zhJvzZsFkVFlX6up6ioqF79vagrTsB3A13KlUVeuGCaYGqInLeNk/Rr41Vf+vZmOdPFixd57bXXKrWfjz/+2JDQ5uTkkJiYSPPmzfnpp58wNzenpKSEadOm8corrxAcHExQUO0MPNoE90Jp7UD+hd0UXS3/902bn0Xukd9AqcKu/VCj2zI6ob3D28HoIBorhUJBq1atTB0GGo2G6Oho/P39sbS0NHU4ogZJ3zZO0q+NwxULi+tmM74RCwsLAkJCajWe+iwjv5hp685wIiEHKJtU8pv72+LvYmPiyCqvvp+3pVodiw/F8cuxBNILig3lrtbmPNzRiye6+mCmqtWpVTh69Cjz5s3D29ub7t27Y2NjQ2RkJDt37qRPnz5MmzatVtsHyMjI4NFHH+XDDz+kXbt2t6xfX/q1snH//PPP7Nq1i8WLF1f4c02rzP6r+pnXlfrSt1A2knoznp6ejB49ulL78vX1Nfy/ubk5AE8//bTh/9VqNc899xw7d+5kw4YNvPTSS9WM+uaUlrZ4jPmchCUTifmgN+YeZYlzQdQBLr/XndLsJFyGzsbcPcDotoxOaNPyiqr1OldbC2ObbhCsrOrPpB6Wlpb1Kh5Rc6RvGyfp14ZNX5RX6bpKheK27mtvKyt+fqwbT6w8yc/HrhKdnUePbw+zanxnBga7mTq8KqmP522JVsfo7w+z+VwKCq5NQVbmcnYph36PZEd0Dmsf74K6lpLaS5cu8cwzzzBmzBheeeWVctvuu+8+vv322zr53MzNzbl69SpQte9opu7XysZdWFhISkqKoU7Pnj3x8/Ortdgrs//qfuZ1xdR9WxktWrTg/fffr/LrPD09uXz5smHE9pprPycmJtZIfDfi2PtxlNaOpPz2KoWR4QAUxZ1EZd8E93Ff4DJoeo20Y3RC6/bmtmq9Tv9p7d2zLYQQQpiKtiCbpJ9n3PC5IVExS7WKH8d2ILiJLW9svUC2ppQhiw/yv5FteLq7n6nDa9A+2hnJ5nMpQPlk9t8//34uhbk7I3mtluY9CQsLw87OjhdffPG6bYGBgbz99tuGn1NTU1mzZo1hApu77rqLzp07G7Zv2rSJS5cuMXr0aH7//XcSEhLw8fFhzJgx2NiUH9WPj49n1apVpKWl4efnx6BBgyqMLz8/nw0bNnD27FnUajX9+/enZ8+ehu1btmwhNjb2lm2WlJSwefNmTp8um7m1Y8eODBkypNztpLdqqypx30pcXBzHjx8vN6Ptf/c9fPhw5s2bx9NPP01AQNlo2YoVK8jNzeWJJ54wvC47O5t3332XZ555hubNm1d6/9WNXRivU6dO7N+/n/T0dDw8PAzl6ellEzY5OdX+kmn2nUdi33kkJRlXKc1JRmlph3mTABTKmrt4ZvSeXuzjz9AQdwCaO1vzWOemTOjSjObOZQulDw1x58U+/tf9J4QQQjQ2eWf+JOrVtmTvXWrqUBokhULB6wOD+PWRjliYKdHq9Ez97TQz1p1Bq6v8JFvi/5VodXy9N4ZbzWiiAL7eF0OJVlcrcezdu5cePXqgVqsr3G5rawtATEwMQ4cOZe/evbRp04bS0lLGjx/P999/b6gbERHBTz/9ZEi2goODWbt2LePHj0en+//4o6KiuO+++zh37hytW7cmLi6ORx555Lq2k5KSGDFiBMuWLaN58+a4uLgwbdo0Fi1aZKhz7ty5SrU5a9YsvvrqK7y8vGjevDk7duxgzpw5VWqrsnFXxoULF9i+fftN9z169Gg2btxIWlqaod7x48cJDw8vt6/CwkI2btxoSIYqu//qxi6MN2rUKCwtLVm1alW58pUrVwIwePDgOotFry0pWwqHa//VHKNHaO9r48HABQe4v50ny8d1xNysLEcuLtUx5qejbDmfwuz+gXRv7mx0sEIIIUR9pNPkkfzry2TuCjOUqexc+T/27ju+qer/4/grSdO9dwuU0kLZG8pGERCRKSiIoCxRQZZft7gRVFwMRWSjDJGp4ALEQdlDZtktoy3du03aprm/Pyr5WSmjTdu04fN8PHxgzz25552eps0n995zNY4eqDT//wbeqCjk5eVhZ2eH+l9HbLS+5l9DZE2GtqxBbU9HBiw9QGJ2PnN2RXMhOYc1I1rjYm/2WxercOBKGtO3nycr79a3vEjXFZBwB5eHKUB8Vh5tZ+/C3aHkovM6Fzsb3uhZj/CgOzu6o9frSU9PL3aE6GY++OADatSowfLly9H8s9q1v78/s2fP5sEHH8TPz8+0z4ULF5quF2zdujUDBgzg1KlTNG3aFICPPvqIBg0asHDhQtMR0pkzZ7JixYpiY86YMQOdTscvv/yCi4sLAA0aNOB///tfsTf8txtTURS2bdvGJ598Ynrc8OHDSUhIuKOxBgwYgK+v7x3nLouK3Hdl7F+UTmBgINOnT+e1114jNTWVVq1acfLkSbZu3cqkSZNo27ZthY6vGI2k7phHys8fY0iNMbWrHd3wuPcpfAa+jdrO0exxzP6r8MKWSPQGI+8/2MBUzALY2qh5v09DNp6I54UtkeyZ3PkWexFCCCGqp5wzfxK3eDQF/9yCQGXnhN+jH+PR7ekbVq3U6XRERkYS2qhRlb9my9La1/bgwJQu9Ft6gBPXsvjxdCKdPo9gy5hwanua/waoupv9VzRbIxNu37GUjv2zMNftuNrZsGrEnRW01wtTg+H295s8cOAAzz77rOkxAAMGDOCjjz7i2LFjptNXa9asWWzxm5CQorP/4uPjTQXt/v37eeGFF4q9Dvv161esuCosLOSPP/5gxIgRpgIToHv37tjY2LB//37Tvm83pkqlokGDBixbtgx7e3tat26Ns7OzqQi/3Vh79uxh4MCBd5S7rCpy35Wxf1F6/fv3p3nz5vz0009cunSJoKAgNmzYQOPGjSt87PiVk0j7bT4qG1vcOo7A1q8ehvRrZOz/lpSfPkJ3cT+1X9mJSm3erdrMLmiv/+ILcL1xdbDAf9qOxmWYO4wQQghRpRjzdSSue43U7XP+OY0KHOt3JfDJZdj6yqU15aG2pyMREzsxbOURfjqdyIlrWbSbG8H3o9vSrnbFX/tVlU3tWoesPMMdHaG90yIVoHmg6x0doZ3a9c5/xrVaLTVr1iQ6OvqW/XQ6HTk5OTdc1+fu7g5Q7JTY/65Kq/7nerzCwkLTvnJzc02Pve6/+9bpdOTn53Po0KEbVntVFIXY2FhT4Xq7MQEWLVrE8uXLmTt3LufOnaNx48ZMmTKFDh063HasmJiYO85dFhW578rYvyi72rVrM378+EodMy82krTf5oNGS/Bru3AIDTdt8x74JlFvtiT37F9k7v8Otw7DzBrL7ILW09GWuEw9u6NT6dXAt9i2iOhUADwcbM0dRgghhKgyci/sI27RSPLjzwGg0trj+8j7ePacXK4LXQhwtdfyw5hwnv/hFHN2RZOQlcc98/ew4tEWDG1Zw9LxLCY8yIMtY8Nv26+g0Eitd3eQmJ13y6vWVICfix0Hp3apkJWOH3jgAVauXElKSgpeXl43bD9z5gwNGjTAy8uLK1euFNt2/euaNWve8XgODg54enoSExNTrP3q1eKLtTk5OeHq6kpISAgdO3Ystq1Lly4EBQUVu0b2djw8PHjuued47rnnyM7OZvbs2TzzzDPs3r37tmOFhYXdce6yKM2+bW1tyc/PL9aWnp5ebvsX1k8XfRAAp0bdixWzAFr3ANw7jyLlxw/RRR80u6A1+zfWE22KfrmMW3eMbWcTKSg0km8wsu1sIk+tO1asjxBCCFGdGQvySPjuVS6918lUzDqEtidk+lG8ek2VYraCaNQqZg9swvzBTdGoVeQZjDy68gjTt59DUWSxqFvRatQ82zn4tkuwKMCznYIr7LY9Tz31FN7e3kyePLnYokKKorBmzRo+/PBDoOj0yPXr15uuOzUajXz55ZcEBASU+nq/vn37snbtWlJTiw6w5Ofns3DhwmJ9VCoVjzzyCOfOnaNbt24MGDDA9J+npydubm53PF52djY//fST6WfS2dmZNm3aoNfryc/Pv+Ox7iR3Wd3pvkNDQzlz5oypiFUUhW+++abc9i+sn9reFQCNU8lH6K+3qx1czR7L7CO0b/cK40JyDuuPX6PXwv1o1EXnzF9fjfCR5gG83atiloAXQgghKovu0hHiFo0kL+YkACobW3weegev3i+g0shCRZVhfMdgQr0ceeTrw2TqDbz5y1nOJmazeEhz7LXmXYNlzV65ry77L6fxYwn3ob3+dZ+Gvrx8X90Ky+Dm5sbq1at5/fXX6d69Oy1btsTFxYXIyEj0ej2TJ08GYOLEiZw+fZr+/fvTsmVLrl69SmpqKnPmzCn1decTJ07k77//pk+fPrRo0YILFy6YTh/+t+eee47MzEzuu+8+mjdvjp2dHRcuXCAoKKjY7YRux8bGhm3btvHxxx8TFhaGwWDgyJEjTJo0CU9Pz9uONWvWrFLlLos73ffDDz/Mxo0b6devH82bNycqKorg4OBy27+wfk6Ne6Bx8Sb3XATGvNwbFn/KPrkNNFrcwoeYPZZKKaePNv+4kMwPpxK4mJKDCgjxcqJ/Yz/uretdHruvdo4cOQIU3X/M0q4vQtJIFiGxOjK31knmtWpRDAUkb5lJ0pb3oLDoekX72i0JfOpr7Gs2KdW+ZG7LR2R8Fn2XHCA6NReAjsEebBrVFl8XO4tlqupzW1Bo5MOdF/hi9yXis/5/1WN/Fzue7RTMy/fVrbCjs/8VHx/P6dOnKSgooGbNmtStWxdb2+KXp0VGRpruQ9uqVati39NTp06RnJzMPffcY2pTFIUffviBtm3bEhgYaGovLCzk8OHDJCcnU6dOHUJCQvjll1/o1KkT3t7F36MmJCRw8uRJVCoV9erVo1atWqZ5ValUZGVl3dGY8fHxREZGotFoaNSoET4+Pjd8D0oa699Kk/vfzpw5Q0xMjOm+sP/9uqR9e3t707lzZ77++mvatWtn6ldQUMDRo0fJyMggLCwMHx8ftm3bRpcuXUwF+p3s/06zV7aq9JqtSnVDeVEKDeSe303sV49j618P34fexdY/DEN6HCm/zibr0Ab8n5iPa+uBxR+o0aLWlu53ebkVtKK4qvSDWZVesKJ8ydxaJ5nXqkMfc5K4hSPRXy76nY7GBu9+0/DpNw2Vza0XzimJzG35ScrO46FlB9l9KQ2AYE8Hfhzbjkb+Lrd5ZMWoLnNbUGhkd3QqqbkFeDpq6VTHs9IK2eqousyrOZKSkkosaK1dVZrbqlQ3lJfUnQuIX1H6hag8uj1NwKgFt+/4L3KOlBBCCPEfirGQlJ8/JmnjmyiGooVR7Go0JnDcChzqtLZwOgHg42zHb+M78OR3x1h5OJZLqTo6zIvgu8db37BIpfh/Wo36rj17TghReexrNsGj+7Olfpxj/S6lfkypC9pn1h8HYMHDzYp9fTvX+wshhBBVWV78OeIWjkR3cV9Rg0qN14Mv4vPQO6U+DUpULDsbDV8Pa0kDX2de//ksmXoDfZYcYO7AJkzoFGzpeEJUC66ursyaNYvQ0FBLRxFWxDGsM45hnStlrFIXtF/tvQz8f4F6/evbkYJWCCFEVaYYjaTumEfid6+gFOgBsPUPI3DcChzrtrdwOnEzKpWKaT3CCPNx5onVf6M3GHl24wnOJGbzaf9G2MjptELckp2dHQMGDLB0DCHKrNQFbcGsPrf8WgghhKhu8pOiiVs8mtwzf5raPO+fiu/DM25YmVFUTY80D6S2hwP9lx4kISuPeRHRXEjO4dvHW+FqX/rrnYUQQlQPpS5o//tJp3zyKYQQorpSFIW0378i4dsXUPJyAND61CHwyWU4NbjnNo8WVU14kAcHpnSm35KDHL+Wyc9nEuk0bzdbxoYT7CkfTAghRGVSFIXsv7eQdWQzBSlXMOZl39DHpfUgvPu8ZNY4siiUEEKIu1JBylXilj5JzsltpjaPbk/jO/QjNA6WWSlXmC/Iw5GIiZ14bNURtkYmcDI+i3ZzdrF5dFs6BHtaOp4QQtwVFEXh6mf9yD72I6hU2LgFoC7hb6sxP9fsscq8KFRpyTW0QgghqgJFUciIWEH8qikYdZkA2HjWJHDMEpyb3m/hdKI8uNjbsHl0W17cEslnf0WRmJ1Pty/3smxoC4a1qmHpeEIIYfVyIneSfexH1I5uBL/6J/ZBzStsrDIvClVaUtAKIYSwNEN6PHHLniL76BZTm1vnUfg/9hkaJ3fLBRPlTqNW8emAxtT3deLZjSfJMxh5bNURziVl8+b9YahUKktHFEIIq2VIvQqAc9PeFVrMQjksCiWEEEJUBxn71xK/YgKFOakAaNz8CBy9CJeW/SycTFSkpzsEE+rlxMMrDpGhN/D2tnOcTcph6dDm2Gs1lo4nhBBWyTagAVA+pxTfTqlXdLLRqMv0nxBCCGEJhqxkYj4fQuz8R03FrGu7RwmdeUqK2btEjzAf9k3uTIhX0cJQa/6O5b4v95KQlWfhZHeHhIQEEhISbro9JyeHy5cvk5+ff9t9JSUlkZSUVJ7xLMrano8Q1znWbY9T0wfIifyN/KToCh1LFoUSQghhtTIPb+ba8qcpzEwEQOPsRcDIL3ENf8TCyURla+Dnwv7JnRm04hC7olLZezmNdnN2sXVsOE0CXC0dr8Jc+aw/BYkX76iv1jeUoOd+KPcMK1as4Ntvv2X37t04ODjcsH3u3LmsW7eOiIgIbG1tb7mv6dOnYzAYmD9/frnnrEjXi1YfH59i7WV5Pjfbl7l9rdHd/vwtrdakDcSvnEz0221x7zIarVcQUPxyD7uaTXBqeK9Z40hBK4QQwuoU5qQRv3IKGXu+MbW5tBpIwKgF2Lj5WTCZsCRvZzu2P92ep9Yd5+tDMVxO09Fx3m6+e6I1DzTwtXS8ClGQeJG8uEiLZhg8eDBLlizh119/ZeDAgcW2GQwGtm7dSu/evXF0tN5bK7311lvY2Ngwd+7cSt1XeY5bHd3tz9/Ssk9uI+voFgqzU0j5+eMS+3h0e1oKWiGEEOLfso//QtySsRjS4wBQO7rhP2Iebh1HyEJAAjsbDcsfbUEDX2de++kMWXkG+izez5yBTZjYuY6l41ml0NBQmjdvzubNm28oaP/66y+Sk5MZNGgQqampZGVlAeDg4ICv760/ZEhNTSUvL4+AgIBi7YWFhcTExODj41OsSDYYDCQlJeHi4oKzs/Md58/Pz+fatWsEBATccIQ5Pj4eOzs7PDw8TG06nY7ExERq1aqFWq0mKSkJnU6HRqPh8uWixVU9PT1xcbn57cFulrU0+7qTvrf6niQmJqJWq/H29iY/P5+0tDR8fHxQq9Wm70tqaio+Pj5oNJrbPtbX1/emv4PvNEdWVhbp6ekEBgaSkZFxy5+XWz3/+Ph4FEUp1v+/83arsa8/39zcXDIyMvDy8rrt2QV3m4KUq8TOH4piyMez13M4N+uN2v7Gn9Py+JBZClohhBBWoVCXScKa50n/c7GpzanpAwSOWYzWU27VIv6fSqXi1e71qOftxBNr/kZXYGTSppOcScxm9oDGsvZHBRg0aBBvv/02cXFxBAYGmto3bdpEcHAwrVu35vPPP+f7778Hiq6r1ev1jBkzhokTJ5a4z507d/LOO+8QERGBm5ubqX3Hjh1MnTqVHTt24OjoiMFgYO7cuaxcuRKtVktOTg733HMPH3744S0L25ycHN58801++eUXXF1dycrKolevXrzzzjumx02YMIF27drx8ssvmx538OBBxo0bx8GDB3F1dWXBggUcPXoUgCeffBKA8ePHM2jQoBvGvF3W0uzrVn3v5Hvy6quvmq5rvnjxIjqdDldXVz755BN27NjBxo0b0Wg06PV6pk+fTt++fU1jv/rqqxQWFqLRaDhx4gR5eXl4eXnx4Ycf0rZt2zt+vv/el1ar5e+//8bDw4O1a9eyevXqW/683Or5T5gwgdatW/PAAw/cdN5uNbZer+ett95iz549uLm5odfrefbZZxk7duxNfpruPrln/0Ix5OPYsBv+j31aoWPJb2whhBDVXs7p34l6vZmpmFXbOxMwehFBz/8kxay4qYebB/LnhE74u9gB8MXuS/RdcoAMXYGFk1mfPn36YGdnx+bNm01taWlp/P777wwePBiAiRMnsn37drZv386ePXtYtmwZK1as4Keffipxn71798bGxoYtW7YUa9+wYQMdOnSgRo2i1/6HH37IihUrmDNnDvv37yciIoKEhATee++9W2b+8MMPOXjwIO+//z47d+7khx9+4MiRI8yYMaNUz/2NN96gQ4cOdOnSxfT8SipA7yRrafZ1q753+j05ePAgQ4cOZc+ePezZswd/f39GjRpFeno6ERER7N27lzFjxvDGG2+QnZ1d7LF79+6lTZs27N+/n0OHDtGhQwcmTZpkOqpamhx79+7lvvvu49ChQ2zfvh1PT8/b/ryU5nt1K/8d29HRkVGjRpGSksJvv/3Gnj17WLRoEfPmzeP3338v9f6tlcrOCQCtR8X/DZaCVgghRLVlzMshfuVkLn9wHwXJRaeUOTbsRsh7J/C490k5xVjcVtsgdw5M6ULzwKIjMr+eTaLjvAiiUyr+VhPm0F08wJXP+nHp/Xtv+V9+8qU73md+8qXb7u/S+/dy5bN+6C4eKFVeFxcXevbsWayg3bp1K0ajkQEDBhTrq9friYmJwd3dndatW/Pnn3+WuE8nJyceeOABNm7caGpLTEwkIiKChx9+GICsrCzWrFnDiBEj6NKlCwDu7u68+OKLfP/99yQmJpa475ycHNatW8fYsWNNhXFISAjPPPMMmzZtIi0trVTP/06UNWtFjtO6dWvTkVcHBwfuv/9+CgoKeOWVV0yn2Pbv35/c3FyioqKKjVOrVi2eeeYZVCoVWq2WV199Fb1ezw8//FDqHI0bN2bYsGElPp87/Xkpq/+O/csvv3D58mXefvtt/P39gaLv06BBg1i8ePHNdnPXcW7SE42bH7qL+1AKDRU6VqlPOU7OLtsS997OdmV6nBBCCFGS3PN7iFs0kvyECwCobB3wGzILj+4TUKnl81px52p5OBAxsROPrTzClsgEIhOyaTd3F5tHtaVjHU9LxytRyrbZZB/dWq77VPJzyT1zZ8WA2sGVmqGrSrX/wYMHs2XLFg4dOkSbNm3YtGkTnTp1ws+v6Bq6Q4cOMXPmTM6dO4e7uzsODg6kpqbSpEmTW+5z+PDhnDlzhgYNGrB582ZcXFzo0aMHAFFRURQUFBAcHGy6jhLA1dUVo9HIxYsXS7xW9/LlyxiNRho2bFisvVGjRiiKwqVLl4pdN1seypq1Isf57/XJjo6OODo64u7uXqwNuOEIbf369Yt9qOjs7EytWrWIjo4udY7atWvf8DzK8vNSFv8d++zZszg4OODq6lost5+fH1u3lu9rsjpT2dhRa+J6YhcMJ/arEXj3fwOtV9CNHzRrtKi15tWJpS5ofd7aVqaBlE/kXn9CCCHMZ8zXk7TxDVJ++QT+WdTDoW5HAsctx86/noXTierK2c6GTaPb8vLWSD75M4qk7HzuW7CXpUOb81irmpaOdwOv+6di1Gdh1Gfdsp8u6iBK/p0dbVbZOuIQ0va2/dT2LnjdP/WO9vlv7du3p0aNGmzatAlXV1dOnTrF7NmzgaJrKZ999ln69evHqlWrTIsvPf/887c8MtmmTRuCg4PZsGED06ZNY+PGjfTr18909PD64j1ffPEFCxcuLPbYoKAgcnNL/t7Y2RW9wdbr9Tg5OZna8/KKDuxcz1fSWSCFhYW3/V6UpKxZq+o4179X/6bX603fu9Lk+O+iU2X9ebmuNPP237FtbGwwGAyMGzfuhr7u7u4UFBSg1Wpvm8Hapf25mPgV4wEoSLlC5v61Jfbz6PY0AaMWmDVWqQva5+8JuaHtbFIOWyMTqOPpSNcQT1QqFX9eTCE6NZe+jfyo7+NUwp6EEEKI0tFFHSR20Ujy404DoNLa4TPoPbweeA6VWnObRwtxaxq1io/7N6a+rzMTNpwgz2Bk+Kq/OZuYw9u9wqrUKewOoeEEPbfltv0uvtr4jm/bY+sdTPCrf5iZ7OZUKhUDBw5kxYoV2NjY4O7uTvfu3QFISEggPT2dPn36mIoTvV7P4cOHqVWr1i33O3jwYJYuXUr37t2Jjo7ms88+M20LCwvD3d2dqVOn3rDCcmFhoWk12/8KCgrC1dWVffv2mTIC7N69GycnJ4KDgwHw8vK6oYA6derUDfuzs7MrscD7tzvNeif7utW4Zf2elNbx48fJyckxfSBw9epVYmNjadSokdk57vTn5Wbfqzudt5K0bduW5cuXs379+mKLkUFRoW1jI2vuAtjXbIJH92dv28+xfhezxyr1d/zj/o2LfR0RlULPr/YxuFkAq4e3wtbmn6W8DUaGrTzMz2cSefW+umYHFUIIcfdSDPkkfT+d5K3vg7HoU3T7Om2oMW4FdjUaWTidsDbj2tcmxNORh78+TLqugHe3n+NsUjbLHm2Bg1Y+ODHHQw89xPz581m7di3Dhw83HUn19/cnMDCQ+fPnM3nyZPR6PQsWLCAhIeG2Be3AgQOZPXs2r732Go0bNy52mrCtrS3Tpk1jxowZZGZm0qpVK4xGI6dOnWLlypVs2rSpxNutaLVapk6dygcffEB+fj5qtZpTp06xZMkS/ve//2Fvbw9At27deP/99/n++++pX78+hw8fZtmyZTfsLzQ0lO+++46jR4/i4eFR4q127jTrnezrduOW5XtSWtnZ2UyePJlnn32WvLw8Zs2aRVhYGL169SrV8y3Jnf683Oz5X5+3kJAQbGxsOHnyZInzVpKuXbvSrVs3Ro8ezTPPPENwcDApKSns2bOHhIQEZs2aZfb3zho4hnXGMaxzpYxl9kcIL2yJRG8w8v6DDUzFLICtjZr3+zRk44l4XtgSyZ7JlfOEhBBCWBf9lePELnqCvCvHiho0WnwGvIl331dQaeSTcFExuof5sHdSJ/ouOcDFlFzWHo3jcpqOzaPb4uci64KUVa1atejVqxeRkZGm1Y2h6LTOxYsXM2/ePF599VWcnJzo2rUrDRo0ID4+3tTPx8cHg6H4AjO+vr7079+fw4cPM3z48BvG7N+/PzVr1mTVqlWsW7cOR0dHGjVqxPz5829ZuA0fPhx7e3tWrVpFREQEvr6+vPvuu8WOJg4dOhS9Xs+aNWsoLCykadOmzJw5k48//rjYEcaRI0eSlJTEu+++S3Z2Ns888wyDBg264fncSdab7askN+t7J+P4+voWu1YWihb3+u8HDBqNhqCgIFORf13v3r1p2rQpc+bMISUlhZYtWzJ16tRi35ey5rjTn5ebPf+hQ4eSlZXFli1b+Ouvv2jevHmJ81bS2ACzZ89m/fr1fPvttyQkJODn50fHjh0ZP358ifMgKpZK+e9dhUvJ4eUf0RuMZM3sjbNd8TcW2XkGXF77GQetmtwP+pgVtLo5cuQIAK1atbJwkqIbRUdGRtKoUaMbbgguqjeZW+sk81pEKTSQ/OOHJG1+BwqLbqNiV6sZNcatwL52C8uGKyOZ2+onJSefQcsP8ldUKgBBHg5sHRtO0wDXYv2q6txe+aw/BYkX76iv1jeUoOd+qOBE1UtVndeqbuzYsXh4ePDxxx9bOspNVaW5rUp1Q3nTXzlO6va56KIOUJibjluH4bh3HU1GxNfYBjTAvdMIs8cw+6NtT0db4jL17I5OpVeD4iuvRUQX/fL3cDD/tAUhhBB3j7y408QuHIk++mBRg1qDd59X8Bn4Jiob+ZsiKo+Xky3bn+7A0+uPs/zgVa6k6eg4L4K1j7fmwYZ+lo53W1KgCiEsJfPAOmIWDEelVmPj5o8h9SrG3DS0HjVJ2/klRkMeLq36o3Fwvf3ObsHsq76faFO08t+4dcfYdjaRgkIj+QYj284m8tS6Y8X6CCGEELeiGAtJ+fkTot5saSpmbQMaUOf1Pfg+/J4Us8IibG3ULB3anPcfbABAdl4h/ZYcYO6uKMw80U0Iq+Tr64uPj4+lYwgLKszNIG7ZOFCMBL/6F159XjFtU9s54tyyH0peDlmHN5s9ltlHaN/uFcaF5BzWH79Gr4X70aiLVgAsNBb9gn+keQBv9wozdxghhBBWLj/hArGLR6M7F1HUoFLh2et/+A6ejtpWTvUTlqVSqXilez3CfJwZsfoIugIjUzaf4kxiNnMHlu99L4Wo7t5//31LRxAWlnvmD4y5GTg17YVDaDi6y0eKbbf1K7rNXl7MCbPHMrugtbPRsG5kG/64kMwPpxK4mJKDCgjxcqJ/Yz/urettdkghhBDWSzEaSdv5JQlrXzLdL1PrG0qNccsrbYVEIe7UoGYB7PLoRL+lB7iWmceXey5zMTmX5Y/IattCCHGdITsFABu3gBK3q7VFi4gphYYSt5dGuS0PeW9dbylehRBClEp+8mXilowhN3Knqc2j+7P4Df0QtZ3cw1xUTa1ruXNgShf6Lz3A37GZbDuXxH0LD/FBByekrBVCiP8vZA2pV0vcnp8UDYDWJ9jsscrnzsmArqCQneeT+frQVRbvuwwUnXZsKDSW1xBCCCGshKIopP25hKhpTU3FrNYriKCXdhDwxOdSzIoqr6a7A38924kBjYsWhjqTlMOoX5PZcyndssGEEKIKcKrfBbWjGzln/yQvNrLYtsKcdLIObQC1Bpfmfc0eq1wK2mUHrlDz3e10X7CXkWuOMm7dcQA6f74b7Us/cuBKWnkMI4QQwgoUpMVx9bO+XFv6JEZ9FgDuXccSMuMEzo27WzidEHfO2c6GjaPa8uK9oQCk5xl5cNlhVh6OsXAyIYSwLLW9M/7DPoNCA5dmdiVj99cA5F7cR/R7HTFkxOP14EvY+oWaP5a5O9h84hpj1h7D3kbD6uHF7500sVMwAAv2XDZ3GCGEENWcoihk7FnFxWlNyD72EwA27gHU+t+PBI5dbPay/UJYglqtYla/Rswf2BCNCvILFR5f/Tdv/HwGo1FWQBZC3L3cu46m5qSNaFx90V3YC0DelWMUZqfgN3w2fo/MLJdxzL6G9oOdFwBYNKQZDzb047FV/7+CVbvaHgDsOJ9k7jBCCCGqMUNmIteWP0PW4U2mNrcOw/EfMReNs6cFkwlRPka1qYE6K5FX92SQpjPw3o7znEvKYfmwFjhoNZaOJ4QQFuHa5iFc2zxEQWoshswE1PYu2PqGolKX25Wv5he0x+IyAega4nXDtlruRatXxWflmTuMEEKIairz4HqurRhPYVYyABoXHwJGfYVrm4csnEyI8tXGz44/nm7LwyuPcz45h++OxXEpLZfvR7fF39Xe0vGEEKLS5MVGknP2L+xqNMapfhe0njXQeta46XZzmF0a22iK7jtrKOG0mnRd0TLMrnbltpiyEEKIaqIwO5WYLx8j5vNHTMWsS5vBhM48JcWssFr1vJ3YN6Uz94QWfdB/4Eo64XN2cfyfAwBCCHE3yDn7F/ErxpO5d1WZtpeG2QVti0A3AHZHp96wbVdU0f2H2ga5mzuMEEKIaiTr6FYuvtaYzH1rAFA7eVDjmdXUnLgOG1cfC6cTomJ5Otqy7an2jAmvBcDVdD2dPo/gx8gECycTQoiqQTHkF/2PRmv2vsw+dPpc1xAiolOZ+v0pAlztTO1nE7N57aczpj5CCCGsX2FuBgmrnyN91zJTm3OLvgSMXojWveSbqwthjWxt1Cwe0pwGvs68/ONpsvMK6b/0AJ/0b8yULnVQqVSWjiiEEOXKmK/HmJcNgJKXU9RWoMfwz1lapn76LLKP/wyA1rOW2eOaXdAOahbAuw/U561fz9L6s12m9gYf/o5KBR/0acj99X3NHUYIIUQVl31qB3GLx5huoq52cMX/sdm4dRklb97FXUmlUvFit7rU83Zi+Oq/yc0v5LnvT3EmMZt5DzVBqym/RVGEEMLS0iOWE79ifLG2jIgVZESsKLG/2tEdt/aPmj1uuVzc+kbPMB5q4s+av2M5nZiNokCYjxPDW9WkWaDchkEIIayZUZ9NwtqXSNv5panNqXEPAscuQesVZMFkQlQNA5sGsOtZB/otOUhcpp6v9l7mYnIO60a2wd3B/NPthBCiKrAPaoHnA88DkHf1GDmndmAX1BynRj2K9VPZ2KL1CsK11UBs3P3NHrfcVmtqEuDKjAApXoUQ4m6Sc+Yv4haPpiApCgCVnRN+Qz/C475n5KisEP/SqqY7B6Z2pv/SgxyJyWDH+WQ6zI1g69hwQr2dLB1PCCHM5li3PY512wNFa2mgKDi37IfX/VMqdFyzC1pDoZGI6FS0GjWd6hTdS/Bapp7Xfz7DpVQdQ1sE8lSH2mYHFUIIUXUY83Ukrp9G6rbZoBStcu9YvyuBTy7D1lfWTRCiJDXcHPhrQkceX/M3m07EcyYxm3ZzdrFpdFu6lHD7QyGEqK5cWvTFpUXfShnL7Is3vj4UQ7cv97Li0FVT29BvDvPdsTj+uJjM0+uPs+F4nLnDCCGEqCJyL+4n6s2WpP76GSgKKq09fo99Ru1XfpdiVojbcLKzYf0TbXi5W10AUnIL6L5gL1//632UEEKIO2d2Qbtw32UAnm5fdBT2dEIWpxOyufpGT5YObQHA5xGXzB1GCCGEhRkL8khY9xqXpnck/9pZABxC2xEy/ShevaaiUssCN0LcCbVaxQd9G7J0aHNs1CoKChVGrjnKtJ9OYzQqlo4nhBDVitmnHJ9JLFqauaGfMwB/XEyhZ5gP7g5aBjQpusg3MiGrTPtOSEhg+/btnD9/Hq1WS2hoKAMGDMDR0bHE/ufPn2fLli0kJCTg7+9P//79CQ0NrdS+QghhjXSX/yZu4UjyYk4UNWi0+A56F6/eL6DSlNtyDELcVUaHB1HH05HBKw6RmlvAzN8ucC4phxXDWuBoK68rIYS4E2Z/nH590Y/8wqJPFA9dTadljaLFobTqom05+YWl3u/ixYvp1q0bv/zyC2FhYdSqVYvVq1fTs2dPjh8/fkP/rVu3MnDgQJKTk2nXrh3x8fEMGDCAHTt2VFpfIYSwNoqhgKTN7xL9TripmLWv3ZKQdw7j3fcVKWaFMNO9db3ZN7kzYT5FC0OtP36Ne+bv4Vqm3sLJhBCiejD7nUgDX2f2XU5j84l4Hm4ewE+nE3mmQzAAF1NyAahbhtX74uPjefvttxkyZIip7ZFHHqFfv3689NJL/PLLL6b2lJQU3njjDQYMGMDMmTMBGDRoEAaDgWnTphEeHo6rq2uF9hVCCGujjzlF3KKR6C8dLmpQa/Du/zo+/aahspFbjQhRXur5OLN3cmceXnGI3y+kcOhqBuGzd7FlbDgtarhZOp4Qoho7f/48S5cu5eTJk2RmZuLn58d9993HiBEjcHZ2tnS8cmH2Edr/3VO0AMjotUfxf3sbQR4OtKlV9Mv3p9MJAPRt5Ffq/U6ePLlYMQvg6OhI+/btiY6OJiUlxdT+448/kpuby6OPFr8x77Bhw0hPT+fXX3+t8L5CCGEtFGMhyT9+SPRbrUzFrF2NxtR5cz++D70txawQFcDT0ZZfn2rPk+2K7t0ck6Gn8+e72XIq3sLJhBDVVWRkJIMHD+bKlSu89957rFmzhpEjR7J48WJGjRqF0WissLHzYiNJ3bmAnLO7yrS9NMwuaB9pHsiWseE82S6ISZ3r8OPYcNNpyKcTs7kn1Mu0YFRp3OzI5+XLl9FoNDg4OJjajh07hlqtpmHDhsX6Nm3aFIC///67wvsKIYQ1yIs/x6UZXUj87hUUQz6o1Hj1eZk67xzGoU5rS8cTwqppNWoWPtKMj/s1QqUqumRrwLKDfPrnRRRFFosSQpTOhg0byMvLY8aMGTRv3pzAwED69OnDqFGjOHHiBCdOnKiwsXPO/kX8ivFk7l1Vpu2lUS4XP/Vt5FfiUdgVw1qWx+5N/vzzTw4ePMj9999fbGGo+Ph43Nzc0GqLHzWws7PDxcWFhISECu97MzqdrlTPsSLo9fpi/wrrIXNrnSwxr4rRSObvX5K2+U2UgqLfWza+dfEZtQj7kHbkGYxgsPzvs+pOXrPWqzzndkK7QGq52jD6u5PkFhh5/odITsVl8Fm/+mg1spp4ZZLXrPW6G+b2eg3z7wOB//7a1ta20jNdpxjyi/5HY/5ZX+W2moeiKMRl6snOKyzxU8QGfi5m7f/q1au8/PLLuLu7M23atGLbCgoKbig6r9NqteTn51d435IoikJkZOQt+1SmqKgoS0cQFUTm1jpV1ryqMmLR7ngXTexhU5uhxTB0HZ4lS28PVej3mLWQ16z1Kq+5DQUWdvfif3+mkKgzsvRQLCeuJvFhF09cbaWorWzymrVeVWVur5/hWp6GDRvGpk2bmDVrFm+99Raurq6cOXOGb775hm7dut1wFqq5jPl6jHlFd8BR8nKK2gr0GLKSi/fTZ5F9/GcAtJ61zB7X7IK2oNDIGz+fZdH+y6TmFty0n/JJvzKPkZCQwKhRoygoKGDZsmX4+/sX2+7o6HjTI6E6nQ4nJ6cK71sSlUpFnTp1btmnMuTn5xMTE0PNmjUt+kmMKH8yt9apsuZVURR0e1eQ+f2bKP/8AdJ4BuE27HPs6nWusHHvZvKatV4VMbchIdC2YQH/23KG00k5pOiNTD+Yzez+DajlZl8uY4hbk9es9apKc3u7onrv3r1MnTr1jvb1zjvv8MADDwBQu3ZtVq9ezcSJEwkPD8fe3h6dTke/fv1MC96Wp/SI5cSvGF+sLSNiBRkRK0rsr3Z0x639oyVuKw2zC9pXfzzNJ39G4WynYULHYII9HVBRfp8wJCcnM3LkSNLS0li8eDHNmjW7oU9QUBB79+4lKysLF5f/PxKcmpqKTqcjKCiowvuWRFGUKvOpD0BMTIylI4gKInNrnSp0XrMSsP3tPTRX9pqaDE0Goes8hWyNE1Sh313WSF6z1qsi5vadcCfg/z9EL0iJIyrl5v1F+ZPXrPWqDnNbUFBAenr6HfXNy8sz/f+5c+cYM2YMderUYcaMGfj5+XH06FFmzJjBxIkT+fLLL9FoNOWW0z6oBZ4PPF+U4+oxck7twC6oOU6NehTrp7KxResVhGurgdi4+5e0q1Ixu6D95nDRD8G6J9rwQANfswP9W2pqKqNGjSIhIYHFixfTqlWrEvt16NCBtWvXcuDAAbp3725q379/PwCdOnWq8L4lUalU5X4ovyz0ej1RUVGEhIRgby+f6FoTmVvrVJHzqigK2ftWkfrdixh1GQBo3APxfvxLHBv3LNexxI3kNWu9KnpujUaFuRHRLN5/BQAbtYq376/PwKbmvxkUNyevWetVleb29OnTt9zeoUMH9u7de8s+1/37VjyzZs0iJyeHL774wrTgbo0aNVCpVDz33HNs2bKFgQMHljn3fznWbY9j3fYAZB3dCoqCc8t+eN0/pdzGKInZBW2m3gBA1xBPs8P8W1ZWFmPHjiU2NpZFixbRuvXNV9fs0aMHwcHBzJ8/n44dO+Lg4EBOTg4LFiygQYMGdOnSpcL73sx/L8K2JHt7+yqVR5QfmVvrVN7zakiPJ27ZU2Qf3WJqc+s8Ev/HZqNxci+3ccTtyWvWelXk3L7aqzGBnq6MW3eMgkKFx9ae5JUkPTN6N0CtLv/r78T/k9es9aoOc6vVavH0LH2tde7cOYKDg2+4e0yTJk0AOHv2bLnkK4lLi764tOhbYfv/N7ML2na1PfjzYgrXMvMI9S63NaZ4//33iYyMpG7duqxatYpVq4ov6fzCCy9Qo0YNoGiSv/zySyZOnEjv3r1p3LgxJ06cwN3dnS+++AK1+v8XT6iovkIIUZVl7F9L/IoJFOakAqBx8yNw1EJcWvW3cDIhRGmMbFuLOp6OPLT8IKm5BXyw8wLnkrL55rGWONqW3/swIUT15+PjQ0xMDPn5+cWuE7506RIAvr7le3ZtSfRXjpO6fS66qAMU5qbj1mE47l1HkxHxNbYBDXDvNMLsMcz+zfdp/0bcO38vM387z+Ihzcttha7Bgwff8pTef1/TChASEsLWrVs5fvw4iYmJPP300zRt2rTEPBXVVwghqhpDVjLxXz9L5oHvTG2u7Ybi/8QX2Dh7WTCZEKKsuoZ6sX9KF/ou3s/ZpBw2nojn8hd7+GFMOIGyWJQQ4h+PP/44L7/8Mm+99RavvPIKbm5unDlzhvfffx93d3f69Sv7or13IvPAOmIWDEelVmPj5o8h9SrG3DS0HjVJ2/klRkMeLq36o3Fwvf3ObsHsgnb1kVi61fVi6YGr/B2bQcdgT+xtbjxy+XH/xqXa761OMb4ZtVpNixYtLNpXCCGqiqwj3xO37CkKMxMB0Dh74f/EfNzaDbFwMiGEuep6O7F3cmce+fowv51P5nBMBuFzdrFlTDgta7pZOp4QogoYOHAgTk5OLFiwgC5duqBSqbCzs6NTp05MnToVb2/vChu7MDeDuGXjQDES/GoEustHTCsgq+0ccW7Zj4yIFWQd3ox75yfMGsvsgvaTP/9/Jcy/YzP5OzazxH6lLWiFEEKUTWFOGvErp5Cx5xtTm0urAQSM+gobNz8LJhNClCcPR1t+HteOiRtPsHDfFWIz9HT+Yjerh7diQBNZLEoIAT179qRnz55Ft+rT6XB0dKyUcXPP/IExNwOnpr1wCA1Hd/lIse22fvUAyIs5YfZYZhe0Se/cb3YIIYQQ5SP7+C/ELRmLIT0OALWjG/4j5uHWcYRcKiGEFdJq1Cx4uBn1fZ15YUskufmFPLT8ILP6NOL5e0PkdS+EAIruvlJZxSyAIbvo3mI2bgElbldriy6PUAoNZo9ldkHr7WxndgghhBDmKdRlkbDmedL/XGRqc2r6AIFjFqP1rGHBZEKIiqZSqfjfPaHU83Zi2Moj5OQX8uLWSM4mZfPFoKbYlnApmBBCVKTrhawh9WqJ2/OTogHQ+gSbP5bZe/iHrqCQvZfSiMnQkW8w8mT72hQaFRRFwUYjv0iFEKKi5Jz+nbjFYyhIvgSA2t4Zv2Gf4n7Pk3J0Roi7SL/G/uye1Im+iw8Qk6Fn8f4rXEzJYf3INng62t5+B0IIUU6c6ndB7ehGztk/yYuNLLatMCedrEMbQK3Bpbn5t/Ypl0pz2YEr1Hx3O90X7GXkmqOMW3ccgM6f70b70o8cuJJWHsMIIYT4F2NeLvErJ3P5g/tMxaxjw26EvHcCj3vHSTErxF2oeaAbB6Z2oW0tdwB+v5BCh7kRnE/KtmwwIcRdRW3vjP+wz6DQwKWZXcnY/TUAuRf3Ef1eRwwZ8Xg9+BK2fqHmj2XuDjafuMaYtcewt9GwenirYtsmdgoGYMGey+YOI4QQ4l9yz+8h6o0WpG6fB4DK1gH/EXOp/dIObMvh9B0hRPUV4GrPHxM68HCzolP+ziXl0G5OBH9cSLZwMiHE3cS962hqTtqIxtUX3YW9AORdOUZhdgp+w2fj98jMchnH7FOOP9h5AYBFQ5rxYEM/Hlv1/ytYtavtAcCO80nmDiOEEAIw5utJ2vQmKT9/AooRAIe6HQgctwI7/3oWTieEqCocbW1Y+3hr3vz1LDN2nCdNV8D9C/fx1cPNGB0eZOl4Qoi7hGubh3Bt8xAFqbEYMhNQ27tg6xuKSl1+l6SaXdAeiyu6TU/XEK8bttVyL1q9Kj4rz9xhhBDirqeLPkTcwpHkxRVdi6LS2uEzaDpeD/wPlVpj4XRCiKpGrVbxXu8GhPk48eR3xygoVBiz9hhnErN5/8GGqNVyWYIQonJoPWtU2CKVZhe0NhoVGMBgVG7Ylq4rWobZ1a7c1p4SQoi7jmLIJ+mH90jeMhOMhQDY12lDjXErsKvRyMLphBBV3RNtalHH05GHlh0kJbeAWb9f5FxSDisfa4mTvEcTQpQDY74OY25GqR+nsnNE4+Bq1thm/xZrEehGRHQqu6NT6dPIr9i2XVFF9x9qG+Ru7jBCCHFX0l85TtyikeivHC1q0NjgM+AtvPu8jMpGa9FsQojqo0uIF/undKHvkgOcScxm88l4us7fww9j2lLDzcHS8YQQ1Vx6xAriV4wv9eM8uj1NwKgFZo1tdkH7XNcQIqJTmfr9KQJc//+etGcTs3ntpzOmPkIIIUrBaCD951mkbZ0BhQUA2NVqRo1xK7Cv3cKy2YQQ1VKotxN7J3fmkRWH2HE+mSMxGYTPjmDL2La0qulu6XhCiGrMIbg13v2mlf5xIeFmj212QTuoWQDvPlCft349S+vPdpnaG3z4OyoVfNCnIffX9zV3GCGEuGvkx5/Fbt1Y0hJOFTWo1Hj3fQXvAW+i1trd+sFCCHEL7g5afhrXjkmbTvLV3svEZerp8sUeVj3WkoFNAywdTwhRTTmEtMUhpK1Fxi6XCyfe6BnGQ038WfN3LKcTs1EUCPNxYnirmjQLNO+caCGEuFsoxkJSt80hcf001AV6AGwDGlBj3AocQs3/BFMIIQC0GjVfDm5KQ19n/vfDKXLzCxm04hAfPNiQF7uFyj2shRBmy4uNJOfsX9jVaIxT/S6l3l4a5bYSQJMAV2YESPEqhBBlkZ9wkdjFo9CdiwBAQYVbj8kEDn0fta1c3yaEKF8qlYopXUOo6+3EoysPk51XyMs/nuZsUjZfDm6GrU353VJDCHH3yTn7F/ErxuPR7ekSC9bbbS+NUhe0ydlluwWPt7OcJieEEP+lGI2k/b6AhG9fRMnPBcDGJ4Sce17Dq8djUswKISpUn0Z+7J7Ymb5L9nM1Xc/SA1eJSsllw6g2eDraWjqeEMJKKYb8ov/RmL/AZakLWp+3tpVpIOWTfmV6nBBCWKuClCvELR5DTuRvpjaP7s/i2v9tzly8bMFkQoi7SbNAVw5M6cKAZQc5cCWdPy6m0H5OBFufDCfMx9nS8YQQ1YQxX48xLxsAJS+nqK1AjyEruXg/fRbZx38GQOtZy+xxS13QPn/PjSsWn03KYWtkAnU8Heka4olKpeLPiylEp+bSt5Ef9X2czA4qhBDWQlEU0nctI2HVVIz6LAC0XkEEjF2Kc+Pu6HQ6CycUQtxt/F3t+WNCR0atOcp3x+I4n5xD+zkRbBjVhm51vS0dTwhRDaRHLL/h1j0ZESvIiFhRYn+1oztu7R81e9xSF7Qf929c7OuIqBR6frWPwc0CWD28lemai3yDkWErD/PzmUReva+u2UGFEMIaFKTFcW3ZOLKP/WRqc+86Fr/HPjX7xuJCCGEOB62GNSNaEebjxHs7zpOmK+D+r/ax4OFmjG0XZOl4Qogqzj6oBZ4PPA9A3tVj5JzagV1Qc5wa9SjWT2Vji9YrCNdWA7Fx9zd7XLMXhXphSyR6g5H3H2xQbAEBWxs17/dpyMYT8bywJZI9kzubO5QQQlRbiqKQuW8N176ZiDEnDQAb9wACRi/CpUUfC6cTQogiarWK6b0bUN/XmbFrj5FfaOTJ745xNjGb9/s0RKOWFZCFECVzrNsex7rtAcg6uhUUBeeW/fC6f0qFjmt2QXssLhOAAFf7G7YF/tN2NC7D3GGEEKLaMmQmcm3FeLIObTS1uXUYjv+IuWicPS2YTAghSjaidU3qeDoycNlBknPy+eiPi5xLymbl8FY425XbTTKEEFbKpUVfXFr0rZSxzP6N5OloS1ymnt3RqfRq4FtsW0R0KgAeDrJKnhDi7pR5cAPXVjxD4T8LImhcfAgY9RWubR6ycDIhhLi1TnU82T+lM/2WHCAyIZvvTyXQ5fPdbBkbTk13WYFdCHFzuef3kHngu9v2c6zXCdfwR8way+yC9ok2Nflg5wXGrTvG4iHN6VbXG0WBPy4m89S6Y6Y+QghxNynMTuXayklk7l1tanNpM5iAkV9i4+pjwWRCCHHnQryc2DOpM0O+Psy2c0kcjcskfM4utowJp3Utd0vHE0JUUfqrx0ndNue2/ZQCveUL2rd7hXEhOYf1x6/Ra+F+07UVhUYFgEeaB/B2rzBzhxFCiGoj6+iPXFs2DkP6NQDUTh4EPP4Fru0fRaWS68+EENWLm4OWH58MZ/Lmk3y55zLXMvPo8sVuVj7WikHNAiwdTwhRBXl0HYNbuxtXMDZkXCP1t/lk7PmGwLFLcW7W2+yxzC5o7Ww0rBvZhj8uJPPDqQQupuSgougTvf6N/bhXlnoXQtwlCnMzSFjzP9L/Wmpqc27eh4DRC9F6BFowmRBCmMdGo+aLQU1p6OvC1O9PoiswMnjFId5/sAEv31dXPqwTQhSjsrFFY3PjZacaJ3cCHp9HftxpYhc+QeiMk9j6BJs1Vrld1X9vXW8pXoUQd63sUzuIWzwGQ+pVANT2LvgPn4Nbl1HyRk8IYRVUKhWTutQh1NuRR785QlaegVd/OsPZpBy+erhZsbtdCCHErTg16UlO5G9k7FmJz4DXzdpXuRW0iqIQl6knO68QRVFu2N7Az6W8hhJCiCrDqM8m4buXSfttvqnNqXEPAscuQesl920UQlifBxv6sXtSJ/ouOcCVNB3LD14lKiWHjaPa4uUkC4EKIW7PmJcLQGF2stn7MrugLSg08sbPZ1m0/zKpuQU37ad80s/coYQQokrJObuLuEWjKEiKAkBl54Tf0I/wuO8ZOSorhLBqTQNcOTClCwOWHmD/lXT+ikql3Zxd/PhkO+r7Ols6nhCiCtNFHybtj68AsA9qYfb+zC5oX/3xNJ/8GYWznYYJHYMJ9nRAhbyRE0JYL2O+jsT100jdNhv+OSPFMawLgU8uw9Yv1LLhhBCikvi52PH7hI6M+fYo3x6N42JKLu3nRrD+idZ0D5PV3IW4m6VHrCBhzfM3tBvzdSj5RUdnHRvdh1uH4WaPZXZB+83hGADWPdGGB/5zH1ohhLA2uRf3E7doJPnXzgKg0trj+/BMPO+fgkot148JIe4uDloNq0e0or6vM+9sO0e6roAHFu1n/uCmjGtf29LxhBAWYuPmj2NY5xvaVTZ22HjWwqnhvbi06Fs+Y5m7g0y9AYCuIZ5mhxFCiKrKWJBH0uZ3SPnxQ1CMANiHhFNj3ArsAhtYOJ0QQliOSqXi7V71CfNxYszaY+QZjDy17jhnErOZ1beR6ZaOQoi7h3PTXjg37VUpY5l9OKFdbQ8ArmXmmR1GCCGqIv3lo0S/3ZaUre8XFbMaLb4Pz6TO67ulmBVCiH881qomO5/pgI9z0cJQn/4ZxaDlB8nOM1g4mRDCmpld0H7avxEudjbM/O18iasbCyFEdaUYCkj6fjpR77QlL+YEULR4Qcjbh/Du9yoqTbktFC+EEFahYx1P9k/uQiO/ooWhfjiVQOfPd3M1TWfhZEIISzBkJpH0wwwuf9ybqLfbcunD7iSsfYm8+PPlNobZ78ZWH4mlW10vlh64yt+xGXQM9sS+hPuQfdy/sblDCSFEpdHHnCJu0Uj0lw4XNag1ePebhk//aahKuFG4EEKIInW8HNkzqTOPrjzML2eSOBaXSficXfwwJpy2Qe6WjieEqCS6iwe48umDFGanAKC2d8GozyI3ciep2+cSOHYZbh2GmT2O2QXtJ39Gmf7/79hM/o7NLLGfFLRCiOpAMRaS8vMnJG18A8WQD4BdjcYEjluBQ53WFk4nhBDVg5uDli1jwnnu+1N8vvsS8Vl53DN/N18Pa8nDzQMtHU8IUcEUQwEx84dSmJ2Ca/gQ/B77DK1HIIW6TFJ+/JDkLTOJWzIGx7DOaL1qmTWW2QVt0jv3m7sLIYSoEvLizxG3aBS6C3uLGlRqvHq/gM9D76C2tbdsOCGEqGZsNGrmDWpKfV9npmw+ia7AyCNfH2bmgzm8cl9duV+3EFYs93wEBcmX0PqGUuPpb0xnt2kcXPF9eAb6q8fJPrqVzEMb8Oo11ayxzC5ovZ3tzN2FEEJYlGI0krrjcxLXvYKSX3Sdl61fPQKfWoFj3Q4WTieEENXbxM51qOvtxJCvD5OVZ+C1n85wJjGbhY80w85GY+l4QogKkJ8UDYBjaPsSL9VyrN+V7KNbKfinnznKdUWTC8k5RKXkABDi5URdb6fy3L0QQpS7/KRLxC0eTe6ZP0xtnj0n4/vI+6jtHC0XTAghrMgDDXzZM6kT/ZYe4FKqjq8PxRCVksumUW3k4IgQVkhj7wKAITOhxO2GjKJ29T/9zFEuBe2uqBQmbDjByfisYu1N/F2YP7gpXUK8ymMYIYQoN4qikP7HIhK+fR6jPhsArXcwgU8uw6nhvZYNJ4QQVqhJgCv7J3dh4LKD7L2cRkR0Ku3mRvDj2HAa+Jn/plYIUXU4hHUGjQ05kTvJOf1HsfdW+UnRpO9aCoBjObznMrugPXQ1nZ5f7SPPYKRTsAcPNPAF4NezSUREp9Lzq33sntiJ1rXczR1KCCHKRUFqDHFLnyTnxK+mNvd7n8Lv0Y/ROMibKiGEqCi+LnbsHN+BMWuPsebvWKJScmk/N4L1I9vQI8zH0vGEEOVE6x6AV+8XSdn6Ppdn9cCl1UDsAupTkBZL5sH1KHk5ODd/EOfGPcwey+yC9u1fz5JnMPJ0h9oseLiZqf31nmE8ve4YC/dd4a1fz7L1yXbmDiWEEGZRFIWM3d8Qv2oyxtwMAGw8ahA4dgnOTXtZOJ0QQtwd7LUaVg1vSQNfZ9769SwZegMPLNrPF4Oa8HSHYEvHE0KUE9+HZ6B1DyD5xw/JOrSB6+fyqh3d8HzwJXweeqdcxjG7oI2ITgXg1fvq3rDt1e71WLjvCrsvpZk7jBBCmMWQHk/c8qfJ/vsHU5tb55H4PzYbjZO75YIJIcRdSKVS8eb9YYT5ODHq26PkGYw8s/4EZxKz+bhfYzRqWQFZiOpOpVLh2XMSnj0nkZ90icLsFNQOLtj6hqJSl9+CcGYXtLoCIwAejtobtnk4aP/pU2juMEIIUWYZ+78j/usJpht7a9z8CBy1EJdW/S2cTAgh7m6PtqxBsKcjA5YeIDE7n9l/RXMhOZfVw1vhYl+ua5cKISzI1icYfIIrZN9qc3dQ17toFdDfziffsG3H+SQA6slqx0IICzBkJRPzxVBi/7mxN4Bru6GEzjgpxawQQlQR7Wt7sH9KF5r4F61hsDUygc6f7+ZKWq6FkwkhqgOzC9ox4UEAjN9wgnXH4sjQFZChK+C7o3GM33ACgNHhtcwdRgghSiXryA9cnNaEzAPfAaBx9qLGhLXUnPAtNi7eFk4nhBDi34I9Hdk9qRO9/1lc9Pi1TMLnRHDgily2JoS4NbPP5ZjaNYRjcZl8cziGIV8fvmH7E21qMrVLiLnDCCHEHSnMSSd+1RQydn9tanNpNYCAkQuwcfe3YDIhhBC34mqv5YcxbXl+SyRzd0WTkJXHPV/sYcWwlgxpEWjpeEKIKsrsglajVvH1Yy15sl0Qm0/GE5WSg0qloo6nIw819Zd70AohKk32iV+JWzIWQ1osULSKnv+Iebh1HIFKJQuMCCFEVWejUTNnYBPq+zgzefNJ9AYjQ785zLmkbKb1qCe/y4UQNyi3q+27hnrRNVSKVyFE5SvUZZHw7Quk/7HQ1ObUtBeBYxaj9axpwWRCCCHKYkKnYEK9HBnyzWEy9Qbe+OUsZ5OyWTykOXY25bc6qhCi+jP7GlohhLCknNN/EPV6M1Mxq7Z3JmD0QoKe/1mKWSGEqMZ6NfBlz6TOBHs6ALDycCzdv9xLUnaehZMJIaqSMhW055OyCX5vB72+2nfLfr2+2kfwezu4kJxTpnBCCHEzxrxc4ldO4fIH3ShIvgSAY4N7CXnvBB73jpPT0oQQwgo09nfhwJQudAz2AGD3pTTazYkgMj7LwsmEEHdCf+U4cUue5OK0Zpx7LoiE714lL/4cietfJ333ynIZo0wF7ZL9V7mcpqNH2K1XCu1ez5vLaTqWH7xapnBCCFGS3PN7iHqjBanb5wKgsnXAb/gcar/8W9F9zoQQQlgNH2c7fnumAyNa1wAgOjWXDvMi2H42ycLJhKgesrOz2bJlC0uWLOHUqVO37JuamsqWLVtYuXIlERERGAyGMo+beWAdUW+3IWPvSoz6TAypVzHmpqH1qEnazi+5tuIZCnWZZd7/dWUqaK/fX7Z7vVsXtNcL3m3yC0cIUQ6M+XoS1r7MpRldyE84D4BD3Q6ETD+K1/2TUanlKgohhLBG9loNXw9rybsP1AcgU2+g9+L9fLnnkmWDCVGFJSYmMmHCBHr27Ml3333HrFmzOHjw4E37b9++ne7du7N+/XouXrzIm2++yeDBg0lKKn0tV5ibQdyycaAYCX71L7z6vGLaprZzxLllP5S8HLIOby7LUyumTO/+rqbrAAhyd7hlv1r/bL/yT38hhCgrXfRhot9qTcpPs0AxorKxxXfoLIKn7cLOP8zS8YQQQlQwlUrFGz3D+HZEK+xt1BQaFSZsOMHUzScpNCqWjidElaMoCoMGDeLPP/9kypQpt+wbFxfH888/T79+/VixYgVvvfUW33//PVlZWbz88sulHjv3zB8YczNwatwDh9DwG7bb+tUDIC/mRKn3/V9lKmjTdAUAuDlob9nPzb5oe1puQVmGEUIIFEM+iRvfIvrdduTFRQJgH9yaOu8cwfvBF1GpZbVLIYS4mwxtWYM/JnTEz8UOgDm7oum/9ACZenm/KcS/+fn50aNHD2xtbW/b99tvvyUvL4/x48eb2lxcXBg+fDi7d+/m/PnzpRrbkJ0CgI1bQInb1Vp7AJTCsp/SbNpXWR7k5Vj0Tbl6myOv17d7Od268BVCiJLor54g+p12JH//LhgLQWODz6B3qfPGXuxrNrZ0PCGEEBbSrrYH+yd3pmmACwA/nU6k07zdXE7NtXAyIaqnAwcOEBAQQEBA8QK0devWAOzfv79U+7teyBpSS15LKT8pGgBtOax9Uqb70LYLcuf7Uwn8cCqBqV1DbtpvS2QCAO1re5QtnRXQ6Sx/urVery/2r7Ae1jq3SqGBjO2fkbblPSgs+sRdW6MJPiMXYhfUAn2BAQrM/0SvqrLWeRUyt9ZM5rby+Tqo2PlkG17ceoq/olLJ1el4ZOle5j3UhGaBruUyhsyr9apOcxsTE8Ovv/56R33vvfdeQkNDyzRGzZo33u7weoEbExNTqv051e+C2tGNnLN/khcbWWxbYU46WYc2gFqDS/O+pc76X2UqaMeEB/H9qQSmbz/Hgw19CfNxvqHP2cRspm8/B8DY8CDzUlZTiqIQGRl5+46VJCoqytIRRAWxprlVpV7CdvtbqBOKVuFTVGoMrUeiCx9HZrYtVKHXVEWzpnkVxcncWi+Z28o3saENExv6/n9DegyR6eU7hsyr9aoqc3ur2w1GRUUxa9asO9qPt7d3mQpanU6HnZ3dDe3X23JzS3f2g9reGf9hnxG3ZAyXZnbF9p/1TnIv7iP6vY4YMuLx6vsqtn6lz/pfZSpo+zfx5+FmAaw/fo22s3cxsVMw99X1xsvJlpScfHZeSObz3ZfI1Bt4tEUgfRr5mR20OlKpVDRs2NDSMdDr9URFRRESEoK9vb2l44hyZE1zqxiNZO78grTv30IpKPq0VOsXhveohdjXuXExAWtmTfMqipO5tV4yt5a39mgsM3ZcwKgULRD1bKdgnulQ26z7ksu8Wq+qNLenT5++5faaNWsyZsyYO9pX3bp1y5TB3t6e/Pz8G9rz8vJM20vLveto1I7uJG6Yhu7C3qL9XTmGxtUXv+Gz8br/1gtV3akyFbQAK4e3xMfZlq/2XmbmbxeY+duFYts1ahUTOwXzSf+7+zo3B4dbrwRdmezt7atUHlF+qvvc5idcJG7xaHLP7SpqUKnw7PUcvoPfQ21bfZ+Xuar7vIqbk7m1XjK3ljOqQ11qeLrxyNeHyNAbeP6nCxyJ17F4SHPsteYtICjzar2qw9yGhISUaaXh0ggICCAxMfGG9uttgYGBZdqva5uHcG3zEAWpsRgyE1Dbu2DrG1qut1osc0FrZ6Nh/uBm/O+eUDafiOdEfCaZegOu9jY09Xfloab+hHo7lVtQIYT1UYxG0n5fQMLal1DycgDQ+oQQOG45TvW7WDidEEKI6qZnfR/2Tu5Mn8UHiE7NZdWRWKJTc9k0qi2+LjeeTimEKNK6dWtWrFhBSkoKXl5epvajR4+atptD61kDrWcNs/ZxM2UuaK+r6+3EC93MP/dZCHF3KUi5QtySseSc2mFq8+g+Ab8hH6K2v/G6fCGEEOJONPRzYf+UzgxafoiI6FT2XEqj3dxdbB3bjsb+LpaOJ0SVNGTIEL755huWL1/O888/DxSdbrxmzRqaNWtG06ZNS7W/zIPryT2/B/fOI7EPal4RkU3MLmiFEKI0FEUhfdcyElY/h1GXCYCNZy0Cn1yKc+MeFk4nhBDCGvg427HjmfaM++443xyO4VKqjo7zIvju8db0auB7+x0IYSWWL19OYWEhsbGxQNHtdwoLCwEYNGgQHh5Fd6MJDQ3lzTff5L333iMuLo6QkBB27NhBbm4u8+fPL/W4xnw9qb9+Ruqvn2FXqxnunZ7ArcNwbNz9y+/J/UMKWiFEpSlIv8a1pePIPvajqc296xj8hn2KxtHNgsmEEEJYGzsbDSuGtaCBrzPTfj5Dpt7Ag4v3M3dgE57tXMfS8YSoFCkpKRgMBuzs7EwLSyUnJwNgMBS/BeKjjz5K+/bt+e2338jMzOTxxx/n/vvvx9m59GfOuXcagUNoOBm7vyFjz0oSvn2BhO9exrnJ/bh1HolLywGobctnMS4paIUQFU5RFDL3reHaNxMx5qQBYOMeQMDoRbi06GPhdEIIIayVSqXitR71qOfjxBOr/0ZvMDJx00nOJuXwaf9G2GjKb2EaIaqi66cP36ng4GDGjh1bLmPb+YfhO3g6PoPeJffsX2Ts/prMg+vJPv4zakc3XNs+gmePiWafkiwFrRCiQhkyk7i2YnzRDbT/4dZhOP4j5qJx9rRgMiGEEHeLR5oHUtvDgf5LD5KQlce8iGguJOfw7eOtcLXXWjqeEFZNpVLh1OAenBrcg//jn5N1eDPpu5aS/udiVGoNAaMWmLV/+VhKCFFhMg9t5OJrjU3FrMbFh5qTNlDjmZVSzAohhKhU4UEeHJjSmWYBrgD8fCaRjvN2cyk118LJhLh75MWdRhe1H/3V4/+0lP0+0dfJEVohRLkrzE7l2spJZO5dbWpzaTOIgJFfYuMqi3EIIYSwjCAPRyImduKxVUfYGpnAqfgs2s3ZxebRbekQLB+0ClERClJjydi7iozdX5MXewpUKhzqdcJ98Axc2w0xe/9S0AohylXWsZ+4tvRJDOnXAFA7eRDw+Oe4th+GSmX+p3BCCCGEOVzsbdg8ui0vbonks7+iSMzOp9uXe1k2tAXDWlXMfTKFuNsY83LJPLSBjN3fkBP5GyhGtD4heA98C/dOT2DrG1JuY0lBK4QoF4W6TBJWP0f6X0tNbc7NHyRg9CK0HoEWTCaEEEIUp1Gr+HRAY+r7OvHsxpPkGYw8tuoI55KyefP+MPkAVggzpe/+mvgV41E7uOLeZRRunUbiWL9Lhby2pKAVQpgt+9RvXFsyhoKUKwCo7V3wGz4b9y6j5U2BEEKIKuvpDsGEejnx8IpDZOgNvL3tHGeTclg6tDn2Wo2l4wlRbdkFNqTGM6twaf0QaluHCh1LClohRJkZ83JIWPsyab99YWpzatyDwLFL0HoFWTCZEEIIcWd6hPmwb3Jn+i45wMWUXNb8HUt0ai6bR7fFVd4pC1EmTg3uqbSx5GUqhCiT3HMRxC4aRUHiRQBUto74PfoxHvc9I0dlhRBCVCsN/FzYN7kzg1YcYldUKvsup9Fuzi7Wj2heDmuwCmH9jPk6jLkZpX6cys4RjYOrWWNLQSuEKBVjvo7EDa+T+utnoCgAOIZ1IfDJZdj6hVo4nRBCCFE23s52bH+6PU+vO86KQzFcTtNx38KDvNfBjUaNLJ1OiKotPWIF8SvGl/pxHt2eNvs+tFLQCiHumO7iAWIXjST/2hkAVFo7fB+eief9U1Cp5VojIYQQ1ZudjYZlj7agga8zr/50hqy8Qp77MxWD0xX+d199S8cTospyCG6Nd79ppX9cSLjZY0tBK4S4LWNBHsnfv0vy1g9AMQJgHxJOjXErsAtsYOF0QgghRPlRqVS80r0e9XyceHz13+gKjDz/4zmi0vOZPaAxNhq1pSMKUeU4hLTFIaStRcaWglYIcUv6y0eJXTSSvKvHixo0WnweehvvB19CpZFfIUIIIazT4GaB+DlqGLjsECl6I1/svsSF5BzWPt4aNwetpeMJIf4h70aFECVSDAUk//gBSd+/C4UGAOyDWhA4bgX2Qc0snE4IIYSoeK1ruLKilw+vHcjh+LVsfj2bRMd5EWwd2446Xo6WjidEtVGQFodRl4FiLCzWrnHyROsRaNa+paAVQtwgLzaS2EUj0UcfKmpQa/DuNw2f/tNQ2dhaNpwQQghRifydNOx4sg1PbjzND6cSiEzIpt3cXWwe1ZaOdTwtHU+IKsuYryNp8zuk/7WEwqzkEvuUx6JQchGAEMJEMRaS/NNHRL3VylTM2gU2os6b+/Ad9I4Us0IIIe5KznY2bBzVlhfuLVrNPyk7n25f7mXV4RgLJxOi6or98jFSfvwQrXcwzi36AeAQ2h7nZr1RO7ji89A7uIYPMXscKWiFEADkxZ/n0oyuJK59CaUgD1QqvB58iTrvHMahThtLxxNCCCEsSqNW8VG/Rix6pBk2ahX5hUZGrP6bt345i/LPbeyEEEX0MSfJOrIZjYs3wa/+iXPzBwGwD2pOree2ovWpQ9bhTTjU7Wj2WFLQCnGXU4xGUrfPI+qN5ugu7AHA1q8uwdMi8Bv6IWpbewsnFEIIIaqOJ9vX5ten2uP+z8JQ724/x7CVR9AVFN7mkULcPfSX/wbAscG9qO0cUalUACiKgkqtxqXlAPRXjpJ54Duzx5KCVoi7WH7SJS7P6kH8ysko+ToAPHtOJmT6MRzrmf+JmRBCCGGN7qvnzb7Jnanr7QTA2qNxdJu/h/hMvYWTCVE1XL9MTa0tOjCisi1aRE3JzwXAxsUbAP3VY2aPJQWtEHchRVFI+2MRUa83Jff07wBovYOp/crv+I+Yg9pOVm4UQgghbqW+rzP7JnfmnlAvAPZfSafd3AhOXMu0cDIhLM+uRmMA8uLPAUVn/wHkJ1wo+jf5MgAae1ezx5KCVoi7TEFqLFc+eZBry57CqM8GwP3epwh57zhODe+1bDghhBCiGvFysmXbU+0Z1bYWAFfSdHScF8FPpxMsnEwIy7Kv2QT7oBboow+Rd+0sDiHh2HjWQndxH3HLnib9r8UAODXtZfZYUtAKcZdQFIX03d9wcVoTck78AoCNRw2Cnv+ZwNFfoXFwsXBCIYQQovqxtVGzdGhzPujTEIDsvEL6LTnA3F1RsliUuKsUpFyhMDfD9HXAqK/wHz4Hoz4LlVpDzQnfYuNZi/Q/FqIU5OH36Mc41m1v9rhyH1oh7gKGjASuLX+arCPfm9rcOj2B//A5aJzcLRdMCCGEsAIqlYqX76tLPW8nRqw+gq7AyJTNpziTmM2cgU3QauQYkrB+Wcd+ImHN/3BtMxj3rmNxbHAPDqHhpu2O9TpS75NLGNLjsHHzR6Upn1JUClohrFzmgXVcWzGewuwUADSuvgSOXohLqwEWTiaEEEJYl0HNAtjl0Yn+Sw8Sl6nnyz2XuZCcw3dPtDGtiiyEtbKv1QxbnxAy9qwkY89KtL6huHcZjXvnUWg9awCgUqvRetYs13Hl4yIhrJQhO4WY+Y8S88UQUzHrGj6E0JmnpJgVQgghKkjrWu4cmNqZljWKFrvZfi6ZjvMiiErJsXAyISqWY72OhM48SZ039+PR7RkKs1NI2vA655+vzZVP+5B5aCOKoaDcx5WCVggrlHXkBy6+1pjM/WsB0Dh7UWPCWmo+u9a0TLoQQgghKkYNNwf+erYTAxr7AXA6IZt2cyKIiEqxcDIhKp5DaDgBo74kbM41ajyzGqeG3cg+/gsx8wZzbmoN4tc8T15sZLmNJwWtEFakMCed2EWjuDpnAIUZRSssOrfsT+iMk7i1G2LhdEIIIcTdw9nOho2j2vJSt1AAknPy6b5gH98cumrhZEJUDrWtPW4dhlH7pe3U+yQan0HvorZ3IfWXT7n4WmOi3+1A9olfzR+nHLIKIaqA7BPbuPh6UzIiVgCgdnQjcNwKak3ZjI27v4XTCSGEEHcftVrFh30bsXhIc2zUKvILjTyx5iiv/3wGo1FWQBZ3D61XED4D3qDuRxcIev5nbDxqoLu4j6zDm8zetywKJUR1l59D8qpJZO1aYmpyanI/gWOXlPtF90IIIYQovbHtggj1cmTQ8kOk6QqYseM855NyWD6sBQ5ajaXjCVEpdNGHSP9rKRn71mDMTQeNFlv/MLP3Wy0K2rS0NGJiYvDy8iIwMPCG7QaDgdOnT5f4WF9fX/z8/ErclpqaSlJSEr6+vnh4eNwyQ2n6ClFZdGf/wm71GLIy4wBQ2zvj9+gnuN87DpVKZeF0QgghhLju3rre7JvSmb6LD3A+OYfvjsVxKS2X70e3xd/V3tLxhKgQhsxEMvasJH3XMvJiTgJgF9gI9/6v49bpCWxcfcweo8oWtEajkQ0bNvDLL79w6tQp0tLSGDp0KO++++4NfdPS0nj44Yfx9/fHy8ur2LahQ4cydOjQYm2pqam89tpr7Nu3j5o1axITE0OXLl2YMWMGrq6uZe4rRGUx5uWSuP41UrfNMV034NjgHgKfXIatTx2LZhNCCCFEycJ8nNk3pTODlx/ij4spHLiSTvicXWwZG07zQDdLxxOiXCiFBrKP/UT6rmVkHfsRCgtQ27vgfs+TRfenrdu+XMersgVtfn4+f//9N6NGjaJBgwZ07tz5to954oknGDt27C37KIrCs88+S3JyMr/++it+fn5cu3aN4cOH89xzz7FkyZIy9RWisuRe2EvcwpHkJ5wHQLGxw2vQDPx6P4dKLZfFCyGEEFWZp6Mtvz7VnvEbjrP0wFWupuvp/Plu1oxoTd9GJZ9VKER1UJByldTtc0nf841pcVKHep3w6DoW13ZDUNs5Vci4Vfbdr729PTNnzqRLly5oNOV3bUFERARHjhxh0qRJplORAwICmDBhAhERERw6dKhMfYWoaMaCPBK+e4VL73U2FbN2Ie3IG7Yat/smSDErhBBCVBO2NmoWD2nOR30boVJBdl4hA5YeYPZfUSiKLBYlqqesYz+S8vPHqFDh9eBLhH54ljqvR+DedXSFFbNQhY/QloVOp+PcuXNoNBpq1aqFra3tDX3+/PNPgBuO+Hbp0sW0vU2bNqXuK0RF0kUfJm7RSPJiTwGgsrHFZ9B0HO+dQPqZsxZOJ4QQQojSUqlUvNAtlLrejgxf/Te5+YU89/0pziRmM++hJmg18kG1qF7sazah1pTNODfvg0pTeWWmVRW0CxYsYOvWraSkpJCfn8/DDz/MCy+8gIODg6lPdHQ0jo6OeHp6Fnusn58fdnZ2REVFlanvzeh0OjOflfn0en2xf0X1oRjySf/5Q9J/ngXGQgBsg1riM2oRtoGNZG6tlMyr9ZK5tV4yt9apMua1V113tj/Zmoe/Oca1rDy+2nuZ84lZrHy0Ke4O2gob924nr9ny5xh2+0tEK4JVFLRarZZp06YxdOhQ7OzsANi0aROvv/46sbGxLFiwwNQ3KysLJ6eSD3k7OjqSmZlZpr4lURSFyMjI0j6dCnMnBbioOlTJF7Dd/hbqpKIjsIpag6Htk+jajCYjHUj//58tmVvrJPNqvWRurZfMrXWq6Hm1A5Z0d+d/f6ZyJq2AnRdT6ThvN7Pv8aSmi1W8Xa+yqsprVu5OUXZW8Qpxd3fniSeeKNb20EMPERkZyddff83Jkydp0qQJABqNBqPRWOJ+jEYjWu3/fxJWmr4lUalUNGzYsDRPpULo9XqioqIICQnB3l6Wha/qlEIDGds/I23Le1BYAIA2sDE+oxZhF9SiWF+ZW+sk82q9ZG6tl8ytdarMeW0E7GpWyJPrT/J9ZBKXMg2M/S2Nbx9rRqdguWVkeatKr9mb3X5U3BmrKGhvpm3btnz99decP3/eVND6+Phw4sQJjEYj6n8tolNQUEBWVhbe3t6mttL0vZl/n+5safb29lUqj7hR3rWzxC0aie7i/qIGlRqvPi/jM/At1Fq7mz5O5tY6ybxaL5lb6yVza50qa14dHGDj6Ha89tMZPvz9Aim5BTy47AiLhzTniTa1Knz8u5G8Zqs/q77aPCMjA6DYpy5NmjShoKCAixcvFut77tw5jEYjjRs3LlNfIcyhGI2k/PIZUW+0MBWztgH1CX5jD36PzLxlMSuEEEII66FWq/igb0OWDm2OVqOioFBh5JqjTPvpNEajrIAsxH9ZRUFb0sJLRqORDRs2YG9vT3h4uKm9d+/e2NjYsHnz5mL9N23ahJ2dHQ888ECZ+gpRVvmJUVz+oBsJa/6HUqAHlQrPB/5HyLt/4xjaztLxhBBCCGEBo8OD2P50ezwdiy5xm/nbBYZ+c5jcfIOFkwlRtVTpU44vXLiATqcjOzsbgLS0NE6cOAFAUFAQbm5uAMyePZv4+Hi6detGzZo1SUxMZNWqVRw/fpx3330XLy8v0z5r1arF5MmTmTt3Lq6urrRp04Z9+/axevVqXnnlFdP9ZkvbV4jSUhSFtJ0LSFj7IkpeDgBanxACxy3HqX4XC6cTQgghhKXdE+rNvsmd6bvkAOeSclh//BqX0nL5YUw4Aa5yrbYQUMUL2i+//JLo6GgAGjduTGxsLG+99RYAL774Ih06dADglVde4c8//2Tbtm2sW7cOGxsbGjduzJtvvkn9+vVv2O/TTz9NWFgYmzZt4vfff8fPz4+vvvrKdH/ZsvYV4k4VpFwhbslYck7tMLV5dJ+A35APUds7WzCZEEIIIaqSej7O7JvcmYdXHGbnhWQOXc0gfPYutowNp0UNN0vHE8LiqnRB+8knn9xRP5VKxb333su99957x/vu1q0b3bp1K/e+QtyKoihk7FpO/OqpGHVFt32y8axF4JNLcW7cw8LphBBCCFEVeTja8stT7Ziw4QSL918hJkNP5893s3p4K/o38bd0PCEsyiquoRWiOihIv8bV2f2JWzLGVMy6dx1D6IwTUswKIYQQ4pa0GjULH2nGx/0aoVJBTn4hA5cf5JM/LqIosliUuHtV6SO0QlgDRVHI3Pct1755FmNOGgA2bv4EjFmMS4s+Fk4nhBBCiOpCpVLx/L2h1PN24rFVR8jJL+SFLZGcS8rm80FN0WrkWJW4+8hPvRAVyJCZRMwXQ4hd8JipmHXt8BihM09JMSuEEEKIMunfxJ+IiZ2o4Va0MNTCfVd4YOF+0nLzLZxMiMonBa0QFSTz0CYuvtaYrIPrAdC4eFNz4npqPrMKjbOnhdMJIYQQojprUcONA1O60KZW0cJQOy8k035uBBeScyycTIjKJQWtEOWsMCeN2AUjiJk3iMKsJABc2gwidOYpXNsOtnA6IYQQQliLQDd7/pzQkcHNAgA4l5RDuzm7+OtiioWTCVF5pKAVohxlHfuJi681JmPvKgDUju7UeHolNSeux8bV18LphBBCCGFtHG1t+O7x1rzWvS4AqbkF9PhqL8sPXLVwMiEqhywKJUQ5KNRlkrD6f6T/tcTU5tz8QQJGL0LrEWjBZEIIIYSwdmq1ihkPNiTMx5lx645RUKgweu1RziZlM6N3A9RqlaUjCgtQFIVjx47x888/8+uvv5KYmMgrr7zCE088cUPfxMRENm7cyG+//calS5dwdnamUaNGjB8/niZNmlgg/Z2TI7RCmCn71G9ETWtqKmbV9i4EjF1Cree2SjErhBBCiEozsm0tdjzdAU9HLQAf7LzAI18fIifPYOFkwhIiIyOZOXMm/v7+vPjiixQWFmI0Gkvs+/zzz/Ptt9/yxBNPsGPHDpYvX46trS1Dhgzh999/r+TkpSMFrRBlZMzL4drXE7kyqwcFKVcAcGrUnZAZJ/DoOgaVSj4NFUIIIUTl6hrqxf4pXajv4wTAxhPx3DN/D3EZegsnE5WtcePGfPfdd4wePRo/P79b9m3bti3ff/89/fr1w83Njdq1azNr1iy8vb2ZM2dOJSUuGylohSiD3HO7ufh6c9J++wIAla0j/k98QdCL27D1rm3hdEIIIYS4m9X1dmLv5M50r+cNwOGYDMLn7OLvmAwLJxNV1eTJk3FzcyvWptVqqVWrFlevVu3rsaWgFaIUjPk64te8wKWZXShIvAiAQ1hnQt87hmf3CajU8pISQgghhOV5ONry87h2PNU+CIDYDD2dv9jN9yfjLZxMVBcpKSmcPHmS4OBgS0e5JVkUqoLpdDpLR0Cv1xf7V5RNXvRBklY8RUH8WQBUNnZ4DHwH1/uepVCtschcy9xaJ5lX6yVza71kbq2TNczrZ33q0crfgY9+v4gCPL/xb2JTQhnVtuZdfXlUdZrbiIgInnrqqTvq++GHH9KvX79yGfedd95Br9fz5JNPlsv+KooUtBVIURQiIyMtHcMkKirK0hGqp8ICbA4swubQClRKIQBGv0bk93yHXM86xJ45a+GAMrfWSubVesncWi+ZW+tU3ee1jSOs7fPv2wdmcfr0aYvlqUqqytze6sMFo9FIYWHhHe3nZos+lda8efP49ddfGTx4ML179y6XfVYUKWgrkEqlomHDhpaOgV6vJyoqipCQEOzt7S0dp1rJizlO8rKnyI89UdSg0eLRdxpu9/8PlcbyLx+ZW+sk82q9ZG6tl8ytdbK2eT2bmMWzG08Sn5UHQHiQO58NaIybvdbCySpfVZrb23240KVLF06dOnVH+9JoNGbnWbZsGZ9//jkPPPAA06dPN3t/Fc3y78itnIODg6UjmNjb21epPFWZUmggeesHJH3/LhQWAGAf1ILAcSuwD2pm4XQ3krm1TjKv1kvm1nrJ3Fona5nXFrUdWD+2IwOWHuTg1XSiTiRzJP4QW8eGU8/H2dLxLKI6zK1KpcLGpnLKtlWrVvHBBx/Qq1cvPvnkk3IpkCuarGAjxH/kxUYSPb0DSRvfKCpm1Rq8B7xBnbf2V8liVgghhBDiTgW42vPHhA483CwAgHNJObSbE8EfF5ItnExY2rp165g+fTr3338/n376aaUV0eaSglaIfyjGQpJ/+piot1qhjz4EgG1gQ+q8uQ/fQe+isrG1cEIhhBBCCPM52tqw9vHWvN6jHgBpugJ6frWPpfuvWDiZsJStW7fy5ptv0qNHj2pVzIKcciwEAHnx54lbNArdhT1FDSoVXr1fwOehd1HbVv9rZoQQQggh/k2tVjG9dwPCfJx48rvj5BcaGfvdMc4mZfP+gw1Rq+/eFZCtScuWLcnLyzN9/eGHHzJr1iwAvv/+e+rVK/pQ46uvvsJoNLJz506aN29+w36OHj2KrW3VPLgjBa24qylGI2m/zSfhu5dQ8otuu2PrV5fAcStwrNfRwumEEEIIISrW421qUcfTkYHLDpKSW8Cs3y9yLimHlY+1xMlOSoXq7tChQyiKUuK2fx+F3bx58037/bdvVSOnHIu7Vn7SJS7P6kH8ykmmYtaz52RCph+TYlYIIYQQd43OIV7sn9KFBr5FC0NtPhlPly92E5uhs3AyYS6NRoONjU2J/91pv6pczIIUtOIupCgKaX8sJur1puSe/h0ArXdtar+yE/8Rc1DbOVo4oRBCCCFE5Qr1dmLv5M70DPMG4O/YTMJnR3AkJt2ywYS4DSloxV2lIDWWq5/24dqycRj12QC43zOOkPdO4NSwm4XTCSGEEEJYjruDlh+fbMczHWoDEJepp8sXe9h84pqFkwlxc1LQiruCoiik717JxWlNyD7+MwA2HjUIev5nAscsROPgYuGEQgghhBCWp9WomT+4KbMHNEatgtz8QgatOMSsnRdueY2lEJZStU+IFqIcGDISuLb8GbKObDa1uXV8HP8Rc9A4eVgumBBCCCFEFaRSqZjSNYS63k48uvIw2XmFvPzjac4kZrPg4WbY2sgxMVF1yE+jsGqZB9Zx8bXGpmJW4+pLrSmbqfH011LMCiGEEELcQp9Gfuye2JkgDwcAlh28yv0L95GSk2/hZEL8PylohVUyZKcQM38YMV8MoTA7BQDX8CGEzjyFS6sBFk4nhBBCCFE9NAt0Zf/kzrQLcgfgz4spdJgbwbmkbMsGE+IfUtAKq5P19xaiXmtC5v5vAdA4eVJjwrfUfHYtNi7eFk4nhBBCCFG9+Lva8/uEjgxpHgjA+eQc2s+J4PcLyRZOJoQUtMKKFOZmELtoNFdn98eQEQ+Ac8v+hM48hVu7oRZOJ4QQQghRfTloNawZ0Yo3etYDIE1XwP1f7WPxvssWTibudrIolLAK2Se2Ebd0LIbUGADUjm74D5+DW6cnUKlUFk4nhBBCCFH9qdUq3n2gAfV9nBmz9hj5hUbGrTvO2aQcPujTEI1a3nOJyicFrajWCnVZJK59kbTfvzK1OTW5n8CxS9B61rRgMiGEEEII6zS8dU2CPR15aPlBkrLz+fiPi5xPymbl8FY420l5ISqXnHIsqq2cM38S9UZzUzGrsnMiYNQCgl74RYpZIYQQQogK1KmOJ/snd6GRnzMA359KoMvnu4lJ11k4mbjbSEErqh1jXi7xq6Zy+f17KUiKBsCxwT2EzjiBR7en5RRjIYQQQohKUMfLkT2TOnN/mA8AR+MyCZ+zi0NX0y0bTNxVpKAV1UruhX1EvdmS1G1zAFDZOuA3fA61X96JrU8dC6cTQgghhLi7uDlo+fHJcCZ0DAbgWmYeXb/Yzcbj1ywbTNw1pKAV1YKxII+E717h0nudyI8/B4BDaHtCph/F6/7JqNTyoyyEEEIIYQk2GjVfDG7K3IFNUKtAV2Bk8IpDfPDbeRRFsXQ8YeXkqm1R5ekuHSFu0UjyYk4CoLKxxWfQdLx6P49KrbFwOiGEEEIIATCpSx1CvR159JsjZOUZePWnM5xNyuGrh5thayMHH0TFkJ8sUWUphgISN71N9LvtTMWsfe1W1HnnMN59XpJiVgghhBCiinmwoR+7J3WitocDAMsPXqXnV3tJzs6zcDJhraSgFVWS/uoJot9tR/Lmd6DQABobfB56hzpv7sO+ZhNLxxNCCCGEEDfRNMCV/VO60L62BwB/RaXSfm4EZxOzLZxMWCMpaEWVohQaSN76AdFvt0F/+W8A7Go2oc5bB/AZ+CYqG62FEwohhBBCiNvxc7Fj5/gOPNoiEICLKbm0nxvBb+eSLJxMWBspaEWVkXftLJdmdCZx3asohnxQqfHq+yp13j6EQ+2Wlo4nhBBCCCFKwUGrYfWIVrx1fxgA6boCHli0n0X7Lls4mbAmsiiUsDjFaCR1+9yiQrZAD4BtQH0Cx63AMbSdhdMJIYQQQoiyUqlUvN2rPmE+ToxZe4w8g5Gn1h3nTGI2s/o2QqNWWTqiqOakoBUWlZ8YRdzi0eSe/auoQaXC8/6p+D48A7Wtg2XDCSGEEEKIcvFYq5oEezgycPlBkrLz+fTPKM4n5bB6RCuc7aQkEWUnpxwLi1AUhdSdC7j4ejNTMav1qUPtV/7A/7FPpZgVQgghhLAyHet4cmBKFxr7uwCwJTKBzp/v5mqazsLJRHUmBa2odAUpV7nyUS/iV4xHycsBwOO+8YS+dxynBl0tnE4IIYQQQlSUYE9H9kzqxAMNfAA4FpdJ+JxdHLySbtlgotqSglZUGkVRSN+1nIvTmpBzajsANp61CHppOwEj56O2d7ZwQiGEEEIIUdFc7bVsGRPOxE7BAMRn5dH1i92sPxZn2WCiWpKCVlSKgvRrXJ3dn7jFozHqMgFw7zKa0BkncG7cw8LphBBCCCFEZbLRqJk3qCnzHmqCWgV6g5FHvj7MzB3nURTF0vFENSJXYIsKpSgKmfvXEv/1sxTmpAJg4+ZPwJhFuLToa+F0QgghhBDCkiZ2rkNdbyeGfnOYTL2BaT+f4WxSNgsfaYadjcbS8UQ1IEdoRYUxZCYR88UQYr8cZipmXdsPI2TmSSlmhRBCCCEEAA808GXPpM4EexYtCvr1oRh6LNhHcnaehZOJ6kAKWlEhMg9v5uK0JmQdXA+AxsWbmhPXU3P8amycvSycTgghhBBCVCWN/V3YP7kLHWp7ABARnUq7uRGcTsiycDJR1UlBK8pVYU4asV89TszchyjMTATApfVDhM48hWvbwRZOJ4QQQgghqipfFzt2ju/AYy1rABCVkkuHuRHsOJdk4WSiKpOCVpSbrGM/c/G1JmTsWQmA2tGdGk+vpOakDdi4+lo4nRBCCCGEqOrstRpWDm/JO73qA5ChN/DAov18tfeSZYOJKksWhRJmK9RlkrDmedL/XGxqc27+IAGjF6H1CLRgMiGEEEIIUd2oVCrevD+MMB8nRn17lDyDkWfWn+BMYjYf92uMRq2ydERRhUhBK8ySE7mTuMWjKUi5AoDa3gW/xz7DvesYVCr5ZSOEEEIIIcrm0ZY1CPZ0ZMDSAyRm5zP7r2jOJ+WwZkRrXOyljBFF5JRjUSbGvByufTOJyx92NxWzjo3uI2TGCTzuGSvFrBBCCCGEMFv72h4cmNKFJv4uAPx4OpHOn+/mSlquhZOJqkIKWlFqued2E/VGC9J2fA6AytYR/8c/p/aL27H1rm3hdEIIIYQQwprU9nRk96RO9G5QtCbL8WuZhM+J4MCVNAsnE1WBFLTijhnz9SR8+yKXZnYhP+ECAA71OhH63jE8ezyLSi0/TkIIIYQQovy52mv5YUxbpnSpA0BCVh73fLGH747GWTiZsDQ5+VzcEV3UQWIXjSQ/7jQAKq0dvoNn4NlrKiq1xsLphBBCCCGEtbPRqJk9sAn1fZ2ZtOkkeoORod8c5lxSNtN61JNL3u5SUtCKW1IM+SRtfpfkHz8AYyEA9nXaUuOpFdgFNrRwOiGEEEIIcbcZ3zGYEE9HhnxzmEy9gTd+OcvZpGwWD2mOnY0caLnbyDmi4qb0V44R9U44yVtmFBWzGi0+D8+gzht7pJgVQgghhBAW06uBL3sndaaOpyMAKw/H0v3LvSRl51k4mahsUtCKGyiFBpJ+mEHU223Ju3IMALug5oS8fRCffq+h0siBfSGEEEIIYVmN/F3YP6UznYI9ANh9KY12cyKIjM+ycDJRmaSgFcXkxZ0menpHkja8DoUFoNbg3f91Qt46gH1Qc0vHE0IIIYQQwsTH2Y7fxndgROsaAESn5tJhXgTbziZaOJmoLFLQCgAUYyEpP39C1Jst0UcfBMA2sCF13tiL7+DpqGxsLZxQCCGEEEKIG9nZaPh6WEumP1AfgEy9gQcXH+DLPZcsG0xUCjl3VJCfcIHYRaPQnd9d1KBS4dX7BXweehe1rb1lwwkhhBBCCHEbKpWK13uGEebjzMg1f6M3GJmw4QRnE7P5pH9jNGpZAdlaSUFrZa581p+CxIvF2oyKgl1eHjF2dqj/tZy51jcE5ya9SPjuZZT8XABs/eoS+ORyHMM6VWpuIYQQQgghzDWkRSDBng70X3qQhKw85uyK5nxyDmtGtMLVXgtAQaGRv6JSOX5VR7J9Kvc1CECrkRNXqyspaK1MQeJF8uIib2hXAwX/actPuUz20a2mrz17TsL3kfdR2zlVbEghhBBCCCEqSHiQBwemdKbvkgOcuJbFT6cT6TRvN5tGtWHN0Ti+iLhEwvXVkHel4e9ix4ROwbxyX10pbKshKWjvYkpeDgBa79oEjl2KU6P7LJxICCGEEEII8wV5OLJ7YmeGrTzMj6cTORmfReOP/iC/UOG/Jx8nZOXx5i9n2X85jU2j20pRW83IbN3l3O8ZR8h7x6WYFUIIIYQQVsXF3obvx4TzXNcQAPILFQCU//S7/vWPpxP5cOeFygsoyoUUtHcxG68gAscsROPgaukoQgghhBBClDuNWsWHfRviYnf7E1NVwBe7L1FQaKz4YKLcyCnHdzGNnbOlIwghhBBCCFGhdkenkpVnuG0/BYjPymN3dCr31vWu+GCVJCkpiW3btpGYmMi9995Ly5Ytb/uYy5cvs3HjRgCmTJmCWl11j4NKQSuEEEIIIYSwWqm5/10atXz7V1Xx8fG8+OKLXL58mYYNG/LHH3/g4eFx24K2sLCQl156iaNHjwIwadKkKl3QVt1kQgghhBBCCGEmT0dthfavqmxsbJg4cSJ//PEH48aNu+PHffXVV8TExNCpU/W4jacUtEIIIYQQQgir1amOJ37OdjesbvxfKsDfxY5OdTwrI1aF8/b2pl27dqU6unrq1Cnmz5/P66+/jpubWwWmKz9S0AohhBBCCCGsllaj5tnOwTesbvxfCvBsp+C79rY9eXl5vPTSS9xzzz307t3b0nHumFxDW8F0Ol2ljmdUbvdSLd63svOJ8qXX64v9K6yDzKv1krm1XjK31knm1XpM7VCDqIQ0/opKRUXxW/dc/7priCdTOtSocu+PL126xKZNm+6ob+/evWnQoEGZxvnkk09ISEhg2bJlZXq8pUhBW4EURSEyMrJSx7S190blGXJHffX23pWeT1SMqKgoS0cQFUDm1XrJ3FovmVvrJPNqHSY2tGFiQ99b9jl39kwlpSlOpbr5CdFXrlxhwYIFd7SfkJCQMhW0+/bt4+uvv2b69On4+t76e1TVSEFbgVQqFQ0bNqzcQRv9ekOTXq8nKiqKkJAQ7O3tKzePqFAyt9ZJ5tV6ydxaL5lb6yTzap0MhUb2Rydx7nIsYbVr0K6ODzYWPM349OnTt9xep04dpkyZckf7KkvtkZ2dzauvvkp4eDiPPPJIqR9vaVLQVjAHBwdLRzCxt7evUnlE+ZG5tU4yr9ZL5tZ6ydxaJ5lX69OprhqP/BQa1fWr8nNbq1YtJkyYUGH7P3XqFHFxcbRu3ZrPPvvM1H7u3DkA5s2bR0BAAI8++miFZTCHFLRCCCGEEEIIcZeqWbNmiUeAr6+OrNVqsbW1rexYd0wKWiGEEEIIIYS4S9WoUaPEI8Dnz5/n3LlzPPPMM9jYVN2yseomE0IIIYQQQghRZp9//jkFBQXEx8cD8Ndff5GWlgbAE088gZeXlyXjlQspaIUQQgghhBDCCtna2qJWq6ldu/YNpxXfamVlgAcffJB69eqh0WgqMqLZpKAVQgghhBBCCCv01FNPlfmxPXv2pGfPnuWYpmJYbn1qIYQQQgghhBDCDFLQCiGEEEIIIYSolqSgFUIIIYQQQghRLUlBK4QQQgghhBCiWpKCVgghhBBCCCFEtSQFrRBCCCGEEEKIakkKWiGEEEIIIYQQ1ZIUtEIIIYQQQgghqiWVoiiKpUNYo8OHDwOgUqksnKSIoihVJosoXzK31knm1XrJ3FovmVvrJPNqvarK3F4vx1q3bm3hJNWTHKG9S1SFF6uoGDK31knm1XrJ3FovmVvrJPNqvWRurYMcoRVCCCGEEEIIUS3JEVohhBBCCCGEENWSFLRCCCGEEEIIIaolKWiFEEIIIYQQQlRLUtAKIYQQQgghhKiWbCwdQJS/3Nxc9Ho9Dg4OODg43LSfTqfDxsYGrVZbielEWSmKQlpaGgAeHh7FVuYzGAxkZmaW+DhnZ2dsbW0rJaO4M9nZ2eTn59/QrlarcXd3v+nj9Ho9Go1GXrNVVGFhIRkZGSVuc3Jyws7Orkx9RdWj0+mwt7e/7Qqp8pqtXoxGI/n5+djb25e4LT09vcTHOTo6lvgYYRn/fr9Uklv9rc3Ly0OlUsn7pmpGVjm2MhkZGfTr14+EhATGjBnDyy+/fEOfn3/+mdmzZ3Pt2jWMRiOtW7fmjTfeoG7duhZILO7UsmXL+OCDDwA4ePAgrq6upm0nTpzg4YcfxsnJ6YY3Tq+99hoDBgyo1Kzi1iZMmMDvv/9ebA4BvL29+fHHH2/ov2PHDj755BNiY2MxGo20bNmSadOm0aBBg8qKLO7AuXPn6NevH46Ojje8GXrhhRd45JFHytRXVA06nY4FCxawceNGsrKysLe3p0ePHkydOhVvb+9iff/44w8+/vhjLl++jKIoNG3alNdff53GjRtbKL24lSNHjjB37lwOHz6Mra0tgYGBjB8/ngcffNDU5/Lly9x///0lvmYnT57M8OHDKzu2uIns7Gy6d+9+Q7uiKGRkZFCjRg127txZbFtERASzZs0iOjoaRVFo3Lgx06ZNo1mzZpUVW5hDEVblueeeU7p166aEhYUpH3zwwQ3bt2/frtSvX1/56quvFIPBoGRmZipPP/200qFDByUxMdECicWdOHfunNK0aVPT3GZkZBTbfvz4cSUsLEzZunWrhRKK0hg/frzSo0ePO+r7xx9/KA0aNFDmzZunFBQUKFlZWcqkSZOU8PBwJS4uroKTitI4e/asEhYWpmzYsKFc+wrL0+v1ytChQ5WHHnpIOXnypKIoipKXl6esX79e+f7774v13bNnj9KwYUPl008/VfLz85Xs7Gzlf//7n9K6dWvlypUrlogvbmH79u1KkyZNlK+++krJyspSFEVRLl26pLzyyivF+l26dEkJCwtTVq9ebYmYohz89NNPSlhYmPL+++8Xaz948KDSuHFj5YMPPlDy8vKU3Nxc5ZVXXlFatGihXLx40UJpRWnINbRW5KeffmLbtm28+eabN+3z0Ucf0bx5c5566ik0Gg0uLi7MnDmTzMxMFi1aVIlpxZ0qKCjgpZde4r777qNDhw6WjiMq2ccff0z9+vWZOHEiNjY2ODs7M336dPR6PQsWLLB0PCHuCl9++SVnz55l4cKFpqOstra2DB48mP79+xfr+/HHHxMcHMzUqVPRarU4OTnxzjvvYDQamT9/viXii5vIzMzktddeY9iwYTz11FM4OzsDULt2bd5//30LpxPlbf369QA3nAHz6aef4u/vz4svvoitrS0ODg689dZb2Nra8vnnn1siqiglKWitREJCAm+//TbPPPPMTU8dvnDhApcuXeLee+8t1u7p6UmLFi3YsWNHJSQVpfX5558TFxfHG2+8cUf9b3Z9pqh6CgoKyM7ORrnJlR9Xr17l3LlzN7xm3dzcaNOmjbxmq7DSvA7lNVu1GY1G1qxZQ9mfxWYAABnLSURBVM+ePfH29sZgMJCdnV1i34SEBE6ePMk999xT7PpaZ2dn2rVrJ6/ZKmbLli1kZGQwbNgwAHJycigoKLjt47Kzs8nLy6voeKIcxcfHs2fPHtq2bUtoaKipPS0tjSNHjnDPPfegVv9/WWRvb0+HDh3YuXMnhYWFlogsSkEKWivx2muv4evry1NPPXXTPufPnwcgODj4hm3BwcHExsaSk5NTURFFGRw9epRFixbx6quv4uXlddv+L7/8Mp06daJZs2b07duXdevWVUJKURYxMTG0atWK9u3b07p1a5577jliYmKK9bndazY5OZnU1NTKiCtK4c0336RTp040bdqU3r178+233970Q4vS9BWWceHCBdLT03Fzc2P8+PG0bNmS9u3b07lzZ7788kuMRmOxvgB16tS5YT/BwcFkZmYSHx9fadnFrR06dAhHR0cOHDhAt27daN++Pc2bN+eJJ57gzJkzJT5mxowZpr+zvXr1YuXKlfKarQY2bNiA0WhkyJAhxdovXryIoig3/Tur0+lu+Nssqh4paK3AqlWr2LNnDzNmzLjlqmzXV8G9fkrNv7m4uBTrIywvNzeXl156iQ4dOjBw4MBb9rWzs2PSpEns2LGDY8eOERERQXh4OK+//rqcLlMFNW3alKVLl3Lo0CGOHj3KF198wfHjxxk6dCgJCQmmfrd6zV5vk9ds1aHVapkwYQLbtm3j2LFj7N27l65du/LWW2/x6aeflrmvsKykpCQAvvnmG9zc3Ni7dy9HjhzhmWeeYfbs2Xz00UemvtdXrr7V39mbrW4tKl9SUhI6nY5PPvmEmTNncvz4cX799Veys7MZMWJEsULGxsaGp556il9++YVjx46xf/9+evbsyfTp0+X05CpOURQ2bdqEu7s7vXr1KrZNXrPWQQraau7SpUt89NFHPP744zRv3vyWfa+f/lTSJ4nXP2H+9+kWwrI+/PBDkpKSePfdd2/bNyzs/9q796ga8/0P4O/u97Z0kSIqIUXU6GJWaCaFNVOYQ64xx2JpoVynkXHJGGYsB2eMwZmxHKfBJJEKNWgMp1IilV0NUtpokdBFkzZ1/vDbz88zXWYXM7V5v9aaP/b3+e7v97P345n25/lenr5YsGABLC0tAbzYLXf16tUYNmwYdu3a1eKjBqhjhISEwMvLCzo6OtDU1ISXlxe2bNmCBw8e4Pvvv1eqDcV1zGu287C1tUVYWBisrKwAvFjOsWLFCvj4+GDPnj1CYtTWutSxFH87TUxMEBkZKTwKbfr06Rg5ciSioqKEG0v8O6ta1NTU0NjYiDlz5sDLywtqamro2bMnvvjiC1RXVyMqKkqoa21tjaVLl6JHjx4AgC5dumDZsmXw9/dHVFQU7t6921Efg/7AhQsXIJPJEBAQ0OSRaLxm3ww8Qypu69atMDQ0xMyZM/Hw4UM8fPhQ+MNaV1eHhw8fCmuzTExMADR/p6mqqgpqamqQSCR/XfDUops3b+LHH3/E7NmzoaenJ5xbxbmsrKxUamTO29sbcrkcBQUFf3bI9IpcXFwgkUiQl5cnlCmu2eZuSCiuY0Ud6ry8vb3x/Plz5Ofnv9a69Nfo2rUrAMDR0bHJj+EhQ4ZALpcLywNau2YV/8/mNdt5KM7F4MGDReWOjo7Q09NT+pptaGjA1atX/4wQ6TWIjY0FAAQFBTU59ke/jV+uQ52XZkcHQK9GTU0NcrkcEyZMEMoUd5mOHDmCEydOYNOmTRgxYoTwzErFGp+XXb9+Hba2tnwweCdRX1+PLl26ICoqSnSHuLa2FgDwt7/9Dfb29jhw4ECr7Sg2t9DU5KXe2TU2NkIul0NDQ0MoU1yzRUVFTerfuHED1tbWwpQo6rwU1+HL5/Z11KW/hp2dHXR1dZvdLEhRpnj+d79+/aCurt7iNWtubt7kmbXUcZycnJCcnIxnz56JyhsaGvDs2bNWl3Ep8Jrt3KqqqnDq1Cm4uro2u2mqg4MDNDU1W/xtLJFIhJk01HlxhFbFbdu2DRkZGaL/jhw5AgCYOnUqMjIyMGLECABAz5494ezsjJ9++km0Y9utW7cglUpFDxCnjtW/f/8m5zUjI0N4PMSpU6dEyWxzU2WeP3+O5ORkGBgYCI+ZoI7X0uYhZ8+eRW1tLdzd3YWybt26wc3NDadOnRL94CorK8OVK1d4zXYyLU1ZS0pKgq6uLgYNGtSuutSxtLW1MWrUKOTn5zcZxUlLS4ORkZFw88nExASenp44c+aMaOfq8vJyZGZmYsyYMX9p7NS6MWPGQENDA+np6aLyzMxMyOVyuLm5CWXNXbONjY1ISkqCtrY2hgwZ8qfHS22XkJCAurq6ZkdngRdrZ729vXH27FnU1dUJ5Y8ePUJ6ejpGjx4t2rGcOicmtG+ZiIgI3L59G6tXr4ZMJsPVq1exePFi2NjY4OOPP+7o8KidwsPDsWPHDly+fBllZWXIysrCvHnzkJ+fj4iICOjr63d0iPR/8vPzMWvWLCQnJ6OoqAjFxcU4cOAAwsPD4eDggL///e+i+p9++inKy8sRERGBW7duIT8/H4sWLYKlpSXmzJnTQZ+CmvPZZ5/h66+/xqVLl1BWVoZLly5h/vz5yM7ORnh4OIyNjdtVlzrekiVLoKuri9DQUOTl5eHmzZtYv349Ll++jPDwcNFIXnh4OKqqqhAeHo6SkhIUFhZi0aJFMDMzQ0hISAd+Cvo9GxsbzJ07F//+979x4MAByGQynDt3DhEREbCzs8OMGTOEupGRkdi6dSuysrJQVlaG7OxshIWFISMjA0uXLhWmplPnEhsbC2NjY4wePbrFOsuWLUNdXR2WL1+Omzdv4tdff8XixYthZGSEBQsW/IXRUnupNXKv8TdOWVkZxo0bh2nTpiE0NLTJ8dzcXHz77bcoLCyEtrY2hg0bhoULFyr1WBjqWBs2bMCxY8dw5swZ0Y58lZWViI6Oxi+//AKZTAZdXV04Oztj2rRpojvM1DlkZWXh4MGDKCgoQHV1NaysrDBixAjMnDkTBgYGTepLpVLs2LED+fn50NLSgqenJ0JDQ2Fubt4B0VNLqqurcejQIfz8888oLS2Frq4uBgwYgKlTp4pG3ttalzqHO3fu4JtvvsHFixdRX18PBwcHzJw5E8OHD29St7CwEDt27MDVq1ehoaEBd3d3hIWFoVu3bh0QOf2Ro0eP4tChQ5DJZDA2Nsbw4cMREhIi2lekpqYGhw8fxpkzZ1BaWgptbW04OjpiypQp8PLy6sDoqSU3b97E1KlTMWHCBHzyySet1r1x4wa2b9+O3NxcqKurY+jQoVi4cCGsra3/omjpVTChJSIiIiIiIpXEKcdERERERESkkpjQEhERERERkUpiQktEREREREQqiQktERERERERqSQmtERERERERKSSmNASERERERGRSmJCS0RERERERCqJCS0RERERERGpJCa0REREREREpJI0OzoAIiJSDUVFRcjMzISfnx9MTU1bLKO3V0lJCdLT04XXHh4esLOzAwDcu3cPKSkp8PLyQu/evTsowpZVVVXh+PHjwut+/frB1dW1AyMiIiJlMKElInoDyGQy/Pe//xVea2pqwsDAAJaWlujfvz/09fVfuY/Lly9j7dq1cHR0FJLX5sro7ZWTk4O1a9cKrzdu3CgktEVFRVi7di02bdrUKRPa8vJyUezBwcFMaImIVAATWiKiN4BUKhX9GH+ZlpYW3nvvPSxevBi2travtV87OzsEBQUxmSURHx8fWFhYvPZ/b38miUSCoKAgyOVyHDlypKPDISIiJTGhJSJ6gwwePBj9+vUDADx58gQymQxSqRTJyck4d+4cvv/+e7zzzjuvrT83Nze4ubm9tvbozRAcHIxhw4Z1dBhtYmZmhnXr1qGqqooJLRGRCmFCS0T0BvHz88Ps2bNFZeXl5Vi/fj2SkpKwdOlSnDp1Ctra2qI69fX1uHTpEu7evQtDQ0MMHToUXbt2/cP+fr+GViqVIjc3F6NGjYKZmVmT+qdPn0ZlZSU++uijNvdfWFiI7OxsjB07FgYGBsjMzMSdO3dgYWGBu3fvwtfXF+bm5s32WVVVhQkTJrT6WV5uX09PD+np6aioqICDgwMGDhyoVCzvvvsurKysALxYM5qdnY0nT56gZ8+ecHNzg4aGRpN+79y5g4KCAtTU1MDGxgbOzs5Nzs8f1YmJiUGPHj3g5eUlel9paSlSU1MxcuRIdO/eHQCQmJgIXV1d+Pr6ory8HBcvXoRcLkdgYCAAoKGhAXl5eSguLoampiZcXFzQs2fPVr+7tmpsbERWVhZkMhmsrKwwdOjQZr+b+/fvo6CgABUVFbC2toarqyu0tLREdX6/NjcnJwc3btxA//794eTkpHQ7RESkmpjQEhG94czNzbFlyxaUlZUhJycHZ86cwZgxY4Tjv/zyC1auXIny8nKhTEdHB8uWLUNwcHCrbf9+De3Tp0+xdu1aPHz4EPPnzxfVrampwdKlS+Ht7S1KaJXtPzU1FZs2bYKVlRW++uorFBUVAQAiIiKwYcMG3L9/H2FhYaI+Hz9+jMWLF8Pf3/8PE1pF+5aWlti4cSNu3bolHBs1ahS2bNkiJJEtxbJz506YmZlh48aNiI6OxvPnz4U27O3t8c033whrSgFg/fr12L9/PxoaGoQya2trfPnll3B3d1e6zrp16+Dv798koc3Ly8PatWvx3XffCQntP//5T5iZmeHRo0eIjIyEXC6HhYUFAgMDce3aNSxZsgTXr18X2lBTU8PUqVOxcuXKZpPOtqqtrUVwcDAyMzOFMicnJ+zevVu4IfHkyROsWLECp0+fFn2HvXr1ws6dO2Fvby+UKdbmRkZG4vPPPxfWkoeGhqJ3795Kt0NERKqJCS0R0VtAQ0MDkydPRk5ODi5fviwktLm5uZg/fz7kcjmGDBmCXr16obKyEmlpafjiiy/Qq1cvjBgxQul+XF1d0bt3b8THxzdJaE+ePIm6ujqMGzdOKGtP/2vWrEFdXR38/PxgYmICDw8PuLi4IDY2FgsWLBAlXXFxcaivr8fkyZOV/gyRkZGoq6uDv78/6uvrkZGRgVOnTmHz5s2IiIhoNRYrKyusX78e0dHRMDQ0hIeHB4yNjXHt2jVIpVKEhIQgISEB2traSE9PR1RUFPT19eHp6YkuXbqgtLQUubm5uHLlCtzd3ZWq0x4ymQyRkZHo06cPHB0d0bVrVzx48ACzZs0SRqX79+8vfP79+/fD0tISc+fObVd/L9u9ezcePXoEHx8f6Ojo4OLFi5BKpViyZAmioqIAANXV1UhOToaNjQ369u0LPT09FBYW4vr16wgNDUViYiLU1NRE7e7atQuPHj3CiBEjYGlpCScnp3a1Q0REqoUJLRHRW0IxGvXgwQOhbPv27VBTU8O+ffvg6ekplJeWlmLixInYu3dvmxJaAAgICMDXX3+NK1euYPDgwUL5sWPHYGJiImqvPf0bGRnh6NGjMDExEcomT56MFStW4Ny5c/Dx8RHKDx8+jL59+7Zp3bChoaGofUUs0dHRCA0NhaGhYYux3L59GzExMXBzc8O//vUvUd3vvvsOmzdvRkpKCkaPHi2MAO/evVuUmJaVleHevXsAoFSd9igvL8fChQuxYMECoWzLli2oqKjAmjVrMHXqVKG8pqYG06ZNw969ezFnzpxXTgCrq6tx9OhRYaS6srISM2fORGZmJvLy8jBw4EAYGBhg165donOpiHH37t24fPlyk7XbNTU1iIuLE21EVV1d3eZ2iIhItTChJSJ6S6irqwOAMPXy+fPnyMjIgJWVFYqLi1FcXCyqb21tjdzc3Db3M27cOGzfvh1xcXFCQnv79m1kZWVh2rRpwtrF9vY/d+5cUTILAGPHjsWXX36JmJgYIXnJzs7G9evXsXr16jbF//v2bWxsMGXKFOzcuRNSqRQeHh4t1k1PT0dDQwPs7OyQkJAgalcxcpybm4vRo0fjnXfegZaWFs6fPw8HBwehne7duwvTg5Wp0x4SiQTz5s0TlaWmpkJPTw9qamo4ePCg6Ji1tTUKCwtx+/btV15PO2nSJNG0a4lEgpCQEISGhuLSpUsYOHAgjIyM4OPjg5KSEhQUFKC6uhrPnz8XvsPCwsImieikSZOa7KrcnnaIiEi1MKElInpLyGQyABA2W6qursbTp09RUlLS4iN/AIgSAGVYW1tj6NChOHnyJCIiIqCtrY1jx46hsbFRNN24vf2/nAwp6OrqYvz48fjhhx9w//59WFhY4NChQ9DX1xc2O1JWc89IVZQ9fvxYVP77WCoqKgC82KQpJiam2farq6sBAH369MGePXuwc+dOeHt7w8rKCm5ubvjwww+FHYKVqdMeNjY20NQU/wSoqKjAb7/91uq5qKqqanefCs09yqdXr14A/v/7raysxOLFi5GamtpsGzU1NU3Kmvt30Z52iIhItTChJSJ6SyhGDAcNGgQA0NfXh5qaGnr06NFqctSeKabjx4/HihUrcPbsWfj5+SE+Ph729vai3YLb239Lu9NOnjwZ+/btw5EjRzB9+nQkJSXhww8/FE37Vcb9+/dbLDMwMGg1FsVxxXNYm/PyiKCHhwc8PDxQX1+Pa9euIS0tDfPmzcPs2bOFDa6UqaOtrY2nT5826evljbZai1sRu5GREcaOHdvsewA0GRlvj+a+X0Wciu9v27ZtSE1NhbW1NZydnWFkZAQNDQ08efIEiYmJog2eFJr7TO1ph4iIVAsTWiKiN1xDQwN27tyJlJQUGBsbY9SoUQBeJEFOTk4oKyvD/Pnz0a1bN9H7nj17huLiYmGqclv4+/vj888/R1xcHMzNzVFSUoKlS5eK6rzu/m1tbeHp6YnDhw9DIpGgtra2TZtBKfzwww/w8fERRoVra2sRExMDdXV1ODo6tvreIUOGAABMTU2xbt26Jsfv3bsnJF43b96ElZUVdHV1oa2tDWdnZzg7OyM9PR0HDhxAWFiYUnWAF1OQc3NzUV9fL+zEXF9f36bnqQ4ZMgSxsbH46KOP4OLi0uR4QUGB8EiiVxEbG4tZs2YJNxoaGhrwn//8BwDg7OwMAMjJyYGFhQV++ukn0Ujyjz/+iMTERKX7el3tEBFR58WElojoDZKTk4ODBw+isbERv/32G0pLS3H+/HncuXMHALBq1SoYGRkJ9UNCQjB//nwEBATAz89PmPpZWlqKs2fPwt3dHZs3b25zHAYGBvD19cXJkyehpaUFdXX1Zqf+vu7+J0+ejLCwMGzduhUuLi4YMGBAm2PPzc3FpEmT4OvrC7lcjoSEBJSWlmL06NEwNTVt9b3Ozs7w9vbG4cOHUVBQAG9vb5iamqKiogLXrl3DuXPnsG/fPnTt2hVHjhxBTEwM3nvvPdja2kJbWxu5ublIS0sT1scqUwcA3N3dsX//fkyfPh1+fn6ora3F8ePHhSnQyvj444+RkJCAGTNm4P3330f//v2ho6OD27dv48KFCwDwWpLAyspKBAQEIDAwELq6ukhJScGVK1dgZ2cnrE/u0aMHpFIpli9fDhcXF8jlcuTl5SEjI6NNfb2udoiIqPNiQktE9AZJTk5GcnJyk3LF8zhHjhwpKvf19cWqVavw1Vdf4dChQ6JjWlpa6Nu3b7tjGT9+POLj45GUlIRhw4Y1GYH9M/r39fWFubk5ysvLMWXKlHbF/emnn2Ljxo3Ytm2bUNanTx+lN5f6xz/+gUWLFiEtLQ1SqVR0zNLSUkiK7e3t8fTp0yajqHp6evjss8+UrgO82Jzq5MmTyMnJQU5ODoAX53zhwoXYsGGDUnHb29tj+/btWL58OU6cOIETJ06IjgcEBCjVzh+ZN28eDh48iG+//VYoMzExwZYtW4TR+Hnz5uH8+fOiOAwMDLBmzRp88sknberrdbRDRESdFxNaIqI3gI2NDYKCgoTXmpqa0NfXR/fu3TFw4EBh3WxzFKN6p0+fRklJCXR0dGBjY4ORI0fC3NxcqGdnZ4egoCDRKGVzZQqenp6YMWMG6uvrhefevkr/jo6OCAoKgkQiabEtTU1NuLi4ICsrq9W1oK0ZPHgw4uPjkZiYiIcPH6Jv374ICAiAjo6OUrFIJBLs3bsXWVlZuHDhAh4/fgxzc3P069cP3t7ewlTm8ePH4/3330dKSgqKiorQ2NiInj17wt/fH126dFG6DvAiUY6Pj0dcXBzu3bsHW1tbBAYGori4GEFBQaKpwh988EGL64qHDx+OM2fO4PTp0/j1118BvBjl9PLyanbTpZb8/PPPuHXrFjw8PIT3devWDUFBQfD09MTEiRMRHx8PmUwGa2trBAYGCpuVAcCAAQOQlJSE48ePo6ysDN26dcMHH3wAHR0dBAUFwcnJSairaLe5zaba0k5VVRWOHz/e7FpkIiLqvNQaGxsbOzoIIiKi1+Hu3bvw9/fHpEmTsGrVqja9d8+ePdi0aRMSEhJeaWT6bXbs2DHRyOfGjRsxYcKEDoxIeUVFRaKbIMHBwVi5cmUHRkRERMrgCC0REam81NRUXL9+HbGxsaivr1eZJOpNY2trK5op0NyoaWclkUhEsbu6unZgNEREpCwmtEREpPKio6OFtcP+/v6iqaT01xk0aFCr09s7MzMzs2Z3piYios6NCS0REam8d999F6ampnBwcMDEiRPb1YYya3SJiIioc+EaWiIiIiIiIlJJyj2tnoiIiIiIiKiTYUJLREREREREKokJLREREREREakkJrRERERERESkkpjQEhERERERkUpiQktEREREREQqiQktERERERERqSQmtERERERERKSSmNASERERERGRSmJCS0RERERERCqJCS0RERERERGppP8B9gt4phHi5P8AAAAASUVORK5CYII="
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "\n",
+    "figure, left_axis = plt.subplots()\n",
+    "right_axis = left_axis.twinx()\n",
+    "\n",
+    "left_axis.plot(\n",
+    "    conditioning_results[\"delivery pressure [bara]\"],\n",
+    "    conditioning_results[\"liquid product [kg/hr]\"],\n",
+    "    marker=\"o\",\n",
+    "    color=\"#0072B2\",\n",
+    "    label=\"Condensed liquid\",\n",
+    ")\n",
+    "right_axis.plot(\n",
+    "    conditioning_results[\"delivery pressure [bara]\"],\n",
+    "    conditioning_results[\"valve outlet temperature [degC]\"],\n",
+    "    marker=\"s\",\n",
+    "    color=\"#D55E00\",\n",
+    "    label=\"Valve outlet temperature\",\n",
+    ")\n",
+    "\n",
+    "left_axis.set_title(\"Rich-gas conditioning sensitivity to delivery pressure\")\n",
+    "left_axis.set_xlabel(\"Delivery pressure [bara]\")\n",
+    "left_axis.set_ylabel(\"Condensed liquid [kg/hr]\", color=\"#0072B2\")\n",
+    "right_axis.set_ylabel(\"Valve outlet temperature [degC]\", color=\"#D55E00\")\n",
+    "\n",
+    "lines = left_axis.get_lines() + right_axis.get_lines()\n",
+    "labels = [line.get_label() for line in lines]\n",
+    "left_axis.legend(lines, labels, loc=\"center right\")\n",
+    "figure.tight_layout()\n",
+    "display(figure)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "validation-limitations-references",
+   "metadata": {},
+   "source": [
+    "\n",
+    "Lower delivery pressure produces more Joule-Thomson cooling and more liquid dropout for this\n",
+    "rich-gas composition. That is the engineering conclusion of the final sensitivity figure; the\n",
+    "absolute values depend on the selected equation of state, feed characterization, heat transfer,\n",
+    "and equilibrium assumptions.\n",
+    "\n",
+    "## Validation summary, limitations, and next steps\n",
+    "\n",
+    "- All five original integrations remain represented and executable in sequence.\n",
+    "- NeqSim owns process state and connectivity; every external result records its units and scope.\n",
+    "- Assertions require finite positive properties, plausible combustion results, monotonic orifice\n",
+    "  response, exact scenario execution, and relative process mass closure below $10^{-10}$.\n",
+    "- The carbonate model is an ideal screening substitute, not a replacement for a validated\n",
+    "  Reaktoro database and activity model.\n",
+    "- CoolProp and ThermoPack comparisons are model cross-checks, not calibration targets.\n",
+    "- The Cantera flame is one-dimensional, adiabatic, freely propagating, and based on GRI-Mech 3.0;\n",
+    "  it does not represent burner geometry, heat loss, turbulence, or flame stabilization.\n",
+    "- The orifice example is a calculation pattern. Final design requires the applicable standard,\n",
+    "  tapping arrangement, uncertainty analysis, and operating-envelope checks.\n",
+    "\n",
+    "Practical exercises:\n",
+    "\n",
+    "1. Replace SRK with PR and quantify changes in liquid recovery and cross-library density.\n",
+    "2. Vary carbonate alkalinity and calcium concentration, then map the calcite saturation index.\n",
+    "3. Change the Cantera equivalence ratio and compare flame speed, peak temperature, and grid size.\n",
+    "4. Add a compressor or heat exchanger to the final flowsheet and close its energy balance.\n",
+    "\n",
+    "Current references:\n",
+    "\n",
+    "- [NeqSim Python examples and process simulation](https://equinor.github.io/neqsimhome/)\n",
+    "- [CoolProp high-level API](https://coolprop.org/coolprop/HighLevelAPI.html)\n",
+    "- [ThermoPack Python documentation](https://thermotools.github.io/thermopack/vcurrent/)\n",
+    "- [Cantera one-dimensional flame documentation](https://cantera.org/stable/python/onedim.html)\n",
+    "- [`fluids` flow-meter documentation](https://fluids.readthedocs.io/fluids.flow_meter.html)\n",
+    "- [Reaktoro documentation](https://reaktoro.org/)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "include_colab_link": true,
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }


### PR DESCRIPTION
## Summary

Modernizes `notebooks/process/neqsimreaktoro.ipynb` as a current, executable tutorial for connecting NeqSim process objects to focused third-party Python calculations.

- preserves all 31 original cells, 21 original code cells, five substantive integration examples, and the embedded Cantera illustration
- replaces NeqSim 2.5.35, deprecated gateway paths, and the runtime-replacing Conda/Reaktoro setup
- repairs CoolProp, ThermoPack, Cantera, and `fluids` integrations with current APIs and explicit units
- fixes the orifice state-wiring defect and uses the mass-flow-driven ISO 5167 meter solver
- adds a substantial rich-gas `Stream`–`Cooler`–`ThrottlingValve`–`Separator` application
- updates `notebooks/notebook_maintenance_ledger.json`

## Validation

Fresh verified public-PyPI environment:

- NeqSim 3.16.0
- Python 3.12.13
- OpenJDK 17.0.19
- resolution: `online-new-snapshot`
- 71 wheels verified by inventory, size, and SHA-256

Notebook gates:

- 41 cells: 26 code, 15 Markdown
- 26/26 code cells executed in order from cleared outputs
- zero exceptions, error outputs, or stderr
- maximum code-line length: 93 characters
- four display equations and 12 inline expressions passed source, HTML/MathJax, and visual checks
- one original visual preserved and five technical figures added; all six visually inspected
- all three rich-gas scenarios closed total mass exactly
- no NeqSim library defect found

## Representative results

- carbonate screening pH: 5.69453
- Cantera flame speed: 0.6217 m/s; maximum temperature: 2292.7353 K
- 3000 kg/h methane orifice differential pressure: 0.30083 bara
- rich-gas liquid recovery: 10.8352 wt% at 40 bara to 3.8033 wt% at 70 bara

## Documentation impact

The notebook becomes the current user-facing guide for third-party model boundaries and Python-defined NeqSim unit operations. No NeqSim public API, default, or library implementation changes.

Draft only. Do not merge or enable auto-merge.