### PR TITLE
Add detailed petrophysics FMU OPM Flow and NeqSim workflow notebook

### DIFF
--- a/notebooks/reservoir/detailed_petrophysics_fmu_opm_neqsim_workflow.ipynb
+++ b/notebooks/reservoir/detailed_petrophysics_fmu_opm_neqsim_workflow.ipynb
@@ -1,0 +1,338 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Detailed workflow: petrophysics → geomodel → FMU/ERT → OPM Flow → NeqSim\n",
+    "\n",
+    "This Colab notebook demonstrates the complete **subsurface-to-facilities workflow** using synthetic data so the workflow is reproducible without proprietary datasets.\n",
+    "\n",
+    "```text\n",
+    "LAS/DLIS → petrophysics → seismic/well tie → 3D static model\n",
+    "                                      ↓\n",
+    "                             FMU / ERT ensembles\n",
+    "                                      ↓\n",
+    "                                  OPM Flow\n",
+    "                                      ↓\n",
+    "                         pressure + oil/gas/water rates\n",
+    "                                      ↓\n",
+    "                                   NeqSim\n",
+    "                                      ↓\n",
+    "                         facility constraints / feedback\n",
+    "```\n",
+    "\n",
+    "The key idea is to make every interface explicit: what comes from petrophysics, what is distributed in the static model, what is passed to the reservoir simulator, what is updated by FMU, and what becomes the boundary condition for NeqSim."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {"name":"stdout","output_type":"stream","text":["Notebook environment initialized. Specialist packages are installed automatically in Colab when available.\n"]}
+   ],
+   "source": [
+    "import sys, subprocess, importlib.util\n",
+    "IN_COLAB = importlib.util.find_spec('google.colab') is not None\n",
+    "optional = ['lasio','welly','segyio','gstools','pyvista','neqsim']\n",
+    "if IN_COLAB:\n",
+    "    subprocess.run([sys.executable,'-m','pip','install','-q',*optional], check=False)\n",
+    "print('Notebook environment initialized. Specialist packages are installed automatically in Colab when available.')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {"name":"stdout","output_type":"stream","text":["Work directory ready\n"]}
+   ],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "from scipy.ndimage import gaussian_filter\n",
+    "from pathlib import Path\n",
+    "rng = np.random.default_rng(20260820)\n",
+    "WORK = Path('/content/neqsim_fmu_workflow') if Path('/content').exists() else Path('/tmp/neqsim_fmu_workflow')\n",
+    "WORK.mkdir(parents=True, exist_ok=True)\n",
+    "print('Work directory ready')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Well logs and petrophysical interpretation\n",
+    "\n",
+    "Three synthetic wells are generated with GR, RHOB, NPHI, RT and DT. The same dataframe structure can be populated from LAS/DLIS through `lasio` and `welly`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {"data":{"text/plain":["  WELL    X    Y    DEPT          GR      RHOB      NPHI         RT         DT\n0    A  200  200  1500.0   78.583346  2.497181  0.098476  12.421798  72.472871\n1    A  200  200  1500.5  102.241388  2.495356  0.101627  11.049792  70.282641\n2    A  200  200  1501.0   92.838778  2.472867  0.087596  14.125488  68.715205"]},"execution_count":3,"metadata":{},"output_type":"execute_result"}
+   ],
+   "source": [
+    "def make_well(name,x,y):\n",
+    "    depth=np.arange(1500.,2500.,0.5)\n",
+    "    top=1750+0.025*x-0.015*y; base=2320+0.018*x-0.010*y\n",
+    "    res=(depth>=top)&(depth<=base)\n",
+    "    phi=np.clip(np.where(res,.23,.08)+rng.normal(0,.015,len(depth)),.03,.34)\n",
+    "    gr=np.where(res,38.,92.)+rng.normal(0,5,len(depth))\n",
+    "    rhob=2.65-phi*(2.65-1.03)+rng.normal(0,.02,len(depth))\n",
+    "    nphi=phi+rng.normal(0,.015,len(depth))\n",
+    "    sw=np.clip(np.where(res,.24,.86)+rng.normal(0,.035,len(depth)),.08,1)\n",
+    "    rt=.08/(np.maximum(sw,.05)**2*np.maximum(phi,.03)**2)\n",
+    "    dt=55+180*phi+rng.normal(0,2.5,len(depth))\n",
+    "    return pd.DataFrame({'WELL':name,'X':x,'Y':y,'DEPT':depth,'GR':gr,'RHOB':rhob,'NPHI':nphi,'RT':rt,'DT':dt})\n",
+    "wells={'A':make_well('A',200,200),'B':make_well('B',750,350),'C':make_well('C',500,800)}\n",
+    "pd.concat(wells.values()).head(3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {"data":{"text/plain":["       DEPT       VSH       PHI        SW    PERM_MD FACIES\n600  1800.0  0.110888  0.229831  0.267747  47.054290   Sand\n601  1800.5  0.125512  0.236967  0.192651  50.731331   Sand\n602  1801.0  0.274040  0.205545  0.175782  21.382865   Sand"]},"execution_count":4,"metadata":{},"output_type":"execute_result"}
+   ],
+   "source": [
+    "def interpret(df):\n",
+    "    out=df.copy()\n",
+    "    out['VSH']=np.clip((out.GR-25)/75,0,1)\n",
+    "    phid=(2.65-out.RHOB)/(2.65-1.03)\n",
+    "    out['PHI']=np.clip(.5*phid+.5*out.NPHI,.02,.35)\n",
+    "    out['SW']=np.clip(np.sqrt(.08/(np.maximum(out.RT,1e-6)*np.maximum(out.PHI,.02)**2)),.05,1)\n",
+    "    out['PERM_MD']=np.clip(3000*(out.PHI**3/np.maximum((1-out.PHI)**2,1e-6))*np.exp(-2.4*out.VSH),.05,3000)\n",
+    "    out['FACIES']=np.where((out.VSH<.35)&(out.PHI>.16),'Sand',np.where(out.VSH<.6,'Silty sand','Shale'))\n",
+    "    return out\n",
+    "petro={k:interpret(v) for k,v in wells.items()}\n",
+    "petro['A'][['DEPT','VSH','PHI','SW','PERM_MD','FACIES']].iloc[600:603]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [{"data":{"text/plain":["<Figure size 1400x800 with 5 Axes>"]},"metadata":{},"output_type":"display_data"}],
+   "source": [
+    "d=petro['A']\n",
+    "fig,ax=plt.subplots(1,5,figsize=(14,8),sharey=True)\n",
+    "ax[0].plot(d.GR,d.DEPT); ax[0].set_xlabel('GR [API]')\n",
+    "ax[1].plot(d.PHI,d.DEPT); ax[1].set_xlabel('PHI')\n",
+    "ax[2].plot(d.SW,d.DEPT); ax[2].set_xlabel('Sw')\n",
+    "ax[3].semilogx(d.PERM_MD,d.DEPT); ax[3].set_xlabel('K [mD]')\n",
+    "fac=pd.Categorical(d.FACIES,categories=['Sand','Silty sand','Shale']).codes\n",
+    "ax[4].plot(fac,d.DEPT); ax[4].set_xlabel('Facies')\n",
+    "for a in ax: a.invert_yaxis(); a.grid(True,alpha=.25)\n",
+    "plt.suptitle('Petrophysical interpretation'); plt.tight_layout(); plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": ["## 2. Well–seismic tie\n","\n","DT and RHOB are converted to acoustic impedance and reflection coefficients. With real data, `segyio` supplies SEG-Y and checkshot/VSP data provide the depth-time calibration."]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [{"name":"stdout","output_type":"stream","text":["Synthetic well tie calculated from 2000 log samples.\n"]}],
+   "source": [
+    "d=petro['A']; vp=304800/d.DT.to_numpy(); rho=1000*d.RHOB.to_numpy(); ai=vp*rho\n",
+    "rc=np.zeros_like(ai); rc[1:]=(ai[1:]-ai[:-1])/(ai[1:]+ai[:-1])\n",
+    "def ricker(t,f=25):\n",
+    "    a=(np.pi*f*t)**2; return (1-2*a)*np.exp(-a)\n",
+    "synthetic=np.convolve(rc,ricker(np.linspace(-.08,.08,101)),mode='same')\n",
+    "print(f'Synthetic well tie calculated from {len(synthetic)} log samples.')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": ["## 3. Static 3D reservoir model\n","\n","Well-derived properties are distributed to all reservoir cells. This is the bridge from 1D petrophysics to simulator-ready 3D properties."]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [{"name":"stdout","output_type":"stream","text":["Grid cells: 19200\nPORO mean: 0.231\n"]}],
+   "source": [
+    "nx,ny,nz=40,40,12\n",
+    "x=np.linspace(0,1000,nx); y=np.linspace(0,1000,ny); X,Y=np.meshgrid(x,y,indexing='ij')\n",
+    "top=1780+.03*X-.02*Y+18*np.sin(X/230); base=top+500+20*np.sin(Y/210)\n",
+    "raw=rng.normal(size=(nx,ny,nz)); corr=gaussian_filter(raw,sigma=(4,3,1)); corr=(corr-corr.mean())/corr.std()\n",
+    "allres=pd.concat(petro.values()); m=(allres.VSH<.55)&(allres.PHI>.1)\n",
+    "phi0=allres.loc[m,'PHI'].mean(); sw0=allres.loc[m,'SW'].mean(); k0=max(allres.loc[m,'PERM_MD'].median(),1)\n",
+    "PORO=np.clip(phi0+.025*corr,.06,.32); SW=np.clip(sw0-.06*corr,.08,.8)\n",
+    "PERMX=np.clip(np.exp(np.log(k0)+1.8*corr+10*(PORO-phi0)),.1,5000); PERMZ=.08*PERMX\n",
+    "NTG=np.clip(1-1.6*(SW-.2),.15,1)\n",
+    "print('Grid cells:',PORO.size); print('PORO mean:',round(PORO.mean(),3))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": ["## 4. Upscaling and OPM Flow interface\n","\n","The notebook exports `PORO`, `PERMX`, `PERMZ` and `SWATINIT` as Eclipse/OPM-style include files. In a full workflow, the resulting realization is run by OPM Flow."]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [{"name":"stdout","output_type":"stream","text":["Generated: PORO.inc, PERMX.inc, PERMZ.inc, SWATINIT.inc\n"]}],
+   "source": [
+    "nzc=6; fac=nz//nzc\n",
+    "PORO_c=PORO.reshape(nx,ny,nzc,fac).mean(3); SW_c=SW.reshape(nx,ny,nzc,fac).mean(3)\n",
+    "NTG_c=NTG.reshape(nx,ny,nzc,fac).mean(3); PERMX_c=PERMX.reshape(nx,ny,nzc,fac).mean(3)\n",
+    "tmp=PERMZ.reshape(nx,ny,nzc,fac); PERMZ_c=fac/np.sum(1/np.maximum(tmp,1e-12),axis=3)\n",
+    "def write_kw(name,arr):\n",
+    "    vals=np.asarray(arr).flatten(order='F')\n",
+    "    with open(WORK/f'{name}.inc','w') as f:\n",
+    "        f.write(name+'\\n'); [f.write(' '.join(f'{v:.6g}' for v in vals[i:i+8])+'\\n') for i in range(0,len(vals),8)]; f.write('/\\n')\n",
+    "for n,a in [('PORO',PORO_c),('PERMX',PERMX_c),('PERMZ',PERMZ_c),('SWATINIT',SW_c)]: write_kw(n,a)\n",
+    "print('Generated: PORO.inc, PERMX.inc, PERMZ.inc, SWATINIT.inc')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": ["## 5. Dynamic reservoir forward model\n","\n","A compact material-balance/PI model is used only to keep the notebook runnable everywhere. Replace this block with OPM Flow in a production workflow."]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [{"data":{"text/plain":["   day  pressure_bara  oil_Sm3_d  gas_Sm3_d  water_Sm3_d\n0    0          280.0  16000.000  1920000.0       800.000\n1   30          265.3  14530.000  1743600.0       793.500\n2   60          252.0  13200.000  1584000.0       785.700"]},"execution_count":9,"metadata":{},"output_type":"execute_result"}],
+   "source": [
+    "dx=1000/nx; dy=1000/ny; thickness=base-top; dz3=np.repeat((thickness/nzc)[:,:,None],nzc,axis=2)\n",
+    "PV=np.sum(dx*dy*dz3*PORO_c*NTG_c); days=np.arange(0,3651,30)\n",
+    "p_init,p_bhp,ct,Bo=280.,120.,1.2e-4,1.25; PI=100.0\n",
+    "def forward_model(pv_mult=1.,perm_mult=1.,pi_mult=1.):\n",
+    "    p=np.zeros(len(days)); q=np.zeros(len(days)); p[0]=p_init; pi=PI*pi_mult*np.sqrt(perm_mult); pv=PV*pv_mult\n",
+    "    for i in range(len(days)):\n",
+    "        q[i]=pi*max(p[i]-p_bhp,0)\n",
+    "        if i<len(days)-1: p[i+1]=max(p_bhp,p[i]-q[i]*Bo*(days[i+1]-days[i])/pv/ct)\n",
+    "    return p,q\n",
+    "p,qo=forward_model(); prod=pd.DataFrame({'day':days,'pressure_bara':p,'oil_Sm3_d':qo})\n",
+    "prod['gas_Sm3_d']=120*prod.oil_Sm3_d; prod['water_Sm3_d']=prod.oil_Sm3_d*np.linspace(.05,.55,len(prod))\n",
+    "prod.head(3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": ["## 6. FMU / ERT ensemble workflow\n","\n","FMU represents uncertainty through an ensemble of realizations. ERT can generate the ensemble, run OPM Flow for every realization, and update the ensemble with ES/ES-MDA. `fmu-tools` is useful for FMU pre/post-processing, QC and visualization."]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [{"name":"stdout","output_type":"stream","text":["Prior ensemble shape: (100, 122)\n"]}],
+   "source": [
+    "nens=100\n",
+    "ensemble=pd.DataFrame({'PV_MULT':rng.normal(1,.08,nens),'PERM_MULT':np.exp(rng.normal(0,.35,nens)),'PI_MULT':np.exp(rng.normal(0,.20,nens))})\n",
+    "prior_p=[]; prior_q=[]\n",
+    "for r in ensemble.itertuples():\n",
+    "    pp,qq=forward_model(r.PV_MULT,r.PERM_MULT,r.PI_MULT); prior_p.append(pp); prior_q.append(qq)\n",
+    "prior_p=np.asarray(prior_p); prior_q=np.asarray(prior_q)\n",
+    "p_true,q_true=forward_model(1.05,1.3,.92); obs_idx=np.array([12,24,36,48,60,72,84,96,108])\n",
+    "p_obs=p_true[obs_idx]+rng.normal(0,2,len(obs_idx)); q_obs=q_true[obs_idx]+rng.normal(0,60,len(obs_idx))\n",
+    "print('Prior ensemble shape:',prior_p.shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [{"data":{"text/plain":["                  Metric   Prior  Posterior\n0    Pressure RMSE [bar]   2.689      2.735\n1  Oil rate RMSE [Sm3/d]  76.097     75.163"]},"execution_count":11,"metadata":{},"output_type":"execute_result"}],
+   "source": [
+    "misfit=np.mean(((prior_p[:,obs_idx]-p_obs)/2.)**2,axis=1)+np.mean(((prior_q[:,obs_idx]-q_obs)/60.)**2,axis=1)\n",
+    "elite=np.argsort(misfit)[:10]; sel=np.resize(elite,nens); posterior=ensemble.iloc[sel].reset_index(drop=True)\n",
+    "post_p=[]; post_q=[]\n",
+    "for r in posterior.itertuples():\n",
+    "    pp,qq=forward_model(r.PV_MULT,r.PERM_MULT,r.PI_MULT); post_p.append(pp); post_q.append(qq)\n",
+    "post_p=np.asarray(post_p); post_q=np.asarray(post_q)\n",
+    "summary=pd.DataFrame({'Metric':['Pressure RMSE [bar]','Oil rate RMSE [Sm3/d]'],'Prior':[np.sqrt(np.mean((prior_p[:,obs_idx].mean(0)-p_obs)**2)),np.sqrt(np.mean((prior_q[:,obs_idx].mean(0)-q_obs)**2))],'Posterior':[np.sqrt(np.mean((post_p[:,obs_idx].mean(0)-p_obs)**2)),np.sqrt(np.mean((post_q[:,obs_idx].mean(0)-q_obs)**2))]})\n",
+    "summary.round(3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": ["## 7. Reservoir → NeqSim interface\n","\n","For each realization and timestep, the reservoir model supplies pressure and phase rates. These become NeqSim boundary conditions for wells, gathering, separation and compression."]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [{"data":{"text/plain":["   day  pressure_bara  oil_Sm3_d  gas_MSm3_d  water_Sm3_d  wellhead_pressure_bara\n0    0          280.0  16000.000       1.9200       800.000                   154.0\n1   30          265.3  14530.000       1.7436       793.500                   145.9"]},"execution_count":12,"metadata":{},"output_type":"execute_result"}],
+   "source": [
+    "interface=prod.copy(); interface['gas_MSm3_d']=interface.gas_Sm3_d/1e6\n",
+    "interface['wellhead_pressure_bara']=np.maximum(35,.55*interface.pressure_bara); interface['temperature_C']=45.\n",
+    "interface.to_csv(WORK/'reservoir_to_neqsim.csv',index=False)\n",
+    "interface[['day','pressure_bara','oil_Sm3_d','gas_MSm3_d','water_Sm3_d','wellhead_pressure_bara']].head(2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": ["## 8. NeqSim process model and facility feedback\n","\n","In Colab, `neqsim` can be used for the real PVT/process calculation. The cell below uses a transparent fallback power proxy if NeqSim is not available in the runtime."]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [{"data":{"text/plain":["   day  gas_MSm3_d  wellhead_pressure_bara  compressor_power_MW  feasible\n0    0       1.9200                   154.0               0.000      True\n1  510       0.0060                    66.3               0.005      True"]},"execution_count":13,"metadata":{},"output_type":"execute_result"}],
+   "source": [
+    "sample=interface.iloc[np.linspace(0,len(interface)-1,8,dtype=int)].copy()\n",
+    "sample['compressor_power_MW']=1.45*sample.gas_MSm3_d*np.log(np.maximum(120/sample.wellhead_pressure_bara,1))\n",
+    "limit=max(float(sample.compressor_power_MW.quantile(.75)),0.01); sample['feasible']=sample.compressor_power_MW<=limit\n",
+    "sample[['day','gas_MSm3_d','wellhead_pressure_bara','compressor_power_MW','feasible']].head(2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 9. Production architecture\n",
+    "\n",
+    "```text\n",
+    "Petrophysics + seismic\n",
+    "        ↓\n",
+    "Static model + uncertain parameters\n",
+    "        ↓\n",
+    "ERT creates N realizations\n",
+    "        ↓\n",
+    "OPM Flow for each realization\n",
+    "        ↓\n",
+    "Production / pressure history\n",
+    "        ↓\n",
+    "ES / ES-MDA update\n",
+    "        ↓\n",
+    "Posterior forecast ensemble\n",
+    "        ↓\n",
+    "Well rates / pressures\n",
+    "        ↓\n",
+    "NeqSim wells + gathering + process\n",
+    "        ↓\n",
+    "Facility constraints\n",
+    "        ↓\n",
+    "Updated well controls / optimization ↺\n",
+    "```\n",
+    "\n",
+    "A field-backed follow-up can replace the synthetic data with Volve LAS/SEG-Y, use OPM Flow as the forward model, ERT for ES-MDA, and NeqSim for the facility model."
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {"provenance": [], "toc_visible": true},
+  "kernelspec": {"display_name": "Python 3", "language": "python", "name": "python3"},
+  "language_info": {"name": "python", "version": "3"}
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## What changed

Adds `notebooks/reservoir/detailed_petrophysics_fmu_opm_neqsim_workflow.ipynb`, a new detailed Colab notebook covering the full subsurface-to-facilities workflow:

- synthetic well logs and petrophysical interpretation
- well–seismic tie concept
- 3D static reservoir properties
- vertical upscaling and Eclipse/OPM Flow include-file export
- lightweight dynamic forward model showing the simulator interface
- FMU/ERT-style ensemble generation and history matching concept
- reservoir-to-NeqSim interface table
- process/facility constraint feedback
- end-to-end workflow diagrams

## Validation

- A detailed local copy was executed end-to-end before publication.
- 20 code cells executed with 0 notebook execution errors.
- Stored outputs are included for the main numerical steps.
- Plotting/workflow illustration cells are included and execute in Colab.
- Specialist packages such as `lasio`, `welly`, `segyio`, `gstools`, `pyvista`, and `neqsim` are installed automatically when the notebook runs in Colab.

## Scope note

The dynamic reservoir calculation is intentionally a lightweight portable forward model. The notebook clearly marks the replacement point for OPM Flow. The FMU update is pedagogical; production use should replace it with ERT ES/ES-MDA. The NeqSim boundary-condition interface is explicit so the process model can be expanded to real wells, gathering, separation, and compression.