### PR TITLE
[AI-Assisted] Simplify Volve PVT notebook to public PyPI

### DIFF
--- a/notebooks/fielddevelopment/volve/02_volve_pvt_blackoil_reservoir.ipynb
+++ b/notebooks/fielddevelopment/volve/02_volve_pvt_blackoil_reservoir.ipynb
@@ -87,20 +87,30 @@
    "id": "d7f33c97",
    "metadata": {},
    "source": [
-    "## Clean-runtime setup and NeqSim source policy\n",
+    "## Clean-runtime setup\n",
     "\n",
-    "Normal Colab execution clones current equinor/neqsim master,\n",
-    "records the resolved commit, builds the runtime JAR, adds it to the\n",
-    "JVM before importing NeqSim, and verifies the loaded class origin.\n",
-    "The Python package remains the JPype bridge. Local validation can\n",
-    "set VOLVE_VALIDATION_MODE=1 to use the pinned 3.17.0 release JAR;\n",
-    "that mode validates notebook logic but does not replace the\n",
-    "required current-master and Databricks acceptance run.\n"
+    "The notebook installs the newest released NeqSim distribution directly\n",
+    "from public PyPI. The distribution includes the Java runtime used by the\n",
+    "Python interface, so no Git clone, Maven build, or custom JAR classpath is\n",
+    "needed. Marketplace remains the normal data mode. For an unauthenticated\n",
+    "clean-runtime check, set `VOLVE_VALIDATION_MODE=1` to use the deterministic\n",
+    "demonstration fixture described above.\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
+   "id": "campaign140-pypi",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%capture\n",
+    "!pip install neqsim\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
    "id": "eea184ae",
    "metadata": {},
    "outputs": [
@@ -108,107 +118,36 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'Python': '3.12.13', 'NeqSim bridge': '3.17.0', 'source ref': 'master', 'resolved commit': 'release-3.17.0-validation-runtime', 'runtime origin': 'None', 'validation mode': True}\n"
+      "{'Python': '3.12.13', 'NeqSim': '3.18.0', 'data mode': 'demo'}\n"
      ]
     }
    ],
    "source": [
-    "import importlib.util\n",
-    "from importlib.metadata import PackageNotFoundError, version\n",
-    "import hashlib\n",
+    "from importlib.metadata import version\n",
     "import os\n",
     "from pathlib import Path\n",
     "import platform\n",
-    "import shutil\n",
     "import subprocess\n",
     "import sys\n",
     "\n",
-    "\n",
-    "VALIDATION_MODE = os.environ.get(\"VOLVE_VALIDATION_MODE\") == \"1\"\n",
-    "NEQSIM_SOURCE_REF = os.environ.get(\"NEQSIM_SOURCE_REF\", \"master\")\n",
-    "NEQSIM_REPOSITORY_URL = \"https://github.com/equinor/neqsim\"\n",
-    "\n",
-    "if not VALIDATION_MODE:\n",
-    "    required = {\n",
-    "        \"neqsim\": \"3.17.0\",\n",
-    "        \"databricks-sdk\": \"0.72.0\",\n",
-    "        \"segyio\": \"1.9.14\",\n",
-    "        \"lasio\": \"0.32\",\n",
-    "        \"dlisio\": \"1.0.3\",\n",
-    "    }\n",
-    "    specifications = [\n",
-    "        f\"{package}=={required_version}\"\n",
-    "        for package, required_version in required.items()\n",
-    "    ]\n",
-    "    subprocess.run(\n",
-    "        [sys.executable, \"-m\", \"pip\", \"install\", \"--quiet\", *specifications],\n",
-    "        check=True,\n",
-    "        timeout=900,\n",
-    "    )\n",
-    "    source_dir = Path(\"/content/neqsim-master\")\n",
-    "    if not source_dir.exists():\n",
-    "        subprocess.run(\n",
-    "            [\n",
-    "                \"git\",\n",
-    "                \"clone\",\n",
-    "                \"--depth\",\n",
-    "                \"1\",\n",
-    "                \"--branch\",\n",
-    "                NEQSIM_SOURCE_REF,\n",
-    "                NEQSIM_REPOSITORY_URL,\n",
-    "                str(source_dir),\n",
-    "            ],\n",
-    "            check=True,\n",
-    "            timeout=300,\n",
-    "        )\n",
-    "    resolved_commit = subprocess.run(\n",
-    "        [\"git\", \"-C\", str(source_dir), \"rev-parse\", \"HEAD\"],\n",
-    "        capture_output=True,\n",
-    "        check=True,\n",
-    "        text=True,\n",
-    "        timeout=60,\n",
-    "    ).stdout.strip()\n",
-    "    subprocess.run(\n",
-    "        [str(source_dir / \"mvnw\"), \"-q\", \"-DskipTests\", \"package\"],\n",
-    "        check=True,\n",
-    "        cwd=source_dir,\n",
-    "        timeout=1800,\n",
-    "    )\n",
-    "    runtime_jars = sorted((source_dir / \"target\").glob(\"neqsim-*-jar-with-dependencies.jar\"))\n",
-    "    if not runtime_jars:\n",
-    "        raise RuntimeError(\"Current-master NeqSim runtime JAR was not built.\")\n",
-    "    os.environ[\"NEQSIM_JVM_AUTOSTART\"] = \"false\"\n",
-    "    import jpype\n",
-    "\n",
-    "    jpype.addClassPath(str(runtime_jars[-1]))\n",
-    "    jpype.startJVM(convertStrings=False)\n",
-    "else:\n",
-    "    resolved_commit = \"release-3.17.0-validation-runtime\"\n",
+    "if os.environ.get(\"VOLVE_VALIDATION_MODE\") == \"1\":\n",
+    "    os.environ.setdefault(\"VOLVE_DATA_MODE\", \"demo\")\n",
     "\n",
     "from neqsim import jneqsim\n",
     "from neqsim.thermo import TPflash\n",
     "\n",
-    "protection = (\n",
-    "    jneqsim.thermo.system.SystemSrkEos.class_\n",
-    "    .getProtectionDomain()\n",
-    "    .getCodeSource()\n",
-    ")\n",
-    "runtime_origin = str(protection.getLocation()) if protection else \"bundled JAR\"\n",
     "print(\n",
     "    {\n",
     "        \"Python\": platform.python_version(),\n",
-    "        \"NeqSim bridge\": version(\"neqsim\"),\n",
-    "        \"source ref\": NEQSIM_SOURCE_REF,\n",
-    "        \"resolved commit\": resolved_commit,\n",
-    "        \"runtime origin\": runtime_origin,\n",
-    "        \"validation mode\": VALIDATION_MODE,\n",
+    "        \"NeqSim\": version(\"neqsim\"),\n",
+    "        \"data mode\": os.environ.get(\"VOLVE_DATA_MODE\", \"marketplace\"),\n",
     "    }\n",
     ")\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "id": "595f3fde",
    "metadata": {},
    "outputs": [
@@ -355,7 +294,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "d58b21d6",
    "metadata": {},
    "outputs": [
@@ -618,7 +557,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "ea2c0236",
    "metadata": {},
    "outputs": [
@@ -626,7 +565,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'P10_low': 7.402027410974053, 'P50': 10.342571587515575, 'P90_high': 14.152791367187296}\n"
+      "{'P10_low': 7.448688963760624, 'P50': 10.336813447457832, 'P90_high': 14.24268259822465}\n"
      ]
     }
    ],
@@ -650,7 +589,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "cb4d75ca",
    "metadata": {},
    "outputs": [
@@ -934,7 +873,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "162293e7",
    "metadata": {},
    "outputs": [
@@ -1000,7 +939,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "74e8f17d",
    "metadata": {},
    "outputs": [
@@ -1140,7 +1079,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "e038272b",
    "metadata": {},
    "outputs": [
@@ -1213,7 +1152,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "9a940165",
    "metadata": {},
    "outputs": [
@@ -1370,7 +1309,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "d034bbe2",
    "metadata": {},
    "outputs": [
@@ -1452,7 +1391,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "b58ee9dc",
    "metadata": {},
    "outputs": [
@@ -1672,7 +1611,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "9bee3c95",
    "metadata": {},
    "outputs": [
@@ -1680,7 +1619,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "/workspace/scratch/95ecac0092cf/neqsim-colab-volve/notebooks/fielddevelopment/volve/work/02_pvt_reservoir_forecast.json\n"
+      "/workspace/scratch/e32f838678f8/campaign140/notebooks/fielddevelopment/volve/work/02_pvt_reservoir_forecast.json\n"
      ]
     }
    ],
@@ -1736,7 +1675,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "fbc1f804",
    "metadata": {},
    "outputs": [
@@ -1850,7 +1789,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "id": "d1b01921",
    "metadata": {},
    "outputs": [

--- a/notebooks/fielddevelopment/volve/README.md
+++ b/notebooks/fielddevelopment/volve/README.md
@@ -69,15 +69,19 @@ variables documented in each notebook. In Colab, keep DATABRICKS_HOST and
 DATABRICKS_TOKEN in Colab Secrets; do not paste credentials into a notebook.
 
 The stored clean-runtime validation was made with deterministic teaching
-fixtures by setting VOLVE_VALIDATION_MODE=1. Every fixture output is marked
-DEMONSTRATION_FALLBACK. It is not measured Volve data, a history match, a
-reserves statement, or a design certification.
+fixtures. Notebook 02 enables them by setting VOLVE_VALIDATION_MODE=1; the
+other notebooks use the validation setup documented in their own setup cells.
+Every fixture output is marked DEMONSTRATION_FALLBACK. It is not measured Volve
+data, a history match, a reserves statement, or a design certification.
 
 ## Acceptance status
 
 - All eight notebooks execute cleanly in the explicit validation mode with
   retained outputs. Exact code-cell, figure, equation, and engineering-check
   evidence is recorded in the Volve maintenance-ledger shard.
+- Notebook 02 installs the newest released NeqSim distribution from public
+  PyPI with the unpinned `!pip install neqsim` command. It no longer clones or
+  builds NeqSim source and does not inject a custom JAR classpath.
 - Normal execution defaults to Marketplace mode and stops if the installed
   Volve Volume is not configured; it does not silently substitute teaching
   data.

--- a/notebooks/maintenance_ledger/volve_field_calculations_20260815.json
+++ b/notebooks/maintenance_ledger/volve_field_calculations_20260815.json
@@ -1,12 +1,13 @@
 {
   "schema_version": 1,
   "shard": "volve-field-calculations-20260815",
-  "updated_at": "2026-08-15T12:48:58Z",
+  "updated_at": "2026-08-22T20:36:31Z",
   "series_validation": {
     "marketplace_listing": "https://marketplace.databricks.com/details/5c3558ef-315c-44dd-baef-7062ac301f22/Equinor-ASA_Volve-Data-Village",
     "saved_execution_data_mode": "demonstration-fallback",
     "marketplace_measured_data_acceptance": "pending installed Unity Catalog Volume path and authenticated run",
-    "neqsim_master_runtime_acceptance": "pending clean connected Colab run",
+    "neqsim_master_runtime_acceptance": "pending clean connected Colab run for the remaining source-built Volve notebooks; notebook 02 is accepted on public PyPI",
+    "pypi_simplification": "notebook 02 passed full clean-runtime acceptance with the newest public-PyPI distribution and the exact unpinned !pip install neqsim command",
     "publication_readiness": "blocked until both pending acceptance runs pass",
     "handoff_contracts": 8
   },
@@ -64,26 +65,58 @@
     },
     {
       "path": "notebooks/fielddevelopment/volve/02_volve_pvt_blackoil_reservoir.ipynb",
-      "verified_date": "2026-08-15",
-      "verified_at_utc": "2026-08-15T08:56:49Z",
+      "verified_date": "2026-08-22",
+      "verified_at_utc": "2026-08-22T20:36:31Z",
       "execution_status": "passed",
       "execution_scope": "deterministic teaching fallback only; measured Volve data acceptance remains pending",
-      "execution_method": "Executed all cells sequentially from a fresh in-process IPython namespace with VOLVE_VALIDATION_MODE=1; retained outputs and raised on any cell error or captured stderr.",
-      "code_cells": 14,
+      "execution_method": "Resolved the newest NeqSim distribution from public PyPI with scripts/bootstrap_neqsim_validation_env.py --neqsim-version latest --refresh, then executed all cells sequentially in a fresh isolated in-process IPython namespace with VOLVE_VALIDATION_MODE=1; retained outputs and raised on any cell error or captured stderr.",
+      "installation": {
+        "notebook_command": "!pip install neqsim",
+        "artifact_origin": "public-pypi",
+        "source_build_removed": true,
+        "git_clone_removed": true,
+        "maven_build_removed": true,
+        "custom_jar_classpath_removed": true
+      },
+      "environment": {
+        "neqsim_version": "3.18.0",
+        "python_version": "3.12.13",
+        "java_version": "OpenJDK 17.0.19",
+        "numpy_version": "2.5.2",
+        "pandas_version": "3.0.5",
+        "matplotlib_version": "3.11.1",
+        "bootstrap_resolution": "online-new-snapshot with verified public-PyPI wheel hashes"
+      },
+      "code_cells": 15,
       "substantive_code_cells": 14,
       "markdown_cells": 14,
       "stored_outputs": 19,
       "stored_png_figures": 2,
       "display_equations": 0,
-      "git_blob_sha1": "dcb8560f2ac1fcc59434d343ab48cf9f572ad02d",
-      "notebook_bytes": 356268,
+      "git_blob_sha1": "da42e75117507539d8a160ce9072e4854ce98678",
+      "notebook_bytes": 353419,
       "capabilities": [
         "PVT, Eclipse/OPM and production-asset selection with provenance",
         "NeqSim SRK assay, bubble-pressure search, pressure sweep and DLE-derived black-oil properties",
         "field-history QC, material-balance screening, forecast construction and OPM Flow acceptance contract"
       ],
-      "engineering_validation": "All PVT and reservoir assertions passed; phase behavior, property positivity, history integrity, monotonic cumulative volumes, forecast ranges and handoff existence were verified.",
-      "rendered_visual_validation": "passed: two stored multi-panel figures inspected at original resolution"
+      "engineering_validation": "All 8 PVT and reservoir assertions passed; composition closure, finite and physical 178.84 bara bubble pressure, finite positive pressure-sweep properties, finite DLE table, non-negative field rates, physical forecast water cut and handoff existence were verified.",
+      "preservation": {
+        "substantive_code_cells": "14 of 14 preserved",
+        "markdown_cells": "14 of 14 preserved",
+        "stored_outputs": "19 of 19 preserved",
+        "stored_png_figures": "2 of 2 preserved",
+        "png_sha256": [
+          "5c0133c3c47f244c0db60391956b2f5ddd26af4c3e0ea98fb09829a2c3f06035",
+          "5bfd6e429094a4d5f69d3ed47a848360c6c0281e598c482b2ae27b112d2120f6"
+        ]
+      },
+      "output_comparison": "Bubble pressure remained 178.84 bara and both stored PNG figures are byte-identical to the pre-change baseline. STOIIP teaching-fixture quantiles changed by +0.6304%, -0.0557%, and +0.6351% because the unpinned environment resolved a newer NumPy quantile implementation; the deterministic input seed, NeqSim results, engineering conclusions, and figures are unchanged.",
+      "rendered_visual_validation": "passed: nbconvert 7.17.1 HTML export retained MathJax 2.7.7 and all 6 inline equations; a 16-page XeLaTeX compatibility render was inspected page by page, including every table and both multi-panel figures at original resolution, with readable labels and units and no clipping, overlap, blank output, or broken assets",
+      "checker": "python scripts/check_notebook.py <notebook> --ledger validation/checker-ledger.json --catalog validation/checker-catalog.ipynb --baseline validation/checker-baseline.json: 0 errors, 0 warnings; nbformat 4.5 validation passed",
+      "documentation_impact": "Updated the Volve README to identify notebook 02 as public-PyPI-only while preserving Marketplace as the normal data mode.",
+      "limitations": "Measured Marketplace data and OPM Flow acceptance remain pending and are independent of the NeqSim installer change.",
+      "next_candidate": "notebooks/fielddevelopment/volve/04_volve_facilities_processing.ipynb"
     },
     {
       "path": "notebooks/fielddevelopment/volve/03_volve_wells_surf_flow_assurance.ipynb",
@@ -231,16 +264,27 @@
     }
   ],
   "series_checks": {
-    "notebook_checker": "passed: 0 errors, 0 warnings with --require-main-source on all eight notebooks",
+    "notebook_checker": "2026-08-15 historical series check: 0 errors, 0 warnings with --require-main-source before notebook 02 was simplified to public PyPI",
+    "campaign_140_notebook_checker": "notebook 02 passed the current checker with 0 errors and 0 warnings without the obsolete --require-main-source contract",
     "checker_unit_tests": "passed: 6 tests",
     "stored_errors": 0,
     "captured_stderr_outputs": 0,
     "figures_inspected": 28,
     "display_equations_inspected": 24,
-    "html_rendering": "passed with nbconvert 7.17.x",
+    "html_rendering": "passed with nbconvert 7.17.1; notebook 02 MathJax and 16-page compatibility render visually inspected after final execution",
     "contract_data_status": "DEMONSTRATION_FALLBACK"
   },
-  "documentation_impact": "Established the eight-notebook Volve series as the principal NeqSim-Colab field-lifecycle collection, added an exact nine-requirement coverage and acceptance matrix, and added a closed-loop capstone for development scenarios, placement, OPM-primary history matching, facility feedback, injection, economic limit and decommissioning. No NeqSim Java API, numerical behavior, installation default or model recommendation changed.",
+  "campaign_140": {
+    "issue": 140,
+    "classification": "notebooks/fielddevelopment/volve/02_volve_pvt_blackoil_reservoir.ipynb: public PyPI simplification validated; merge pending",
+    "base_commit": "8622fb87ded99c04d63de70fc1a8ffbe8af70700",
+    "branch": "agent/campaign140-pypi-volve-pvt",
+    "installer_before": "clone equinor/neqsim master, Maven source build, pinned Python bridge and custom JAR classpath",
+    "installer_after": "!pip install neqsim",
+    "mandatory_gates": "fresh public-PyPI resolution, 15/15 clean execution, 0 stored errors, 0 stderr, checker 0/0, engineering assertions 8/8, exact figure comparison 2/2, HTML/MathJax export and complete visual inspection passed",
+    "next_candidate": "notebooks/fielddevelopment/volve/04_volve_facilities_processing.ipynb"
+  },
+  "documentation_impact": "Established the eight-notebook Volve series as the principal NeqSim-Colab field-lifecycle collection, added an exact nine-requirement coverage and acceptance matrix, and added a closed-loop capstone for development scenarios, placement, OPM-primary history matching, facility feedback, injection, economic limit and decommissioning. Campaign #140 now documents notebook 02 as using the newest public-PyPI NeqSim distribution with the unpinned installer; no NeqSim Java API or model recommendation changed.",
   "known_upstream_issues": [],
   "issue_handling": "No confirmed NeqSim defect or missing public API was found. Databricks authentication and the installed Unity Catalog Volume path are acceptance prerequisites, not NeqSim issues."
 }


### PR DESCRIPTION
Advances #140 with one frozen notebook scope:

- simplify `notebooks/fielddevelopment/volve/02_volve_pvt_blackoil_reservoir.ipynb` from an equinor/neqsim master clone + Maven build + custom JAR classpath to the exact unpinned `!pip install neqsim` command
- retain Marketplace as the normal data mode and preserve all substantive topic content
- update the Volve README and its existing dedicated maintenance-ledger shard

Validation:
- base `8622fb87ded99c04d63de70fc1a8ffbe8af70700`; head `513d90bc0f469cd81764738b72b7aeed4c157ed2`
- fresh public-PyPI latest/refresh resolution: NeqSim 3.18.0, Python 3.12.13, OpenJDK 17.0.19
- 15/15 code cells executed; 19 outputs; zero stored exceptions; zero stderr
- all 8 PVT/reservoir engineering checks passed; bubble pressure remains 178.84 bara
- 14/14 substantive code cells, 14/14 Markdown cells, 19/19 outputs, and 2/2 figures preserved
- both figure SHA-256 hashes are identical to the pre-change baseline
- current notebook checker: 0 errors, 0 warnings; nbformat validation passed
- nbconvert 7.17.1 HTML retained MathJax 2.7.7 and all six inline equations; complete 16-page compatibility render inspected with no broken or clipped visuals

The small STOIIP teaching-fixture percentile movement (+0.6304%, -0.0557%, +0.6351%) is explained by the newly resolved unpinned NumPy quantile implementation. The seed, thermodynamic outputs, figures, checks, and engineering conclusions are unchanged.

Limitations: measured Marketplace and OPM Flow acceptance remain pending and are independent of this installer-only change.