### PR TITLE
Fix MultiphaseOptim notebook integrity

### DIFF
--- a/notebooks/process/MultiphaseOptim.ipynb
+++ b/notebooks/process/MultiphaseOptim.ipynb
@@ -3783,16 +3783,6 @@
       ]
     },
     {
-      "cell_type": "code",
-      "source": [],
-      "metadata": {
-        "id": "lQcgsYA7pJbJ"
-      },
-      "id": "lQcgsYA7pJbJ",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
       "cell_type": "markdown",
       "id": "8a372a83",
       "metadata": {


### PR DESCRIPTION
## Summary

- remove the accidental empty code cell appended to `notebooks/process/MultiphaseOptim.ipynb`
- restore the notebook's existing 21-code-cell maintenance-ledger contract
- preserve every executed calculation, output, equation, table, figure, reference, and engineering conclusion

## Root cause

Google Colab added a 22nd blank code cell with no execution count. Because the maintenance ledger correctly marks the notebook as passed with 21 executed code cells, the repository-wide integrity workflow failed with:

- `ledger records 21 code cells, notebook has 22`
- `ledger says passed but execution counts are missing for code cells [22]`

The stray cell contains no source and no output, so removing it is the smallest correct repair.

## Validation

Base: `7848628fe0c74b36e7318e163cfbd2f809fb9071`  
Head: `df756b64aa4dd88c2875c3d7937c3a53737af3d2`

- `git diff --check` — passed
- `python -m unittest discover -s scripts -p 'test_check_notebook.py'` — 6/6 passed
- `python scripts/check_notebook.py notebooks/process/MultiphaseOptim.ipynb --quiet-warnings` — 0 errors, 0 warnings
- `python scripts/check_notebook.py --all --quiet-warnings` — 337 notebooks, 0 errors, 43 non-blocking pre-existing warnings
- clean isolated re-execution of the exact repaired notebook source — 21/21 cells completed in order, counts 1–21, zero stored exceptions, zero stderr
- validation runtime — NeqSim 3.18.0, Python 3.12.13, OpenJDK 17.0.20
- engineering validation — all 32 assertions passed; 7 connected unit operations; separator feed and products both 68.5586182 kg/s; residual `-4.547e-12 kg/s`
- visual validation — Colab-compatible HTML generated; a 33-page XeLaTeX rendering was inspected page by page, covering all equations, tables, and five stored figures; labels, legends, units, equations, contrast, and layout were readable with no clipping or broken visual
- repository has no `.pre-commit-config.yaml`; the current pull-request workflow and direct repository checks above were inspected and run

## Documentation impact

Documentation impact: none. This removes only an accidental empty cell and changes no public API, installation path, model behavior, input, output, unit, assumption, default, compatibility contract, catalog entry, or user-facing guidance.

## Publication state

Draft PR. GitHub **Notebook integrity** run 142 passed on the published head, the PR is mergeable, and no merge or auto-merge was requested.
