### PR TITLE
Fix notebook ledger count after field-development merges

### DIFF
--- a/notebooks/notebook_maintenance_ledger.json
+++ b/notebooks/notebook_maintenance_ledger.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 3,
-  "updated_at": "2026-08-05T07:25:00Z",
-  "active_notebook_count": 253,
+  "updated_at": "2026-08-05T07:58:00Z",
+  "active_notebook_count": 255,
   "shards_glob": "maintenance_ledger/*.json",
   "retired_notebooks": [
     {


### PR DESCRIPTION
The Earth-tools and metocean PRs merged concurrently and both introduced a ledger shard, but the shared index retained the single-PR count of 253. This focused integration fix updates `active_notebook_count` to 255 so it matches the 255 loaded shard entries. No notebook content or validation evidence changes.