### PR TITLE
[AI-Assisted] fix: synchronize active notebook ledger count

### DIFF
--- a/notebooks/notebook_maintenance_ledger.json
+++ b/notebooks/notebook_maintenance_ledger.json
@@ -1,7 +1,7 @@
 {
  "schema_version": 3,
  "updated_at": "2026-09-13T08:18:55.509118Z",
- "active_notebook_count": 305,
+ "active_notebook_count": 306,
  "shards_glob": "maintenance_ledger/*.json",
  "retired_notebooks": [
   {


### PR DESCRIPTION
The notebook integrity workflow fails on master `103f0f332b3cc0bcdb986ea78d01da6deac0e568` because the maintenance index records 305 active notebooks while its 49 shards contain 306 unique entries.

Correct `active_notebook_count` to 306. Every active entry points to an existing notebook, and active/retired entries do not overlap.

Validation:

- Reproduced the reported count error using the unchanged checker and exact GitHub ledger files.
- Validated all 49 ledger shards after the correction: 306 unique active entries, zero ledger errors.
- `python -m unittest discover -s scripts -p 'test_check_notebook.py'`: 6 tests passed.
- Verified that the one-line count correction is the only change.
- `python scripts/check_notebook.py --all --quiet-warnings`: **350 notebooks checked, 0 errors, 45 existing warnings**; exit 0 in [Notebook integrity CI](https://github.com/EvenSol/NeqSim-Colab/actions/runs/34750349206).
- GitHub CI also passed all 6 checker unit tests.
- CI tested PR head `4de52cf925a36f2ef4abcd05d6921909d17fa694` merged with base `103f0f332b3cc0bcdb986ea78d01da6deac0e568`.

Documentation impact: none — this corrects maintenance metadata without changing notebook usage, public APIs, or calculation behavior.